### PR TITLE
Add guides/references + leaderboard FAQ

### DIFF
--- a/docs/source/guides/benchmark_transcoding.rst
+++ b/docs/source/guides/benchmark_transcoding.rst
@@ -1,0 +1,135 @@
+How To Benchmark Transcoding
+=============================
+
+Pre-requisites
+**************
+
+Before proceeding with this guide:
+
+- Setup go-livepeer and its dependencies by following the pre-requisites and setup section in the `go-livepeer installation guide <https://github.com/livepeer/go-livepeer/blob/master/doc/install.md#pre-requisites-and-setup>`_.
+
+- Build the benchmark tool ``livepeer_bench`` from source:
+
+::
+
+    $ cd go-livepeer
+    $ PKG_CONFIG_PATH=~/compiled/lib/pkgconfig make livepeer_bench
+
+- Download the `test stream <https://storage.googleapis.com/lp_testharness_assets/bbb_1080p_30fps_1min_2sec_hls.tar.gz>`_ and unarchive it:
+
+::
+    
+    $ cd go-livepeer
+    $ wget -c https://storage.googleapis.com/lp_testharness_assets/bbb_1080p_30fps_1min_2sec_hls.tar.gz
+    $ tar -xvf bbb_1080p_30fps_1min_2sec_hls.tar.gz
+    $ ls bbb/   # Should print the stream *.ts segments and source.m3u8 manifest
+
+Run the benchmark
+*****************
+
+Run the benchmark on the CPU (x264) transcoder:
+
+::
+
+    ./livepeer_bench -in bbb/source.m3u8 
+
+If you want to transcode on your GPU, make sure to get your GPU IDs (see the :doc:`GPU guide <orchestrator_transcoder_gpu>`) and then run:
+
+::
+
+    # For GPU IDs 0,1
+    ./livepeer_bench -in bbb/source.m3u8 \
+        -nvidia 0,1
+
+By default the benchmark transcodes the stream only once. You can optionally specify a number of concurrent transcoding sessions:
+
+::
+
+    ./livepeer_bench -in bbb/source.m3u8 \
+        -concurrentSessions 5
+    
+The default configuration for the output renditions is - 240p30fps, 360p30fps, 720p30fps.
+You may follow the `transcoding options guide <https://github.com/livepeer/go-livepeer/blob/master/doc/transcodingoptions.md>`_ to set custom output profiles, or use the JSON for most common configuration found on the network as:
+
+::
+
+    ./livepeer_bench -in bbb/source.m3u8 \
+        -transcodingOptions cmd/livepeer_bench/transcodingOptions.json
+
+Benchmark output
+****************
+
+Running a sample benchmark on a GTX 1060 with default profiles:
+
+::
+    
+    ./livepeer_bench -in bbb/source.m3u8 -nvidia 0
+
+The first few lines of the output would show the source manifest, the profiles, and number of concurrent sessions:
+
+::
+
+    *---------------------*----------------------------------------------*
+    | Source File         | .../go-livepeer/bbb/source.m3u8              |
+    | Transcoding Options | P240p30fps16x9,P360p30fps16x9,P720p30fps16x9 |
+    | Concurrent Sessions | 1                                            |
+    *---------------------*----------------------------------------------*
+
+Then as each segment gets transcoded, its metrics will be output in CSV format:
+
+::
+
+    timestamp,session,segment,transcode_time
+    2020-12-03 02:21:25.7953,0,0,0.2782
+    2020-12-03 02:21:25.917,0,1,0.1216
+    2020-12-03 02:21:26.0199,0,2,0.1029
+    2020-12-03 02:21:26.1123,0,3,0.09238
+    2020-12-03 02:21:26.207,0,4,0.09467
+    2020-12-03 02:21:26.3012,0,5,0.0941
+    2020-12-03 02:21:26.4,0,6,0.09877
+    2020-12-03 02:21:26.5025,0,7,0.1025
+    2020-12-03 02:21:26.6073,0,8,0.1047
+    2020-12-03 02:21:26.7085,0,9,0.1013
+    2020-12-03 02:21:26.8179,0,10,0.1093
+    2020-12-03 02:21:26.9216,0,11,0.1036
+    2020-12-03 02:21:27.0175,0,12,0.09585
+    2020-12-03 02:21:27.1185,0,13,0.101
+    2020-12-03 02:21:27.2134,0,14,0.0949
+    2020-12-03 02:21:27.3171,0,15,0.1037
+    2020-12-03 02:21:27.42,0,16,0.1028
+    2020-12-03 02:21:27.5236,0,17,0.1035
+    2020-12-03 02:21:27.627,0,18,0.1034
+    2020-12-03 02:21:27.7622,0,19,0.1352
+    2020-12-03 02:21:27.8608,0,20,0.09819
+    2020-12-03 02:21:27.9576,0,21,0.09678
+    2020-12-03 02:21:28.0526,0,22,0.09495
+    2020-12-03 02:21:28.148,0,23,0.09533
+    2020-12-03 02:21:28.2408,0,24,0.09276
+    2020-12-03 02:21:28.3362,0,25,0.09531
+    2020-12-03 02:21:28.4292,0,26,0.09297
+    2020-12-03 02:21:28.5288,0,27,0.09961
+    2020-12-03 02:21:28.6285,0,28,0.09969
+    2020-12-03 02:21:28.6961,0,29,0.06757
+
+When all the transcoding sessions end it will output the total time taken for transcoding, total number of segments in the stream, and the total duration of the segments:
+
+::
+
+    Took 3.281 seconds to transcode 30 segments of total duration 60s (1 concurrent sessions)
+
+**NB**: This benchmark only gauges local transcoding capacity. An estimate of *good performance* is if the time taken to transcode is *significantly less* than the total segment duration - such that the overall transcoding happens in real-time for a live-stream on the network.
+
+If you want to get a rough idea of how many streams the transcoder can handle at-a-time, you can increase the number of concurrent sessions via ``-concurrentSessions #`` and compare the total time taken.
+
+To export the segment-wise CSV data to a file ``output.csv`` and analyze it with other tools, redirect the ``stdout`` like:
+
+::
+
+    ./livepeer_bench -in bbb/source.m3u8 -nvidia 0 > output.csv
+
+    *---------------------*----------------------------------------------*
+    | Source File         | .../go-livepeer/bbb/source.m3u8              |
+    | Transcoding Options | P240p30fps16x9,P360p30fps16x9,P720p30fps16x9 |
+    | Concurrent Sessions | 1                                            |
+    *---------------------*----------------------------------------------*
+    Took 3.281 seconds to transcode 30 segments of total duration 60s (1 concurrent sessions)

