### PR TITLE
Create 3rd party section + version bump in example

### DIFF
--- a/docs/installation/install-livepeer/binary-release.md
+++ b/docs/installation/install-livepeer/binary-release.md
@@ -7,7 +7,7 @@ sidebar_position: 2
 ### Darwin (macOS)
 
 ```bash
-# <RELEASE_VERSION> is the release version i.e. 0.5.14
+# <RELEASE_VERSION> is the release version i.e. 0.5.23
 
 # First, fetch the latest release
 wget https://github.com/livepeer/go-livepeer/releases/download/<RELEASE_VERSION>/livepeer-darwin-amd64.tar.gz
@@ -22,7 +22,7 @@ mv livepeer-darwin-amd64/* /usr/local/bin/
 ### Linux
 
 ```bash
-# <RELEASE_VERSION> is the release version i.e. 0.5.14
+# <RELEASE_VERSION> is the release version i.e. 0.5.23
 
 # First, fetch the latest release
 wget https://github.com/livepeer/go-livepeer/releases/download/<RELEASE_VERSION>/livepeer-linux-amd64.tar.gz
@@ -37,7 +37,7 @@ mv livepeer-linux-amd64/* /usr/local/bin/
 ### Windows
 
 ```bash
-# <RELEASE_VERSION> is the release version i.e. 0.5.14
+# <RELEASE_VERSION> is the release version i.e. 0.5.23
 
 # First, fetch the latest release
 wget https://github.com/livepeer/go-livepeer/releases/download/<RELEASE_VERSION>/livepeer-windows-amd64.tar.gz
@@ -47,4 +47,20 @@ tar -zxvf livepeer-windows-amd64.tar.gz
 
 # Finally, move it to the appropriate directory
 mv livepeer-windows-amd64/* /usr/local/bin/
+```
+A community created Bash script to update Livepeer is [available on the forum](https://forum.livepeer.org/t/bash-script-to-update-livepeer/1513).
+
+## Third-party packages
+Packages for different Linux distributions are maintained by Livepeer community members. Before using these packages, please verify that they have been updated to use the [latest builds of go-livepeer](https://github.com/livepeer/go-livepeer/releases). This list will be updated as a best-effort, but we cannot guarantee if individual packages are up-to-date or verify their integrity.
+
+In the future, Livepeer core contributors may publish official packages for the distributions below.
+
+### Arch Linux
+**Source**
+
+https://aur.archlinux.org/packages/go-livepeer-bin/
+
+**Installation**
+```
+paru go-livepeer-bin
 ```


### PR DESCRIPTION
1. Created a third-party section to list community created packages with a disclaimer that they are not official Livepeer packages as suggested by @hthillman.
See discussion at https://github.com/livepeer/docs/pull/90/commits/d7ccac240639743189f7067545aa5c53e4c77cee

2. Updated three listed instances of the Livepeer version to the current, 0.5.23 from 0.5.14