### PR TITLE
Add URL to Arbitrum bridge

### DIFF
--- a/docs/video-miners/how-to-guides/l2-migration.md
+++ b/docs/video-miners/how-to-guides/l2-migration.md
@@ -109,7 +109,7 @@ Other options are: [set up an Arbitrum node](https://developer.offchainlabs.com/
     
 4. **Register your service URI and fee structure on Arbitrum  using “Set orchestrator config”**
 
-To receive work, you must register your service URI and fees so that broadcasters can discover your orchestrator. This can be done by selecting option `13: Set orchestrator config` in the Livepeer CLI. To do this, you'll need some arbETH in your wallet to pay for the transaction.
+To receive work, you must register your service URI and fees so that broadcasters can discover your orchestrator. This can be done by selecting option `13: Set orchestrator config` in the Livepeer CLI. To do this, you'll need some arbETH in your wallet to pay for the transaction. Use the [Arbitrum bridge](https://bridge.arbitrum.io) to send Ethereum on Layer 1, to Arbitrum on Layer 2, over the appropriate (Mainnet / Rinkeby) network.
 
 Once this is complete, you're all set to receive work, rewards, and fees on Arbitrum.
 


### PR DESCRIPTION
Add one-liner + URL for bridge to send ETH from L1 to L2.
Good place to make L1 v L2 distinction while playing on testnet.