--- a/docs/source/guides/orchestrator_transcoder_gpu.rst
+++ b/docs/source/guides/orchestrator_transcoder_gpu.rst
@@ -1,0 +1,123 @@
+How To Run An Orchestrator With GPU Transcoding
+===============================================
+
+Orchestrators can use GPUs to transcode streams.
+
+Pre-requisites
+**************
+
+Before proceeding with this guide:
+
+- Make sure you followed the :doc:`livepeer installation instructions <../installation>`
+- Make sure you are in the active orchestrator set. See the :doc:`activation guide <../transcoding>`
+- Make sure you have an Ethereum JSON-RPC URL. See the :doc:`Ethereum node guide <../quickstart>`
+- Make sure you have a `Nvidia driver <https://www.nvidia.com/Download/index.aspx>`_ installed on your machine
+- Make sure you have Nvidia GPUs accessible on your machine
+    - See this `list of tested GPUs <https://github.com/livepeer/wiki/blob/master/GPU-SUPPORT.md>`_
+
+Get GPU IDs
+***********
+
+You can print a list of the GPUs accessible on your machine using the :code:`nvidia-smi` utility:
+
+::
+
+    nvidia-smi -L
+    GPU 0: GeForce GTX 1070 Ti (UUID: GPU-fcbaffa0-38ae-02d0-5c47-f8fd9922eb75)
+    GPU 1: GeForce GTX 1070 Ti (UUID: GPU-d46a085e-0d66-0214-34d3-96860a5c778f)
+    GPU 2: GeForce GTX 1070 Ti (UUID: GPU-32b7c120-c2c9-0069-6130-cb67afd89642)
+    GPU 3: GeForce GTX 1070 Ti (UUID: GPU-9e4163c3-a120-3cbb-7869-1223b322eab2)
+    GPU 4: GeForce GTX 1070 Ti (UUID: GPU-3370975a-f669-e108-6428-602be9eba7d4)
+
+The above output indicates that there are 5 GPUs accessible on the machine with IDs from 0 through 4. 
+
+Run the orchestrator
+********************
+
+The following flags are required to run an orchestrator with GPU transcoding: 
+
+::
+
+    livepeer -orchestrator \
+        -transcoder \
+        -network mainnet \
+        -ethURL <ETH RPC URL> \
+        -nvidia <NVIDIA GPU DEVICE IDs>
+
+You can use all GPUs accessible on your machine by specifying all GPU IDs in the argument passed to the :code:`-nvidia` flag.
+For example, the following command will use GPUs 0-5 when transcoding:
+
+::
+
+    livepeer -orchestrator \
+        -transcoder \
+        -network mainnet \
+        -ethURL http://127.0.0.1:8545 \
+        -nvidia 0,1,2,3,4
+
+You can use a subset of the GPUs accessible on your machine by excluding GPU IDs in the argument passed to the :code:`-nvidia` flag.
+For example, the following command will not use GPU #1 when transcoding:
+
+::
+
+    livepeer -orchestrator \
+        -transcoder \
+        -network mainnet \
+        -ethURL http://127.0.0.1:8545 \
+        -nvidia 0,2,3,4
+
+You can use an optional :code:`-v 6` flag to set the logging level to verbose in order to observe more detailed transcoding logs:
+
+::
+
+    livepeer -orchestrator \
+        -transcoder \
+        -network mainnet \
+        -ethURL http://127.0.0.1:8545 \
+        -nvidia 0,1,2,3,4 \
+        -v 6
+
+On startup, the orchestrator will automatically run a test to confirm that it is able to transcode using the specified GPUs.
+The orchestrator will exit if this test fails. If the test passes, you should see the following message in the log output without any
+additional error messages following it indicating that your orchestrator is ready to transcode streams using the specified GPUs:
+
+::
+
+    Received Ping request  
+
+Transcoding information
+***********************
+
+If you set the logging level to verbose via the :code:`-v 6` flag, then you should see messages similar to the following when your orchestrator is transcoding:
+
+::
+
+    Downloaded segment manifestID=e1353c56 sessionID=29b089af seqNo=0 dur=65.220433ms
+    LB: Creating transcode session for e1353c56
+    LB: Created transcode session for e1353c56_1
+    LB: Transcode submitted for e1353c56_1
+    Transcoding of segment manifestID=e1353c56 sessionID=29b089af seqNo=0 took=396.34309ms
+
+You can observe the download speed (from the broadcaster to the orchestrator) in the :code:`dur` field of the following line:
+
+::
+ 
+    Downloaded segment manifestID=e1353c56 sessionID=29b089af seqNo=0 dur=65.220433ms
+
+You can observe the transcoding speed specified in the :code:`took` field of the following line:
+
+::
+
+    Transcoding of segment manifestID=e1353c56 sessionID=29b089af seqNo=0 took=396.34309ms
+
+In the above line, the segment was transcoded in ~396.34ms.
+
+You can also verify that the GPUs are being used for transcoding by checking the video encoder (:code:`enc`) and decoder (:code:`dec`) utilization on the GPUs using :code:`nvidia-smi`:
+
+::
+
+    nvidia-smi dmon
+    # gpu   pwr gtemp mtemp    sm   mem   enc   dec  mclk  pclk
+    # Idx     W     C     C     %     %     %     %   MHz   MHz
+        0    319    69    -    100   100    93    76  9251  1875
+        1    319    69    -     99   100    93    76  9251  1890

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -55,3 +55,5 @@ Index
 .. toctree::
    :maxdepth: 2
    :caption: Reference
