### PR TITLE
add broadcaster role to protocol overview & minor fixups

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ These docs are visible at http://livepeer.readthedocs.io
 
 All contributions and doc updates are appreciated! The docs are written in Markdown and RestructuredText, and can be edited directly in this repo or by editing the page that you want at http://livepeer.readthedocs.io. Please make pull requests into the master branch with updates.
 
-If you have questions, feel free to join our chat room at (http://gitter.im/livepeer/Lobby).
+If you have questions, feel free to join [the Livepeer Discord server](https://discord.gg/RR4kFAh).
 
 ## Building Locally
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -38,10 +38,10 @@ Index
 
 .. toctree::
    :maxdepth: 2
-
+   
+   overview
    quickstart
    installation
-   overview
    transcoding
    broadcasting
    developers

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -1,11 +1,17 @@
 # Installation
 
-First, download the latest Streamflow compatible release for your platform from the [releases](https://github.com/livepeer/go-livepeer/releases) page. If you are using OSX, download `livepeer_darwin.tar.gz`. If you are using Linux, download `livepeer_linux.tar.gz`.
+First, download the latest mainnet compatible release for your platform from the [releases](https://github.com/livepeer/go-livepeer/releases) page. If you are using OSX, download `livepeer-darwin-amd64.tar.gz`. If you are using Linux, download `livepeer-linux-amd64.tar.gz`.
+
+To download the file using wget:
+
+```
+$ wget https://github.com/livepeer/go-livepeer/releases/download/<RELEASE_VERSION>/livepeer-<YOUR PLATFORM>-amd64.tar.gz
+```
 
 After downloading the file, untar the archive and move the `livepeer` binary so that it is executable within your `$PATH`:
 
 ```
-$ tar -zxvf livepeer_<YOUR_PLATFORM>.tar.gz
-$ mv livepeer_<YOUR_PLATFORM>/livepeer /usr/local/bin
-$ mv livepeer_<YOUR_PLATFORM>/livepeer_cli /usr/local/bin
+$ tar -zxvf livepeer-<YOUR_PLATFORM>-amd64.tar.gz
+$ mv livepeer-<YOUR_PLATFORM>-amd64/livepeer /usr/local/bin
+$ mv livepeer-<YOUR_PLATFORM>-amd64/livepeer_cli /usr/local/bin
 ```

--- a/docs/source/overview.md
+++ b/docs/source/overview.md
@@ -1,13 +1,18 @@
 # Overview
 
-This documentation will refer to two roles that infrastructure providers can play:
+(Livepeer)[https://livepeer.org] is a live video streaming network protocol that is fully decentralized, highly scalable, crypto token incentivized, and results in a solution which is cheaper to an app developer or broadcaster than using traditional centralized live video solutions.
+
+Users that participate in the Livepeer protocol have one of following roles:
 
 1. Orchestrator
 2. Transcoder
+3. Broadcaster
 
 An **orchestrator** is a protocol-aware, smart, 24/7 process that is responsible to the end user of the network for transcoding jobs being performed correctly. They stake LPT to secure the work that they perform, and ensure it is done correctly. They can be penalized if they maliciously cheat and mistranscode an end users content. When a user starts a Livepeer node on a CPU based server in `-orchestrator` mode, they are operating that process as an orchestrator.
 
 A **transcoder** on the other hand, is a simple process that knows how to take an input segment of video, and transcode it to the desired outcome. It is not Livepeer protocol aware, it has no requirement for high reliability or being online 24/7, it makes no representation to the end user, and it has nothing at risk. While a user can start a Livepeer node on a server using the `-transcoder` flag to run a process in this role, they often will be running many transcoder processes, likely connected to many GPUs.
+
+A **broadcaster** is a protocol-aware process that fulfills the demand side of the Livepeer network, it takes input streams from the end-user on its exposed RTMP interface to have them transcoded by the infrastructure providers running on Livepeer. The broadcaster takes care of splitting up streams into segments for transcoding and aggregating the transcoded results in a media playlist. Nodes running in `-broadcaster` mode will be able to determine the output renditions and maximum price per pixel for transcoding jobs it sends into the Livepeer network and pay for these jobs in ETH using [probabilistic micropayments](https://medium.com/livepeer-blog/streamflow-probabilistic-micropayments-f3a647672462). 
 
 ![Orchestrator and Transcoders](https://livepeer-assets.s3.amazonaws.com/bot.png)
 
@@ -15,7 +20,9 @@ An orchestrator distributes work across one or many transcoders.
 
 The most popular, and default setup, is that whomever is playing the role of orchestrator, is also running many transcoder processes, and they are distributing the work only to their own processes.
 
-While it is possible to come up with constructions for "public transcoder pools" that allow orchestrators to distribute work to random transcoders, the design space for this sort of setup is outside the scope of this documentation. This document will focus on teaching a user how to run their own orchestrator/transcoder setup to perform work on the Livepeer network. This includes: 
+While it is possible to come up with constructions for "public transcoder pools" that allow orchestrators to distribute work to random transcoders, the design space for this sort of setup is outside the scope of this documentation. 
+
+This document will focus on teaching a user how to run their own orchestrator/transcoder setup to perform work on the Livepeer network. This includes: 
 
 * How to run an orchestrator
 * How to scale transcoding on an orchestrator

--- a/docs/source/overview.md
+++ b/docs/source/overview.md
@@ -1,6 +1,6 @@
 # Overview
 
-(Livepeer)[https://livepeer.org] is a live video streaming network protocol that is fully decentralized, highly scalable, crypto token incentivized, and results in a solution which is cheaper to an app developer or broadcaster than using traditional centralized live video solutions.
+[Livepeer](https://livepeer.org) is a live video streaming network protocol that is fully decentralized, highly scalable, crypto token incentivized, and results in a solution which is cheaper to an app developer or broadcaster than using traditional centralized live video solutions.
 
 Users that participate in the Livepeer protocol have one of following roles:
 

--- a/docs/source/quickstart.md
+++ b/docs/source/quickstart.md
@@ -20,13 +20,13 @@ $ livepeer -network rinkeby -broadcaster
 
 *Note that if you are already running an orchestrator node on the same machine, you will also have to pass additional flags into this command to specify unique ports so as not to conflict with your orchestrator node. See the below section on testing your transcoding setup for more detail.*
 
-### Getting test ETH
+## Getting test ETH
 
 If you are connecting to the Rinkeby public testnet you can get test ETH from the [Rinkeby faucet](https://faucet.rinkeby.io/).
 
-### Getting test LPT
+## Getting test LPT
 
-You can get test LPT using `livepeer_cli`. Before getting test LPT, make sure your account has test ETH.
+You can get test LPT using `livepeer_cli` when running on Rinkeby. Before getting test LPT, make sure your account has test ETH.
 
 In a separate terminal window other than the one that is running `livepeer`, run:
 


### PR DESCRIPTION
This PR:

- adds the broadcaster to the roles in the `overview` section

- changes the gitter chat link in the readme to discord

- minor fixups 

- sets protocol overview as first page and quickstart as second.