### PR TITLE
streamflow-public-testnet: Add verification section

### DIFF
--- a/docs/source/streamflow-public-testnet.md
+++ b/docs/source/streamflow-public-testnet.md
@@ -315,6 +315,84 @@ If you observe the `ticket faceValue higher than max faceValue` error in the bro
 
 If you observe the `ticket EV higher than max EV` error in the broadcaster's logs, you can try running the broadcaster with `-maxTicketEV <MAX_TICKET_EV>` where `MAX_TICKET_EV` is the maximum expected value (denominated in wei) for tickets sent by the broadcaster. The default value is 10 gwei so you could try using a higher value.
 
+### Transcoding verification (experimental)
+
+The broadcaster can verify transcoded results received from orchestrators by sending verification requests to a verifier that runs alongside the broadcaster. The current default verifier implementation uses a machine learning classifier - refer to the [verifier documentation](https://github.com/livepeer/verification-classifier) for more details. 
+
+Transcoding verification is currently experimental and needs to be explicitly enabled by the user. R&D to improve its accuracy (in classifying correctly vs. incorrectly transcoded video) and performance (in terms of run time and computation cost) is underway, but in the short term, expect to see higher computational costs and transcoding latency after enabling verification for a broadcaster.
+
+In order to enable transcoding verification, first make sure that you have [Docker](https://docs.docker.com/install/) installed and setup the verifier.
+
+```
+git clone https://github.com/livepeer/verification-classifier
+cd verification-classifier
+./launch_api.sh
+```
+
+`./launch_api.sh` will start a verifier server running within a Docker container that accepts verification requests at the `/verify` endpoint. You should see log output that indicates that the verifier is listening on port 5000:
+
+```
+Sending build context to Docker daemon  5.904MB
+Step 1/4 : FROM verifier:v1
+ ---> fe5d1924dab5
+Step 2/4 : COPY /api ./scripts
+ ---> Using cache
+ ---> bc21bfb203ef
+Step 3/4 : ENTRYPOINT ["python"]
+ ---> Using cache
+ ---> 816b804bc7e7
+Step 4/4 : CMD ["scripts/api.py"]
+ ---> Using cache
+ ---> 548f58689798
+Successfully built 548f58689798
+Successfully tagged verifier-api:v1
+Verifier server listening in port 5000
+```
+
+If you are running the verifier on the same machine as the broadcaster, then you can run the below command in order to connect the broadcaster with the verifier:
+
+```
+livepeer -network rinkeby -broadcaster -verifierUrl http://localhost:5000/verify -verifierPath ~/verification-classifier/stream
+```
+
+The broadcaster logs should indicate the address of the verifier being used:
+
+```
+Using the Epic Labs classifier for verification at http://localhost:5000/verify
+```
+
+The value of `-verifierUrl` should be the address (`http://<IP>:<port>/verify`) that the verifier is receiving requests at. In this case, since the verifier and broadcaster are on the same machine all requests can be received on `localhost`.
+
+The value of `-verifierPath` should be the path to the volume that the verifier will read segment data from. By default, the verifier will read segment data from a volume mounted on the `/stream` directory within the `verification-classifier` project. So, if you started the verifier from within `~/verification-classifier` the value for `-verifierPath` should be `~/verification-classifier/stream`.
+
+If you are running the verifier on a separate machine from the broadcaster, you will need to make sure that the verifier endpoint is accessible by the broadcaster and that the verifier's volume is accessible over the network.
+
+One way to make the verifier endpoint accessible to the broadcaster without making it publicly accessible is to create an SSH tunnel from the broadcaster machine to the verifier machine.
+
+Create an SSH tunnel with the following command run from the broadcaster machine:
+
+```
+ssh -N -L 5000:127.0.0.1:5000 -i <SSH_KEY_FILE> <USER>@<HOSTNAME>
+```
+
+Note that the command will not output anything if it is successfuly run.
+
+One way to make the verifier's volume accessible over the network is to mount the verifier's volume on the broadcaster machine over an SSH connection using [sshfs](https://github.com/libfuse/sshfs).
+
+Mount the verifier's volume on the broadcaster machine by running the following command on the broadcaster machine:
+
+```
+sshfs -o IdentityFile=<SSH_KEY_FILE> <USER>@<HOSTNAME>:<FOLDER_ON_VERIFIER> <FOLDER_ON_BROADCASTER>
+```
+
+After the SSH tunnel is setup and the remote volume is mounted, run the following command to start the broadcaster:
+
+```
+livepeer -network rinkeby -broadcaster -verifierUrl http://localhost:5000/verify -verifierPath <FOLDER_ON_BROADCASTER>
+```
+
+The broadcaster also supports sharing segment data with a verifier using external cloud storage providers such as Amazon's S3 or Google's GCS. Documentation on using external cloud storage providers will be added in the future.
+
 ## Running an Ethereum node
 
 By default `livepeer` will use Infura as the ETH RPC provider. If you would like to run your own ETH node you can use `geth` (the Rinkeby testnet is only supported by `geth`) which can be installed using the instructions on the [installing geth page](https://geth.ethereum.org/docs/install-and-build/installing-geth). 


### PR DESCRIPTION
This PR adds a transcoding verification section to the docs. The section gives a brief overview on how to activate the experimental transcoding verification feature. The instructions do not mention how to use external cloud storage providers to share data with the verifier - since the docs do not mention external cloud storage providers at all right now I think we can wait to add documentation for this option until we have a section in the docs dedicated to cloud storage outside of the context of verification.