+
+   reference/leaderboard_faq

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -52,6 +52,8 @@ Index
    :maxdepth: 2
    :caption: Guides
 
+   guides/orchestrator_transcoder_gpu
+
 .. toctree::
    :maxdepth: 2
    :caption: Reference

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -56,4 +56,5 @@ Index
    :maxdepth: 2
    :caption: Reference
 
+   reference/hardware_requirements
    reference/leaderboard_faq

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,25 +1,23 @@
 Welcome to the Livepeer Documentation
 ========================================
 
-`Livepeer`_ is a decentralized video broadcasting platform powered by
-a crypto token on the Ethereum blockchain. Livepeer is for:
+`Livepeer`_ is a decentralized video streaming network build on the Ethereum blockchain. Livepeer is for:
 
 .. _Livepeer: http://livepeer.org
 
 - Developers who want to build applications that include live video.
+- Tokenholders who want to help improve, secure and curate the network by acquiring and staking LPT towards performance orchestrators.
+- Node operators who want to transcode video in exchange for ETH and LPT rewards.
 
-- Users who want to stream video, gaming, coding, entertainment, educational courses, and other types of content..
+Use this documentation to learn how to:
 
-- Broadcasters who currently have large audiences and high streaming bills or infrastructure costs can use the Livepeer network to potentially reduce costs or infrastructure overhead.
+- Broadcast video on the network.
+- Participate as an orchestrator, transcoder or delegator.
+- Build applications with live video features.
 
