### PR TITLE
Update installing-for-development.md

### DIFF
--- a/docs/installation/install-livepeer/installing-for-development.md
+++ b/docs/installation/install-livepeer/installing-for-development.md
@@ -33,9 +33,15 @@ Building `livepeer` requires some system dependencies.
 Linux (Ubuntu: 16.04 or 18.04):
 
 ```bash
-apt-get update && apt-get -y install build-essential pkg-config autoconf git curl protobuf-compiler-grpc golang-goprotobuf-dev
+apt-get update && apt-get -y install build-essential pkg-config autoconf git curl
 # To enable transcoding on Nvidia GPUs
 apt-get -y install clang-8 clang-tools-8
+```
+
+Linux (Ubuntu: 20.04):
+
+```bash
+apt-get install protobuf-compiler-grpc golang-goprotobuf-dev 
 ```
 
 Darwin (macOS):

--- a/docs/installation/install-livepeer/installing-for-development.md
+++ b/docs/installation/install-livepeer/installing-for-development.md
@@ -33,7 +33,7 @@ Building `livepeer` requires some system dependencies.
 Linux (Ubuntu: 16.04 or 18.04):
 
 ```bash
-apt-get update && apt-get -y install build-essential pkg-config autoconf git curl
+apt-get update && apt-get -y install build-essential pkg-config autoconf git curl protobuf-compiler-grpc golang-goprotobuf-dev
 # To enable transcoding on Nvidia GPUs
 apt-get -y install clang-8 clang-tools-8
 ```

--- a/docs/installation/install-livepeer/installing-for-development.md
+++ b/docs/installation/install-livepeer/installing-for-development.md
@@ -41,7 +41,7 @@ apt-get -y install clang-8 clang-tools-8
 Linux (Ubuntu: 20.04):
 
 ```bash
-apt-get install protobuf-compiler-grpc golang-goprotobuf-dev 
+apt-get -y install protobuf-compiler-grpc golang-goprotobuf-dev 
 ```
 
 Darwin (macOS):


### PR DESCRIPTION
I had to install protobuf-compiler-grpc and golang-goprotobuf-dev to build from source on Ubuntu 20.04 using makefile.  Installing first fixed error "/bin/bash: protoc: command not found" protoc not found".  Installing second fixed error "protoc-gen-go: program not found or is not executable".