### PR TITLE
Update documented reward logic

### DIFF
--- a/docs/video-miners/reference/configuration.md
+++ b/docs/video-miners/reference/configuration.md
@@ -123,7 +123,7 @@ redeemer: Set to true to run a ticket redemption service. Default `false`
 
 redeemerAddr: URL of the ticket redemption service to use. No default
 
-reward: Set to true to run a reward service. Default `false`
+reward: Run a reward service, set false to disable automatic reward claims. Default `true`
 
 monitor: Set to true to send performance metrics. Default `false`
 


### PR DESCRIPTION
Discord context:
https://discord.com/channels/423160867534929930/932724294230900776/933417846237716550
https://discord.com/channels/423160867534929930/932724294230900776/933792649788411935

I think it has been established that `reward` is actually true by default and must be explicitly disabled with `reward false` / `-reward=false` on both O and T processes. This confusion is potentially costing many new orchestrators / transcoders hundreds of dollars in unnecessarily spent gas.