-Use this documentation to learn how to broadcast video through
-Livepeer, participate in the Livepeer protocol as a transcoder or
-delegator, and build apps or DApps with video based features using
-Livepeer.
+If you want a walkthrough of the core concepts of Livepeer, start with the :doc:`overview` and then jump into the :doc:`quickstart`. 
 
-We suggest you start with :doc:`quickstart`. If you are interested in testing out Livepeer without setting up your own nodes, sign up for `early access`_ to the pilots program.
-
-.. _early access: https://mailchi.mp/livepeer.org/pluginpartner
+The guides section contains a list of step-by-step instructions for accomplishing various tasks and the references section contains technical reference materials.
 
 .. _contributing:
 
@@ -38,6 +36,7 @@ Index
 
 .. toctree::
    :maxdepth: 2
+   :caption: Core Concepts
    
    overview
    quickstart
@@ -48,3 +47,11 @@ Index
    developers
    help
    license
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Guides
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Reference

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -57,4 +57,5 @@ Index
    :caption: Reference
 
    reference/hardware_requirements
+   reference/bandwidth_requirements
    reference/leaderboard_faq

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -53,6 +53,7 @@ Index
    :caption: Guides
 
    guides/orchestrator_transcoder_gpu
+   guides/benchmark_transcoding
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/reference/bandwidth_requirements.rst
+++ b/docs/source/reference/bandwidth_requirements.rst
@@ -1,0 +1,23 @@
+Bandwidth Requirements
+======================
+
+The amount of available bandwidth will not only impact the number of streams that can be transcoded on a machine, but also the
+speed of data upload/download which needs to be fast so that live video streaming applications can receive transcoded results as 
+soon as possible. 
+
+The amount of bandwidth required for a stream will depend on the bitrate of the source stream and the bitrate of the output renditions. The download
+bandwidth required for a single stream can be roughly estimated as the bitrate of the source stream. The upload bandwidth required for a single stream can be
+roughly estimated as the sum of the bitrates of each of the output renditions for the stream. As a result, the total number of streams that can be transcoded given a certain amount of available of bandwidth will vary. 
+
+While there is not a strict bandwidth requirement for the Livepeer network, past testing has demonstrated that 1G upload/download bandwidth is a good starting point if possible. If you
+do not have access to this amount of bandwidth you will still be able to transcode on the network, but you will have a lower ceiling on the number of streams you will be able to handle.
+
+Upload/download bandwidth available can be tested with tools such as:
+
+- `speedtest <https://www.speedtest.net/apps/cli>`_
+    - By default the tool will run a bandwidth test against the closest public server, but there is also an option to run the test against a specified public server
+    - Note: The results of this test also depend on the available bandwidth on the server used
+- `iperf3 <https://iperf.fr/>`_
+    - This tool can be run on client and server machines that you have access to
+    - If you have access to a machine with good bandwidth availability in a region that you expect/want to receive streams from, then this tool will likely be more useful than speedtest
+

