### PR TITLE
Required -ethUrl updates

### DIFF
--- a/docs/source/broadcasting.md
+++ b/docs/source/broadcasting.md
@@ -8,6 +8,8 @@ on port 1935. You can broadcast into Livepeer using this port.
 
 The following instructions assume that you have followed the [installation](installation.html) and [quickstart](quickstart.html) instructions.
 
+Some of the `livepeer` commands in these instructions require an Ethereum node JSON-RPC URL to be provided via the `-ethUrl <ETH_RPC_URL>` flag. See the [quickstart](quickstart.html) instructions for more details on obtaining an Ethereum node JSON-RPC URL.
+
 ### Deposit broadcasting funds
 
 You will need to deposit funds (ETH) used to pay orchestrators on the network for transcoding video.
@@ -117,7 +119,7 @@ Verifier server listening in port 5000
 If you are running the verifier on the same machine as the broadcaster, then you can run the below command in order to connect the broadcaster with the verifier:
 
 ```
-livepeer -network rinkeby -broadcaster -verifierUrl http://localhost:5000/verify -verifierPath ~/verification-classifier/stream
+livepeer -network rinkeby -ethUrl <ETH_RPC_URL> -broadcaster -verifierUrl http://localhost:5000/verify -verifierPath ~/verification-classifier/stream
 ```
 
 The broadcaster logs should indicate the address of the verifier being used:
@@ -153,7 +155,7 @@ sshfs -o IdentityFile=<SSH_KEY_FILE> <USER>@<HOSTNAME>:<FOLDER_ON_VERIFIER> <FOL
 After the SSH tunnel is setup and the remote volume is mounted, run the following command to start the broadcaster:
 
 ```
-livepeer -network rinkeby -broadcaster -verifierUrl http://localhost:5000/verify -verifierPath <FOLDER_ON_BROADCASTER>
+livepeer -network rinkeby -ethUrl <ETH_RPC_URL> -broadcaster -verifierUrl http://localhost:5000/verify -verifierPath <FOLDER_ON_BROADCASTER>
 ```
 
 The broadcaster also supports sharing segment data with a verifier using external cloud storage providers such as Amazon's S3 or Google's GCS. Documentation on using external cloud storage providers will be added in the future.

--- a/docs/source/broadcasting.md
+++ b/docs/source/broadcasting.md
@@ -158,45 +158,6 @@ livepeer -network rinkeby -broadcaster -verifierUrl http://localhost:5000/verify
 
 The broadcaster also supports sharing segment data with a verifier using external cloud storage providers such as Amazon's S3 or Google's GCS. Documentation on using external cloud storage providers will be added in the future.
 
