### PR TITLE
install: fix chain build tag

### DIFF
--- a/docs/installation/install-livepeer/installing-for-development.md
+++ b/docs/installation/install-livepeer/installing-for-development.md
@@ -83,9 +83,9 @@ Building `livepeer` requires Go. Follow the
    Set the `BUILD_TAGS` variable to enable mainnet support:
 
    ```bash
-   export BUILD_TAGS=arbitrum-one-mainnet
+   export BUILD_TAGS=mainnet
    # To build with support for only development networks and the Rinkeby test network
-   # export BUILD_TAGS=arbitrum-one-rinkeby
+   # export BUILD_TAGS=rinkeby
    # To build with support for only development networks
    # export BUILD_TAGS=dev
    ```


### PR DESCRIPTION
It seems like the chain build tags described in the docs don't work for building from source. 

From [Marco on Discord](https://discord.com/channels/423160867534929930/930504210884206663/943237306817593365): 
> The guide for building go-livepeer (https://docs.livepeer.org/installation/install-livepeer/installing-for-development#build-and-install) instructs you to use export BUILD_TAGS=arbitrum-one-mainnet, but the resulting binaries throw an error:  node does not support chainID = 42161 right now
Building with export BUILD_TAGS=mainnet does work however with arbitrum

