### PR TITLE
installation: automatically move binaries into /usr/local/bin upon untarring

### DIFF
--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -11,7 +11,5 @@ $ wget https://github.com/livepeer/go-livepeer/releases/download/<RELEASE_VERSIO
 After downloading the file, untar the archive and move the `livepeer` binary so that it is executable within your `$PATH`:
 
 ```
-$ tar -zxvf livepeer-<YOUR_PLATFORM>-amd64.tar.gz
-$ mv livepeer-<YOUR_PLATFORM>-amd64/livepeer /usr/local/bin
-$ mv livepeer-<YOUR_PLATFORM>-amd64/livepeer_cli /usr/local/bin
+$ tar -C /usr/local/bin -fxz livepeer-<YOUR_PLATFORM>-amd64.tar.gz
 ```

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -11,5 +11,5 @@ $ wget https://github.com/livepeer/go-livepeer/releases/download/<RELEASE_VERSIO
 After downloading the file, untar the archive and move the `livepeer` binary so that it is executable within your `$PATH`:
 
 ```
-$ tar -C /usr/local/bin -fxz livepeer-<YOUR_PLATFORM>-amd64.tar.gz
+$ tar -C /usr/local/bin -xfz livepeer-<YOUR_PLATFORM>-amd64.tar.gz --strip 2
 ```


### PR DESCRIPTION
the -C flag moves all of the unpacked files into the provided directory. 

This can be useful so that users don't have to move every executable into their $PATH manually which is sometimes a point of confusion for users less acquainted with the command line.