-## Running an Ethereum node
-
-By default `livepeer` will use Infura as the ETH RPC provider. If you would like to run your own ETH node you can use `geth` (the Rinkeby testnet is only supported by `geth`) which can be installed using the instructions on the [installing geth page](https://geth.ethereum.org/docs/install-and-build/installing-geth). 
-
-Run `geth`:
-
-```
-$ geth -rinkeby -rpc -rpcapi eth,net,web3
-```
-
-If `geth` is running on a different machine than `livepeer` you will have to specify the `-rpcaddr` flag to indicate the interface to listen on.
-
-Wait until `geth` is fully synced with the latest block on the Rinkeby testnet. You can check if `geth` is done syncing by using the Geth Javascript Console:
-
-```
-$ geth attach http://localhost:8545
-Welcome to the Geth JavaScript console!
-
-instance: Geth/v1.9.0-stable-52f24617/linux-amd64/go1.12.7
-coinbase: 0x0161e041aad467a890839d5b08b138c1e6373072
-at block: 583 (Wed, 23 Oct 2019 17:41:00 EDT)
- modules: debug:1.0 eth:1.0 miner:1.0 net:1.0 personal:1.0 rpc:1.0 txpool:1.0 web3:1.0
-
-> eth.syncing
-false
-```
-
-In order to connect to your own ETH node, you will need to set the `-ethUrl` flag on your `livepeer` node to the ETH node's RPC URL.
-
-For example, you could use the following command to connect an orchestrator to an ETH node running at `localhost:8545`.
-
-```
-$ livepeer -network rinkeby -orchestrator -pricePerUnit 1 -ethUrl http://localhost:8545
-```
-
-## Migrating to Streamflow
-
-If you are upgrading from a go-livepeer < v0.5.3 you do not need to take any additional action - the node will create a fresh DB that is compatible with the changes included in the Streamflow protocol upgrade.
-
 ## Broadcasting To A Local Node Using OBS
 
 Start by reading our [step by step guide](https://github.com/livepeer/wiki/wiki/Blueprint:-set-up-a-broadcasting-node-using-Livepeer-and-OBS)

--- a/docs/source/quickstart.md
+++ b/docs/source/quickstart.md
@@ -1,5 +1,58 @@
 # Quickstart
 
+## Connecting to an Ethereum node
+
+An Ethereum RPC provider needs to be specified via the `-ethUrl` flag when starting `livepeer` in order to connect to mainnet or Rinkeby.
+
+If you do not want to run your own Ethereum node, you can use services such as [Infura](https://infura.io/) or [Alchemy](https://alchemyapi.io/) that host Ethereum nodes on behalf of users.
+
+For example, you could use the following command to connect an orchestrator to Infura.
+
+```
+$ livepeer -network rinkeby -orchestrator -pricePerUnit 1 -ethUrl https://rinkeby.infura.io/v3/<PROJECT_ID>
+```
+
+See the [Infura docs](https://infura.io/docs/gettingStarted/makeRequests.md) for more details on how to obtain a `<PROJECT_ID>`.
+
+If you would like to run your own Ethereum node you can use one of the clients mentioned [here](https://docs.ethhub.io/using-ethereum/running-an-ethereum-node/).
+
+`geth` is recommended because it supports both mainnet and the Rinkeby testnet. Additionally, at this time `livepeer` has been the most thoroughly tested with `geth.`
+
+Install `geth` using the instructions on the [installing geth page](https://geth.ethereum.org/docs/install-and-build/installing-geth).
+
+Run `geth`:
+
+```
+$ geth -rinkeby -rpc -rpcapi eth,net,web3
+```
+
+If `geth` is running on a different machine than `livepeer` you will have to specify the `-rpcaddr` flag to indicate the interface to listen on.
+
+Wait until `geth` is fully synced with the latest block on the Rinkeby testnet. You can check if `geth` is done syncing by using the Geth Javascript Console:
+
+```
+$ geth attach http://localhost:8545
+Welcome to the Geth JavaScript console!
+
+instance: Geth/v1.9.0-stable-52f24617/linux-amd64/go1.12.7
+coinbase: 0x0161e041aad467a890839d5b08b138c1e6373072
+at block: 583 (Wed, 23 Oct 2019 17:41:00 EDT)
+ modules: debug:1.0 eth:1.0 miner:1.0 net:1.0 personal:1.0 rpc:1.0 txpool:1.0 web3:1.0
+
+> eth.syncing
+false
+```
+
+You could use the following command to connect an orchestrator to an Ethereum node running at `localhost:8545`.
+
+```
+$ livepeer -network rinkeby -orchestrator -pricePerUnit 1 -ethUrl http://localhost:8545
+```
+
+## Migrating to Streamflow
+
+If you are upgrading from a go-livepeer < v0.5.3 you do not need to take any additional action - the node will create a fresh DB that is compatible with the changes included in the Streamflow protocol upgrade.
+
 ## Run an orchestrator
 
 Starting `livepeer` with the `-orchestrator` and `-transcoder` flags starts the node in orchestrator mode with solo transcoding. This is the simplest and fastest way to run an orchestrator and start transcoding video on the network. The [transcoding](transcoding.html) section will describe the difference between solo and split transcoding as well as how to scale transcoding on your orchestrator with split transcoding.

--- a/docs/source/quickstart.md
+++ b/docs/source/quickstart.md
@@ -60,7 +60,7 @@ Starting `livepeer` with the `-orchestrator` and `-transcoder` flags starts the 
 The example commands in this document will use the `-network rinkeby` flag to connect the node to the Rinkeby public testnet. If you are connecting the node to mainnet, you should use the `-network mainnet` flag.
 
 ```
-$ livepeer -network rinkeby -orchestrator -transcoder -pricePerUnit 1
+$ livepeer -network rinkeby -ethUrl <ETH_RPC_URL> -orchestrator -transcoder -pricePerUnit 1
 ```
 
 ## Run a broadcaster
@@ -68,7 +68,7 @@ $ livepeer -network rinkeby -orchestrator -transcoder -pricePerUnit 1
 Starting `livepeer` with the `-broadcaster` flag starts the node in broadcaster mode enabling you to stream video to be transcoded on the network. 
 
 ```
-$ livepeer -network rinkeby -broadcaster
+$ livepeer -network rinkeby -ethUrl <ETH_RPC_URL> -broadcaster
 ```
 
 *Note that if you are already running an orchestrator node on the same machine, you will also have to pass additional flags into this command to specify unique ports so as not to conflict with your orchestrator node. See the below section on testing your transcoding setup for more detail.*

--- a/docs/source/transcoding.md
+++ b/docs/source/transcoding.md
@@ -24,6 +24,12 @@ Quicklinks:
 
 [Transcoder chat](https://discord.gg/cBfD23u)
 
+## Install Livepeer
+
+The following instructions assume that you have followed the [installation](installation.html) and [quickstart](quickstart.html) instructions.
+
+Some of the `livepeer` commands in these instructions require an Ethereum node JSON-RPC URL to be provided via the `-ethUrl <ETH_RPC_URL>` flag. See the [quickstart](quickstart.html) instructions for more details on obtaining an Ethereum node JSON-RPC URL.
+
 ## Activation
 
 In order to start transcoding video on the network and earning fees, your orchestrator node must be active.
@@ -61,13 +67,13 @@ You can test your orchestrator setup by setting up your own broadcaster and rout
 First, make sure to turn on verbose logging on your orchestrator (transcoding/payment related logs will not be shown with the default logging level):
 
 ```
-$ livepeer -network rinkeby -orchestrator -transcoder -pricePerUnit 1 -v 99
+$ livepeer -network rinkeby -ethUrl <ETH_RPC_URL> -orchestrator -transcoder -pricePerUnit 1 -v 99
 ```
 
 Start a broadcaster that will connect directly to your orchestrator:
 
 ```
-$ livepeer -network rinkeby -broadcaster -orchAddr <ORCH_SERVICE_URI>
+$ livepeer -network rinkeby -ethUrl <ETH_RPC_URL> -broadcaster -orchAddr <ORCH_SERVICE_URI>
 ```
 
 `<ORCH_SERVICE_URI>` should be the publicly accessible `serviceURI` that your orchestrator registered on-chain.


### PR DESCRIPTION
- Moves section about connecting to an ETH node to the "Quick Start" section since users will have to specify their own ETH node JSON-RPC URL as of livepeer/go-livepeer#1448
- Moves section about migrating to Streamflow to the "Quick Start" section since this is general information that is relevant to anyone getting started with the docs regardless of whether they are running a broadcaster or orchestrator
- Update `livepeer` commands to use the `-ethUrl` flag since it is now required