--- a/docs/source/reference/hardware_requirements.rst
+++ b/docs/source/reference/hardware_requirements.rst
@@ -1,0 +1,11 @@
+Hardware Requirements
+=====================
+
+Transcoding
+***********
+
+Transcoding can be performed using either a software based encoder/decoder on a CPU or using a hardware encoder/decoder on a GPU.
+
+GPU transcoding is generally significantly faster than CPU transcoding. In the past, the video quality from GPU transcoding was substantially 
+worse than the video quality from CPU transcoding, but the gap in video quality has been closed in recent years with newer GPU models. See 
+this `page <https://github.com/livepeer/wiki/blob/master/GPU-SUPPORT.md>`_ for a list of GPUs that have been tested and are known to be supported by Livepeer software.   

--- a/docs/source/reference/leaderboard_faq.rst
+++ b/docs/source/reference/leaderboard_faq.rst
@@ -127,7 +127,7 @@ In order to improve your metrics, the following factors should be considered:
 
 A few things you can explore to improve the speed of transcoding include:
 
-- Evaluate your current transcoding speed by using a transcoding benchmarking tool
+- Evaluate your current transcoding speed by using a :doc:`transcoding benchmarking tool <../guides/benchmark_transcoding>`
 - Review the :doc:`hardware_requirements` and consider upgrading your hardware
 - If you have access to a `supported GPU <https://github.com/livepeer/wiki/blob/master/GPU-SUPPORT.md>`_:
     - Consider running an :doc:`orchestrator with GPU transcoding <../guides/orchestrator_transcoder_gpu>`

--- a/docs/source/reference/leaderboard_faq.rst
+++ b/docs/source/reference/leaderboard_faq.rst
@@ -130,7 +130,7 @@ A few things you can explore to improve the speed of transcoding include:
 - Evaluate your current transcoding speed by using a transcoding benchmarking tool
 - Review the :doc:`hardware_requirements` and consider upgrading your hardware
 - If you have access to a `supported GPU <https://github.com/livepeer/wiki/blob/master/GPU-SUPPORT.md>`_:
-    - Consider running an orchestrator with GPU transcoding
+    - Consider running an :doc:`orchestrator with GPU transcoding <../guides/orchestrator_transcoder_gpu>`
     - Consider running a standalone orchestrator that sends transcoding tasks to standalone GPU transcoders
 
 A few things you can explore to improve the speed of data upload/download:

--- a/docs/source/reference/leaderboard_faq.rst
+++ b/docs/source/reference/leaderboard_faq.rst
@@ -128,11 +128,11 @@ In order to improve your metrics, the following factors should be considered:
 A few things you can explore to improve the speed of transcoding include:
 
 - Evaluate your current transcoding speed by using a transcoding benchmarking tool
