### PR TITLE
Update bridge-lpt.md

### DIFF
--- a/docs/delegators/how-to-guides/bridge-lpt.md
+++ b/docs/delegators/how-to-guides/bridge-lpt.md
@@ -11,6 +11,11 @@ Please note that you will need some ETH in your wallet to complete this guide. I
 1. Make sure your wallet (i.e. Metamask) is connected to the Ethereum mainnet (Rinkeby if using testnet) and then navigate to the [Arbitrum Bridge](https://bridge.arbitrum.io/)
 2. Click "Token", and enter the L1 LPT contract address ([0x58b6a8a3302369daec383334672404ee733ab239](/protocol/reference/deployed)). If you are using testnet, use the `LivepeerToken` address for Rinkeby.
 3. Select LPT from the dropdown. Once you've done this, you should see your L1 balance.
-4. Click `Deposit` to move your L1 LPT to L2.
+4. Click `Deposit` to move your L1 LPT to L2.  This will initiate an Approval transaction.  The first of 2 transactions required to bridge LPT to Arbitrum.
+5. After the Approval transaction status changes from pending to success (about 10 mins) LPT can now be Deposited.
+6. Click 'Deposit' and confirm the transaction in your wallet to complete the bridging of LPT from L1 to L2
+7. 
+![Bridge](https://user-images.githubusercontent.com/89408276/155375033-6fd66e8a-53ab-43e9-9fe6-3a0cec847a55.jpg)
 
 If you need to move from L2 to L1, the same instructions apply; the only difference is that you should start with your wallet connected to Arbitrum (Arbitrum Rinkeby if using testnet) and enter the L2 LPT contract address ([0x289ba1701C2F088cf0faf8B3705246331cB8A839](/protocol/reference/deployed)) as the destination address.
+


### PR DESCRIPTION
4. Click `Deposit` to move your L1 LPT to L2.  This will initiate an Approval transaction.  The first of 2 transactions required to bridge LPT to Arbitrum.
5. After the Approval transaction status changes from pending to success (about 10 mins) LPT can now be Deposited.
6. Click 'Deposit' and confirm the transaction in your wallet to complete the bridging of LPT from L1 to L2

![Bridge](https://user-images.githubusercontent.com/89408276/155375033-6fd66e8a-53ab-43e9-9fe6-3a0cec847a55.jpg)