### PR TITLE
Clarify that ports need to allow TCP

### DIFF
--- a/docs/source/streamflow-public-testnet.md
+++ b/docs/source/streamflow-public-testnet.md
@@ -108,8 +108,8 @@ Select the option to get test LPT (note: the option numbering will be slightly d
 
 If you would like to test running an orchestrator or broadcaster node on the public testnet you may need certain ports open to the internet, or at least to specific IPs.
 
-* Port **8935** - Orchestrators need this port open to the world so that other broadcasters can discover and communicate with the orchestrator. Broadcasters should also open this port if they would like to serve their output video publicly from their node, or restrict access to this port for a specific audience or CDN.
-* Port **1935** - Broadcasters should open this port if they would like to stream into their node from a non-local source of video. You can restrict access to this port to the IP of the source of your video.
+* Port **8935** (TCP) - Orchestrators need this port open to the world so that other broadcasters can discover and communicate with the orchestrator. Broadcasters should also open this port if they would like to serve their output video publicly from their node, or restrict access to this port for a specific audience or CDN.
+* Port **1935** (TCP) - Broadcasters should open this port if they would like to stream into their node from a non-local source of video. You can restrict access to this port to the IP of the source of your video.
 
 
 You now have a node running, and have the test ETH and LPT you need to begin interacting with the Livepeer network. Read on to learn how to activate your orchestrator node and confirm that it is transcoding video correctly.


### PR DESCRIPTION
In the current description, the documentation states that certain ports need to be open on a server, in order to allow traffic in.

It does not specify whether these ports need to allow traffic via TCP or UDP.

e.g. when specifying ports to open in a firewall on Digital Ocean, it requires a user to choose between TCP or UDP:

![image](https://user-images.githubusercontent.com/2212651/68122598-9c5f0080-ff02-11e9-8311-90d4f17331e0.png)