-- Review the hardware reference and consider upgrading your hardware
-- If you have access to a supported GPU:
+- Review the :doc:`hardware_requirements` and consider upgrading your hardware
+- If you have access to a `supported GPU <https://github.com/livepeer/wiki/blob/master/GPU-SUPPORT.md>`_:
     - Consider running an orchestrator with GPU transcoding
     - Consider running a standalone orchestrator that sends transcoding tasks to standalone GPU transcoders
 
 A few things you can explore to improve the speed of data upload/download:
 
-- Review the bandwidth reference and consider upgrading your bandwidth 
+- Review the :doc:`bandwidth_requirements` and consider upgrading your bandwidth 

--- a/docs/source/reference/leaderboard_faq.rst
+++ b/docs/source/reference/leaderboard_faq.rst
@@ -1,0 +1,138 @@
+Orchestrator Leaderboard FAQ
+============================
+
+The orchestrator leaderboard can be found in the `explorer <https://explorer.livepeer.org/?orchestratorTable=performance>`_.
+
+What is the orchestrator leaderboard?
+***************************************
+
+The orchestrator leaderboard displays performance metrics of individual orchestrators on the Livepeer network based on
+the results of transcoding tests.
+
+What is the purpose of the leaderboard?
+****************************************
+
+The purpose of the leaderboard is to increase visibility of individual orchestrator performance. An assessment of an orchestrator's performance
+is difficult using only on-chain data due to limitations on the frequency and types of data that can be measured on-chain. The leaderboard provides
+access to off-chain data to complement on-chain data in order to create a more complete view of an orchestrator's performance.
+
+Who is running the transcoding tests for the leaderboard?
+**********************************************************
+
+The transcoding tests are currently run by Livepeer Inc. Since the transcoding tests are run using open source software, anyone can run these tests
+themselves as well.
+
+What software is used to run the transcoding tests?
+*****************************************************
+
+The software used to run these tests consists of:
+
+- A `broadcaster node <https://github.com/livepeer/go-livepeer>`_
+- A `stream-tester <https://github.com/livepeer/stream-tester>`_ that sends streams to the broadcaster
+- A `monitoring instance <https://github.com/livepeer/docker-livepeer/tree/master/monitoring>`_ that collects metrics from the broadcaster
+- An `orch-tester process <https://github.com/livepeer/stream-tester/tree/master/cmd/orch-tester>`_ that automates tests and saves metrics
+
+What happens during a transcoding test?
+*****************************************
+
+A transcoding test involves running a broadcaster node that sends one or many streams to an orchestrator to be transcoded and then recording metrics about the transcoding
+performance for the streams. A transcoding test is run for each orchestrator on the network at a regular interval each day from different regions.
+
+At the moment, a transcoding test uses the following configuration:
+
+- 1 30 second source video stream
+- 4 output renditions
+
+The transcoding test configuration is subject to change in the future in order to assess other aspects of an orchestrator's performance.
+
+What regions are the transcoding tests run from?
+*************************************************
+
+The transcoding tests are currently run from the following regions:
+
+- North America (Chicago)
+- Europe (Frankfurt)
+- Asia (Singapore)
+
+The tests are run from different regions in order to assess the transcoding performance a user in that region can expect from orchestrators.
+
+The regions that transcoding tests are run from are subject to change in order to asess orchestrator performance from a greater number of regions in the world.
+
+What metrics are displayed in the leaderboard?
+************************************************
+
+The leaderboard currently displays the following metrics:
+
+- **Total score**: The average utility of using an orchestrator based on past transcoding tests.
+- **Success rate**: The average percentage of source video segments that were successfully transcoded in past transcoding tests.
+- **Latency score**: The average utility of an orchestrator's overall transcoding latency in past transcoding tests.
+
+Additional metrics for other aspects of an orchestrator's performance may be added in the future.
+
+How is the success rate in the leaderboard calculated?
+********************************************************
+
+The success rate is calculated by counting the number of transcoded results (could contain one or many output renditions) received from an orchestrator and dividing it by the number of source video segments in a stream.
+For example, given 100 source video segments in a stream and 60 transcoded results received, the success rate would be 60%.
+
+The number of transcoded results received in a transcoding test is impacted by whether the orchestrator is online during the test and whether the orchestrator can 
+keep up with the stream. The latter is also influenced by the broadcaster's implementation. The current broadcaster implementation results in dropped segments (missing transcoded results)
+if a) the orchestrator is still transcoding the previous segment when a new segment is ready or b) the orchestrator takes longer than 8 seconds to return the transcoded results
+for a segment.
+
+The leaderboard in the explorer displays this metric as a value in the range 0-100%.
+
+How is the latency score in the leaderboard calculated?
+*********************************************************
+
+The current formula for the latency score is:
+
+::
+
+    latency_score = 1 - e^{-base_latency_score}
+    base_latency_score = avg_segment_duration / avg_round_trip_time
+
+:code:`base_latency_score` measures the average round time for a broadcaster to receive the transcoded results for a segment relative to the average segment duration in a stream. When this value is less than
+1.0, the orchestrator is returning transcoded results slower than real-time. When the value is greater than or equal to 1.0, the orchestrator is returning transcoded results
+in real-time or faster. 
+
+Since live streaming applications require fast transcoding, the latency score increases as the base latency score increases. However, the rate of increase for the latency score 
+also decreases as the base latency score increases which reflects diminishing utility from increases in transcoding speed.
+
+The leaderboard in the explorer scales this metric and displays it as a value in the range 0-10.
+
+How is the total score in the leaderboard calculated?
+*******************************************************
+
+The current formula for the total score is:
+
+::
+
+    total_score = success_rate * latency_score
+
+Since the latency score only considers successfully transcoded source segments, it is multiplied by the success rate to take into account the number of source segments
+that were actually transcoded by an orchestrator in its total score.
+
+The formula for the total score is subject to change as additional performance metrics are added in the future.
+
+The leaderboard in the explorer scales this metric and displays it as a value in the range 0-10.
+
+As an orchestrator operator, how can I improve my metrics on the leaderboard?
+*******************************************************************************
+
+In order to improve your metrics, the following factors should be considered:
+
+- The speed of transcoding which depends on compute resources (i.e. type of hardware, amount of hardware, etc.)
+- The speed of data upload/download which depends on bandwidth resources
+
+A few things you can explore to improve the speed of transcoding include:
+
+- Evaluate your current transcoding speed by using a transcoding benchmarking tool
+- Review the hardware reference and consider upgrading your hardware
+- If you have access to a supported GPU:
+    - Consider running an orchestrator with GPU transcoding
+    - Consider running a standalone orchestrator that sends transcoding tasks to standalone GPU transcoders
+
+A few things you can explore to improve the speed of data upload/download:
+
+- Review the bandwidth reference and consider upgrading your bandwidth 


### PR DESCRIPTION
This PR starts the transition to a documentation structure based on the [Divio system](https://documentation.divio.com/) which is also used for livepeer.com/docs - a lot of iteration left to do! This PR also contains the orchestrator leaderboard FAQ which is structured as a reference that also points to a few resources that an orchestrator operator can take a look at to start taking steps to improve their metrics on the leaderboard.

- Update the project description to better align with the description at livepeer.org
- Add "Guides" and "References" section
- Add the following guides
    - How To Run An Orchestrator With GPU Transcoding
- Add the following references
    - Hardware Requirements
    - Bandwidth Requirements
    - Leaderboard FAQ

See commit history for a more detailed breakdown of the each of the changes.

TODOs:
- [x] Add link to orch-tester code in leaderboard FAQ once https://github.com/livepeer/stream-tester/pull/62 is merged