### PR TITLE
Add a page with Prometheus metrics

### DIFF
--- a/docs/video-miners/how-to-guides/metrics-monitoring.md
+++ b/docs/video-miners/how-to-guides/metrics-monitoring.md
@@ -23,6 +23,12 @@ livepeer \
     -monitor
 ```
 
+Additionally, you can add the following parameters:
+- `-metricsPerStream`: groups performance metrics per stream
+- `-metricsClientIP`: exposes client's IP in metrics
+
+To check what metrics are exposed, please refer to [Prometheus Metrics](/video-miners/reference/metrics).
+
 ## Monitoring with Prometheus and Grafana
 
 The metrics recorded by `livepeer` can be exported to

--- a/docs/video-miners/reference/index.md
+++ b/docs/video-miners/reference/index.md
@@ -13,3 +13,4 @@ This section contains video miner references:
 - [Orchestrator performance leaderboard](/video-miners/reference/leaderboard)
 - [Supported GPUs](/video-miners/reference/gpu-support)
 - [Glossary](/video-miners/reference/glossary)
+- [Prometheus Metrics](/video-miners/reference/metrics)

--- a/docs/video-miners/reference/metrics.md
+++ b/docs/video-miners/reference/metrics.md
@@ -1,0 +1,14 @@
+---
+title: Prometheus Metrics
+sidebar_position: 7
+---
+
+# Prometheus Metrics
+
+Livepeer exposes a number of metrics via the Prometheus exporter. This page documents all metrics that you can scrape via the `/metrics` endpoint when the [monitoring is enabled](/video-miners/how-to-guides/metrics-monitoring).
+
+## General
+
+| Name                     | Description                                                                                                 |
+| ----------------------------- | ------------------ |
+| test metrics | Test Description |

--- a/docs/video-miners/reference/metrics.md
+++ b/docs/video-miners/reference/metrics.md
@@ -11,95 +11,95 @@ Livepeer exposes a number of metrics via the Prometheus exporter. This page docu
 
 ### General
 
-| Name                                                     | Description                                                                                                      | Unit | Type      | Tags                                              |
-| -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | ---- | --------- | ------------------------------------------------- |
-| `livepeer_versions`                                      | Versions used by LivePeer node.                                                                                  | Num  | gauge     | compiler,goos,goversion,livepeerversion,node_type |
-| `livepeer_segment_source_appeared_total`                 | SegmentSourceAppeared                                                                                            | tot  | counter   | node_id,node_type,profile,seg_type                |
-| `livepeer_segment_source_emerged_total`                  | SegmentEmerged                                                                                                   | tot  | counter   | node_id,node_type                                 |
-| `livepeer_segment_source_emerged_unprocessed_total`      | Raw number of segments emerged from segmenter.                                                                   | tot  | counter   | node_id,node_type                                 |
-| `livepeer_segment_source_uploaded_total`                 | SegmentUploaded                                                                                                  | tot  | counter   | node_id,node_type,orchestrator_uri                |
-| `livepeer_segment_source_upload_failed_total`            | SegmentUploadedFailed                                                                                            | tot  | counter   | error_code,node_id,node_type,orchestrator_uri     |
-| `livepeer_segment_transcoded_downloaded_total`           | SegmentDownloaded                                                                                                | tot  | counter   | node_id,node_type                                 |
-| `livepeer_segment_transcoded_total`                      | SegmentTranscoded                                                                                                | tot  | counter   | node_id,node_type,profiles,trusted,verified       |
-| `livepeer_segment_transcoded_unprocessed_total`          | Raw number of segments successfully transcoded.                                                                  | tot  | counter   | node_id,node_type,profiles                        |
-| `livepeer_segment_transcode_failed_total`                | SegmentTranscodeFailed                                                                                           | tot  | counter   | error_code,node_id,node_type                      |
-| `livepeer_segment_transcoded_appeared_total`             | SegmentTranscodedAppeared                                                                                        | tot  | counter   | node_id,node_type,profile,seg_type                |
-| `livepeer_segment_transcoded_all_appeared_total`         | SegmentTranscodedAllAppeared                                                                                     | tot  | counter   | node_id,node_type,profiles                        |
-| `livepeer_broadcast_client_start_failed_total`           | StartBroadcastClientFailed                                                                                       | tot  | counter   | node_id,node_type                                 |
-| `livepeer_stream_create_failed_total`                    | StreamCreateFailed                                                                                               | tot  | counter   | node_id,node_type                                 |
-| `livepeer_stream_created_total`                          | StreamCreated                                                                                                    | tot  | counter   | node_id,node_type                                 |
-| `livepeer_stream_started_total`                          | StreamStarted                                                                                                    | tot  | counter   | node_id,node_type                                 |
-| `livepeer_stream_ended_total`                            | StreamEnded                                                                                                      | tot  | counter   | node_id,node_type                                 |
-| `livepeer_max_sessions_total`                            | Max Sessions                                                                                                     | tot  | gauge     | node_id,node_type                                 |
-| `livepeer_current_sessions_total`                        | Number of streams currently transcoding                                                                          | tot  | gauge     | node_id,node_type                                 |
-| `livepeer_discovery_errors_total`                        | Number of discover errors                                                                                        | tot  | counter   | error_code,node_id,node_type,orchestrator_uri     |
-| `livepeer_transcode_retried`                             | Number of times segment transcode was retried                                                                    | tot  | counter   | node_id,node_type,try                             |
-| `livepeer_transcoders_number`                            | Number of transcoders currently connected to orchestrator                                                        | tot  | gauge     | node_id,node_type                                 |
-| `livepeer_transcoders_capacity`                          | Total advertised capacity of transcoders currently connected to orchestrator                                     | tot  | gauge     | node_id,node_type                                 |
-| `livepeer_transcoders_load`                              | Total load of transcoders currently connected to orchestrator                                                    | tot  | gauge     | node_id,node_type                                 |
-| `livepeer_success_rate`                                  | Number of transcoded segments divided on number of source segments                                               | per  | gauge     | node_id,node_type                                 |
-| `livepeer_success_rate_per_stream`                       | Number of transcoded segments divided on number of source segments, per stream                                   | per  | gauge     | node_id,node_type                                 |
-| `livepeer_transcode_time_seconds`                        | TranscodeTime, seconds                                                                                           | sec  | histogram | node_id,node_type,profiles,trusted,verified       |
-| `livepeer_transcode_latency_seconds`                     | Transcoding latency, from source segment emerged from segmenter till transcoded segment apeeared in manifest     | sec  | histogram | node_id,node_type,profile                         |
-| `livepeer_transcode_overall_latency_seconds`             | Transcoding latency, from source segment emerged from segmenter till all transcoded segment apeeared in manifest | sec  | histogram | node_id,node_type,profiles                        |
-| `livepeer_upload_time_seconds`                           | UploadTime, seconds                                                                                              | sec  | histogram | node_id,node_type,orchestrator_uri                |
-| `livepeer_download_time_seconds`                         | Download time                                                                                                    | sec  | histogram | node_id,node_type                                 |
-| `livepeer_auth_webhook_time_milliseconds`                | Authentication webhook execution time, milliseconds                                                              | ms   | histogram | node_id,node_type                                 |
-| `livepeer_source_segment_duration_seconds`               | Source segment's duration                                                                                        | sec  | histogram | node_id,node_type                                 |
-| `livepeer_http_client_timeout_1`                         | Number of times HTTP connection was dropped before transcoding complete                                          | tot  | counter   | node_id,node_type                                 |
-| `livepeer_http_client_timeout_2`                         | Number of times HTTP connection was dropped before transcoded segments was sent back to client                   | tot  | counter   | node_id,node_type                                 |
-| `livepeer_http_client_segment_transcoded_realtime_ratio` | Ratio of source segment duration / transcode time as measured on HTTP client                                     | rat  | histogram | node_id,node_type                                 |
-| `livepeer_http_client_segment_transcoded_realtime_3x`    | Number of segment transcoded 3x faster than realtime                                                             | tot  | counter   | node_id,node_type                                 |
-| `livepeer_http_client_segment_transcoded_realtime_2x`    | Number of segment transcoded 2x faster than realtime                                                             | tot  | counter   | node_id,node_type                                 |
-| `livepeer_http_client_segment_transcoded_realtime_1x`    | Number of segment transcoded 1x faster than realtime                                                             | tot  | counter   | node_id,node_type                                 |
-| `livepeer_http_client_segment_transcoded_realtime_half`  | Number of segment transcoded no more than two times slower than realtime                                         | tot  | counter   | node_id,node_type                                 |
-| `livepeer_http_client_segment_transcoded_realtime_slow`  | Number of segment transcoded more than two times slower than realtime                                            | tot  | counter   | node_id,node_type                                 |
-| `livepeer_transcode_score`                               | Ratio of source segment duration vs. transcode time                                                              | rat  | histogram | node_id,node_type,profiles,trusted,verified       |
-| `livepeer_recording_save_latency`                        | How long it takes to save segment to the OS                                                                      | sec  | histogram | node_id,node_type                                 |
-| `livepeer_recording_save_errors`                         | Number of errors during save to the recording OS                                                                 | tot  | counter   | node_id,node_type                                 |
-| `livepeer_recording_saved_segments`                      | Number of segments saved to the recording OS                                                                     | tot  | counter   | node_id,node_type                                 |
-| `livepeer_orchestrator_swaps`                            | Number of orchestrator swaps mid-stream                                                                          | tot  | counter   | node_id,node_type                                 |
+| Name                                                     | Description                                                                                                      | Unit | Type      | Tags                                                  |
+| -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | ---- | --------- | ----------------------------------------------------- |
+| `livepeer_versions`                                      | Versions used by LivePeer node.                                                                                  | Num  | gauge     | compiler, goos, goversion, livepeerversion, node_type |
+| `livepeer_segment_source_appeared_total`                 | SegmentSourceAppeared                                                                                            | tot  | counter   | node_id, node_type, profile, seg_type                 |
+| `livepeer_segment_source_emerged_total`                  | SegmentEmerged                                                                                                   | tot  | counter   | node_id, node_type                                    |
+| `livepeer_segment_source_emerged_unprocessed_total`      | Raw number of segments emerged from segmenter.                                                                   | tot  | counter   | node_id, node_type                                    |
+| `livepeer_segment_source_uploaded_total`                 | SegmentUploaded                                                                                                  | tot  | counter   | node_id, node_type, orchestrator_uri                  |
+| `livepeer_segment_source_upload_failed_total`            | SegmentUploadedFailed                                                                                            | tot  | counter   | error_code, node_id, node_type, orchestrator_uri      |
+| `livepeer_segment_transcoded_downloaded_total`           | SegmentDownloaded                                                                                                | tot  | counter   | node_id, node_type                                    |
+| `livepeer_segment_transcoded_total`                      | SegmentTranscoded                                                                                                | tot  | counter   | node_id, node_type, profiles, trusted, verified       |
+| `livepeer_segment_transcoded_unprocessed_total`          | Raw number of segments successfully transcoded.                                                                  | tot  | counter   | node_id, node_type, profiles                          |
+| `livepeer_segment_transcode_failed_total`                | SegmentTranscodeFailed                                                                                           | tot  | counter   | error_code, node_id, node_type                        |
+| `livepeer_segment_transcoded_appeared_total`             | SegmentTranscodedAppeared                                                                                        | tot  | counter   | node_id, node_type, profile, seg_type                 |
+| `livepeer_segment_transcoded_all_appeared_total`         | SegmentTranscodedAllAppeared                                                                                     | tot  | counter   | node_id, node_type, profiles                          |
+| `livepeer_broadcast_client_start_failed_total`           | StartBroadcastClientFailed                                                                                       | tot  | counter   | node_id, node_type                                    |
+| `livepeer_stream_create_failed_total`                    | StreamCreateFailed                                                                                               | tot  | counter   | node_id, node_type                                    |
+| `livepeer_stream_created_total`                          | StreamCreated                                                                                                    | tot  | counter   | node_id, node_type                                    |
+| `livepeer_stream_started_total`                          | StreamStarted                                                                                                    | tot  | counter   | node_id, node_type                                    |
+| `livepeer_stream_ended_total`                            | StreamEnded                                                                                                      | tot  | counter   | node_id, node_type                                    |
+| `livepeer_max_sessions_total`                            | Max Sessions                                                                                                     | tot  | gauge     | node_id, node_type                                    |
+| `livepeer_current_sessions_total`                        | Number of streams currently transcoding                                                                          | tot  | gauge     | node_id, node_type                                    |
+| `livepeer_discovery_errors_total`                        | Number of discover errors                                                                                        | tot  | counter   | error_code, node_id, node_type, orchestrator_uri      |
+| `livepeer_transcode_retried`                             | Number of times segment transcode was retried                                                                    | tot  | counter   | node_id, node_type, try                               |
+| `livepeer_transcoders_number`                            | Number of transcoders currently connected to orchestrator                                                        | tot  | gauge     | node_id, node_type                                    |
+| `livepeer_transcoders_capacity`                          | Total advertised capacity of transcoders currently connected to orchestrator                                     | tot  | gauge     | node_id, node_type                                    |
+| `livepeer_transcoders_load`                              | Total load of transcoders currently connected to orchestrator                                                    | tot  | gauge     | node_id, node_type                                    |
+| `livepeer_success_rate`                                  | Number of transcoded segments divided on number of source segments                                               | per  | gauge     | node_id, node_type                                    |
+| `livepeer_success_rate_per_stream`                       | Number of transcoded segments divided on number of source segments, per stream                                   | per  | gauge     | node_id, node_type                                    |
+| `livepeer_transcode_time_seconds`                        | TranscodeTime, seconds                                                                                           | sec  | histogram | node_id, node_type, profiles, trusted, verified       |
+| `livepeer_transcode_latency_seconds`                     | Transcoding latency, from source segment emerged from segmenter till transcoded segment apeeared in manifest     | sec  | histogram | node_id, node_type, profile                           |
+| `livepeer_transcode_overall_latency_seconds`             | Transcoding latency, from source segment emerged from segmenter till all transcoded segment apeeared in manifest | sec  | histogram | node_id, node_type, profiles                          |
+| `livepeer_upload_time_seconds`                           | UploadTime, seconds                                                                                              | sec  | histogram | node_id, node_type, orchestrator_uri                  |
+| `livepeer_download_time_seconds`                         | Download time                                                                                                    | sec  | histogram | node_id, node_type                                    |
+| `livepeer_auth_webhook_time_milliseconds`                | Authentication webhook execution time, milliseconds                                                              | ms   | histogram | node_id, node_type                                    |
+| `livepeer_source_segment_duration_seconds`               | Source segment's duration                                                                                        | sec  | histogram | node_id, node_type                                    |
+| `livepeer_http_client_timeout_1`                         | Number of times HTTP connection was dropped before transcoding complete                                          | tot  | counter   | node_id, node_type                                    |
+| `livepeer_http_client_timeout_2`                         | Number of times HTTP connection was dropped before transcoded segments was sent back to client                   | tot  | counter   | node_id, node_type                                    |
+| `livepeer_http_client_segment_transcoded_realtime_ratio` | Ratio of source segment duration / transcode time as measured on HTTP client                                     | rat  | histogram | node_id, node_type                                    |
+| `livepeer_http_client_segment_transcoded_realtime_3x`    | Number of segment transcoded 3x faster than realtime                                                             | tot  | counter   | node_id, node_type                                    |
+| `livepeer_http_client_segment_transcoded_realtime_2x`    | Number of segment transcoded 2x faster than realtime                                                             | tot  | counter   | node_id, node_type                                    |
+| `livepeer_http_client_segment_transcoded_realtime_1x`    | Number of segment transcoded 1x faster than realtime                                                             | tot  | counter   | node_id, node_type                                    |
+| `livepeer_http_client_segment_transcoded_realtime_half`  | Number of segment transcoded no more than two times slower than realtime                                         | tot  | counter   | node_id, node_type                                    |
+| `livepeer_http_client_segment_transcoded_realtime_slow`  | Number of segment transcoded more than two times slower than realtime                                            | tot  | counter   | node_id, node_type                                    |
+| `livepeer_transcode_score`                               | Ratio of source segment duration vs. transcode time                                                              | rat  | histogram | node_id, node_type, profiles, trusted, verified       |
+| `livepeer_recording_save_latency`                        | How long it takes to save segment to the OS                                                                      | sec  | histogram | node_id, node_type                                    |
+| `livepeer_recording_save_errors`                         | Number of errors during save to the recording OS                                                                 | tot  | counter   | node_id, node_type                                    |
+| `livepeer_recording_saved_segments`                      | Number of segments saved to the recording OS                                                                     | tot  | counter   | node_id, node_type                                    |
+| `livepeer_orchestrator_swaps`                            | Number of orchestrator swaps mid-stream                                                                          | tot  | counter   | node_id, node_type                                    |
 
 ### Sending payments
 
-| Name                             | Description                                        | Unit | Type    | Tags              |
-| -------------------------------- | -------------------------------------------------- | ---- | ------- | ----------------- |
-| `livepeer_ticket_value_sent`     | Ticket value sent                                  | gwei | counter | node_id,node_type |
-| `livepeer_tickets_sent`          | Tickets sent                                       | tot  | counter | node_id,node_type |
-| `livepeer_payment_create_errors` | Errors when creating payments                      | tot  | counter | node_id,node_type |
-| `livepeer_broadcaster_deposit`   | Current remaining deposit for the broadcaster node | gwei | gauge   | node_id,node_type |
-| `livepeer_broadcaster_reserve`   | Current remaining reserve for the broadcaster node | gwei | gauge   | node_id,node_type |
-| `livepeer_max_transcoding_price` | Maximum price per pixel to pay for transcoding     | wei  | gauge   | node_id,node_type |
+| Name                             | Description                                        | Unit | Type    | Tags               |
+| -------------------------------- | -------------------------------------------------- | ---- | ------- | ------------------ |
+| `livepeer_ticket_value_sent`     | Ticket value sent                                  | gwei | counter | node_id, node_type |
+| `livepeer_tickets_sent`          | Tickets sent                                       | tot  | counter | node_id, node_type |
+| `livepeer_payment_create_errors` | Errors when creating payments                      | tot  | counter | node_id, node_type |
+| `livepeer_broadcaster_deposit`   | Current remaining deposit for the broadcaster node | gwei | gauge   | node_id, node_type |
+| `livepeer_broadcaster_reserve`   | Current remaining reserve for the broadcaster node | gwei | gauge   | node_id, node_type |
+| `livepeer_max_transcoding_price` | Maximum price per pixel to pay for transcoding     | wei  | gauge   | node_id, node_type |
 
 ### Receiving payments
 
-| Name                                | Description                                        | Unit | Type    | Tags                         |
-| ----------------------------------- | -------------------------------------------------- | ---- | ------- | ---------------------------- |
-| `livepeer_ticket_value_recv`        | Ticket value received                              | gwei | counter | node_id,node_type            |
-| `livepeer_tickets_recv`             | Tickets received                                   | tot  | counter | node_id,node_type            |
-| `livepeer_payment_recv_errors`      | Errors when receiving payments                     | tot  | counter | error_code,node_id,node_type |
-| `livepeer_winning_tickets_recv`     | Winning tickets received                           | tot  | counter | node_id,node_type            |
-| `livepeer_value_redeemed`           | Winning ticket value redeemed                      | gwei | counter | node_id,node_type            |
-| `livepeer_ticket_redemption_errors` | Errors when redeeming tickets                      | tot  | counter | node_id,node_type            |
-| `livepeer_suggested_gas_price`      | Suggested gas price for winning ticket redemption  | gwei | gauge   | node_id,node_type            |
-| `livepeer_min_gas_price`            | Minimum gas price to use for gas price suggestions | gwei | gauge   | node_id,node_type            |
-| `livepeer_max_gas_price`            | Maximum gas price to use for gas price suggestions | gwei | gauge   | node_id,node_type            |
-| `livepeer_transcoding_price`        | Transcoding price per pixel                        | wei  | gauge   | node_id,node_type            |
+| Name                                | Description                                        | Unit | Type    | Tags                           |
+| ----------------------------------- | -------------------------------------------------- | ---- | ------- | ------------------------------ |
+| `livepeer_ticket_value_recv`        | Ticket value received                              | gwei | counter | node_id, node_type             |
+| `livepeer_tickets_recv`             | Tickets received                                   | tot  | counter | node_id, node_type             |
+| `livepeer_payment_recv_errors`      | Errors when receiving payments                     | tot  | counter | error_code, node_id, node_type |
+| `livepeer_winning_tickets_recv`     | Winning tickets received                           | tot  | counter | node_id, node_type             |
+| `livepeer_value_redeemed`           | Winning ticket value redeemed                      | gwei | counter | node_id, node_type             |
+| `livepeer_ticket_redemption_errors` | Errors when redeeming tickets                      | tot  | counter | node_id, node_type             |
+| `livepeer_suggested_gas_price`      | Suggested gas price for winning ticket redemption  | gwei | gauge   | node_id, node_type             |
+| `livepeer_min_gas_price`            | Minimum gas price to use for gas price suggestions | gwei | gauge   | node_id, node_type             |
+| `livepeer_max_gas_price`            | Maximum gas price to use for gas price suggestions | gwei | gauge   | node_id, node_type             |
+| `livepeer_transcoding_price`        | Transcoding price per pixel                        | wei  | gauge   | node_id, node_type             |
 
 ### Pixel accounting
 
-| Name                            | Description              | Unit       | Type    | Tags              |
-| ------------------------------- | ------------------------ | ---------- | ------- | ----------------- |
-| `livepeer_mil_pixels_processed` | Million pixels processed | mil pixels | counter | node_id,node_type |
+| Name                            | Description              | Unit       | Type    | Tags               |
+| ------------------------------- | ------------------------ | ---------- | ------- | ------------------ |
+| `livepeer_mil_pixels_processed` | Million pixels processed | mil pixels | counter | node_id, node_type |
 
 ### Fast verification
 
-| Name                                                        | Description                                                                                                             | Unit | Type    | Tags              |
-| ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ---- | ------- | ----------------- |
-| `livepeer_fast_verification_done`                           | Number of fast verifications done                                                                                       | tot  | counter | node_id,node_type |
-| `livepeer_fast_verification_failed`                         | Number of fast verifications failed                                                                                     | tot  | counter | node_id,node_type |
-| `livepeer_fast_verification_enabled_current_sessions_total` | Number of currently transcoded streams that have fast verification enabled                                              | tot  | gauge   | node_id,node_type |
-| `livepeer_fast_verification_using_current_sessions_total`   | Number of currently transcoded streams that have fast verification enabled and that are using an untrusted orchestrator | tot  | gauge   | node_id,node_type |
+| Name                                                        | Description                                                                                                             | Unit | Type    | Tags               |
+| ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ---- | ------- | ------------------ |
+| `livepeer_fast_verification_done`                           | Number of fast verifications done                                                                                       | tot  | counter | node_id, node_type |
+| `livepeer_fast_verification_failed`                         | Number of fast verifications failed                                                                                     | tot  | counter | node_id, node_type |
+| `livepeer_fast_verification_enabled_current_sessions_total` | Number of currently transcoded streams that have fast verification enabled                                              | tot  | gauge   | node_id, node_type |
+| `livepeer_fast_verification_using_current_sessions_total`   | Number of currently transcoded streams that have fast verification enabled and that are using an untrusted orchestrator | tot  | gauge   | node_id, node_type |
 
 ## Golang metrics
 

--- a/docs/video-miners/reference/metrics.md
+++ b/docs/video-miners/reference/metrics.md
@@ -11,8 +11,9 @@ Livepeer exposes a number of metrics via the Prometheus exporter. This page docu
 
 ### General
 
-| Name                                                     | Description                                                                                                      | Type |
+| Name                                                     | Description                                                                                                      | Unit |
 | -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | ---- |
+| `livepeer_versions`                                      | Version information.                                                                                             | Num  |
 | `livepeer_segment_source_appeared_total`                 | SegmentSourceAppeared                                                                                            | tot  |
 | `livepeer_segment_source_emerged_total`                  | SegmentEmerged                                                                                                   | tot  |
 | `livepeer_segment_source_emerged_unprocessed_total`      | SegmentEmerged, counted by number of transcode profiles                                                          | tot  |
@@ -61,7 +62,7 @@ Livepeer exposes a number of metrics via the Prometheus exporter. This page docu
 
 ### Sending payments
 
-| Name                             | Description                                        | Type |
+| Name                             | Description                                        | Unit |
 | -------------------------------- | -------------------------------------------------- | ---- |
 | `livepeer_ticket_value_sent`     | TicketValueSent                                    | gwei |
 | `livepeer_tickets_sent`          | TicketsSent                                        | tot  |
@@ -72,7 +73,7 @@ Livepeer exposes a number of metrics via the Prometheus exporter. This page docu
 
 ### Receiving payments
 
-| Name                                | Description           | Type |
+| Name                                | Description           | Unit |
 | ----------------------------------- | --------------------- | ---- |
 | `livepeer_ticket_value_recv`        | TicketValueRecv       | gwei |
 | `livepeer_tickets_recv`             | TicketsRecv           | tot  |
@@ -87,16 +88,48 @@ Livepeer exposes a number of metrics via the Prometheus exporter. This page docu
 
 ### Pixel accounting
 
-| Name                            | Description        | Type       |
+| Name                            | Description        | Unit       |
 | ------------------------------- | ------------------ | ---------- |
 | `livepeer_mil_pixels_processed` | MilPixelsProcessed | mil pixels |
 
 ### Fast verification
 
-| Name                                                        | Description                                                                                                             | Type |
+| Name                                                        | Description                                                                                                             | Unit |
 | ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ---- |
 | `livepeer_fast_verification_done`                           | FastVerificationDone                                                                                                    | tot  |
 | `livepeer_fast_verification_failed`                         | FastVerificationFailed                                                                                                  | tot  |
 | `livepeer_fast_verification_enabled_current_sessions_total` | Number of currently transcoded streams that have fast verification enabled                                              | tot  |
 | `livepeer_fast_verification_using_current_sessions_total`   | Number of currently transcoded streams that have fast verification enabled and that are using an untrusted orchestrator | tot  |
 
+## Golang metrics
+
+| Name                               | Description                                                                                 |
+| ---------------------------------- | ------------------------------------------------------------------------------------------- |
+| `go_gc_duration_seconds`           | A summary of the pause duration of garbage collection cycles.                               |
+| `go_goroutines`                    | Number of goroutines that currently exist.                                                  |
+| `go_info`                          | Information about the Go environment.                                                       |
+| `go_memstats_alloc_bytes`          | Number of bytes allocated and still in use.                                                 |
+| `go_memstats_alloc_bytes_total`    | Total number of bytes allocated, even if freed.                                             |
+| `go_memstats_buck_hash_sys_bytes`  | Number of bytes used by the profiling bucket hash table.                                    |
+| `go_memstats_frees_total`          | Total number of frees.                                                                      |
+| `go_memstats_gc_cpu_fraction`      | The fraction of this program's available CPU time used by the GC since the program started. |
+| `go_memstats_gc_sys_bytes`         | Number of bytes used for garbage collection system metadata.                                |
+| `go_memstats_heap_alloc_bytes`     | Number of heap bytes allocated and still in use.                                            |
+| `go_memstats_heap_idle_bytes`      | Number of heap bytes waiting to be used.                                                    |
+| `go_memstats_heap_inuse_bytes`     | Number of heap bytes that are in use.                                                       |
+| `go_memstats_heap_objects`         | Number of allocated objects.                                                                |
+| `go_memstats_heap_released_bytes`  | Number of heap bytes released to OS.                                                        |
+| `go_memstats_heap_sys_bytes`       | Number of heap bytes obtained from system.                                                  |
+| `go_memstats_last_gc_time_seconds` | Number of seconds since 1970 of last garbage collection.                                    |
+| `go_memstats_lookups_total`        | Total number of pointer lookups.                                                            |
+| `go_memstats_mallocs_total`        | Total number of mallocs.                                                                    |
+| `go_memstats_mcache_inuse_bytes`   | Number of bytes in use by mcache structures.                                                |
+| `go_memstats_mcache_sys_bytes`     | Number of bytes used for mcache structures obtained from system.                            |
+| `go_memstats_mspan_inuse_bytes`    | Number of bytes in use by mspan structures.                                                 |
+| `go_memstats_mspan_sys_bytes`      | Number of bytes used for mspan structures obtained from system.                             |
+| `go_memstats_next_gc_bytes`        | Number of heap bytes when next garbage collection will take place.                          |
+| `go_memstats_other_sys_bytes`      | Number of bytes used for other system allocations.                                          |
+| `go_memstats_stack_inuse_bytes`    | Number of bytes in use by the stack allocator.                                              |
+| `go_memstats_stack_sys_bytes`      | Number of bytes obtained from system for stack allocator.                                   |
+| `go_memstats_sys_bytes`            | Number of bytes obtained from system.                                                       |
+| `go_threads`                       | Number of OS threads created.                                                               |

--- a/docs/video-miners/reference/metrics.md
+++ b/docs/video-miners/reference/metrics.md
@@ -11,125 +11,92 @@ Livepeer exposes a number of metrics via the Prometheus exporter. This page docu
 
 ### General
 
-| Name                                                     | Description                                                                                                      | Unit | Type      | Tags                                                  |
-| -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | ---- | --------- | ----------------------------------------------------- |
-| `livepeer_versions`                                      | Versions used by LivePeer node.                                                                                  | Num  | gauge     | compiler, goos, goversion, livepeerversion, node_type |
-| `livepeer_segment_source_appeared_total`                 | SegmentSourceAppeared                                                                                            | tot  | counter   | node_id, node_type, profile, seg_type                 |
-| `livepeer_segment_source_emerged_total`                  | SegmentEmerged                                                                                                   | tot  | counter   | node_id, node_type                                    |
-| `livepeer_segment_source_emerged_unprocessed_total`      | Raw number of segments emerged from segmenter.                                                                   | tot  | counter   | node_id, node_type                                    |
-| `livepeer_segment_source_uploaded_total`                 | SegmentUploaded                                                                                                  | tot  | counter   | node_id, node_type, orchestrator_uri                  |
-| `livepeer_segment_source_upload_failed_total`            | SegmentUploadedFailed                                                                                            | tot  | counter   | error_code, node_id, node_type, orchestrator_uri      |
-| `livepeer_segment_transcoded_downloaded_total`           | SegmentDownloaded                                                                                                | tot  | counter   | node_id, node_type                                    |
-| `livepeer_segment_transcoded_total`                      | SegmentTranscoded                                                                                                | tot  | counter   | node_id, node_type, profiles, trusted, verified       |
-| `livepeer_segment_transcoded_unprocessed_total`          | Raw number of segments successfully transcoded.                                                                  | tot  | counter   | node_id, node_type, profiles                          |
-| `livepeer_segment_transcode_failed_total`                | SegmentTranscodeFailed                                                                                           | tot  | counter   | error_code, node_id, node_type                        |
-| `livepeer_segment_transcoded_appeared_total`             | SegmentTranscodedAppeared                                                                                        | tot  | counter   | node_id, node_type, profile, seg_type                 |
-| `livepeer_segment_transcoded_all_appeared_total`         | SegmentTranscodedAllAppeared                                                                                     | tot  | counter   | node_id, node_type, profiles                          |
-| `livepeer_broadcast_client_start_failed_total`           | StartBroadcastClientFailed                                                                                       | tot  | counter   | node_id, node_type                                    |
-| `livepeer_stream_create_failed_total`                    | StreamCreateFailed                                                                                               | tot  | counter   | node_id, node_type                                    |
-| `livepeer_stream_created_total`                          | StreamCreated                                                                                                    | tot  | counter   | node_id, node_type                                    |
-| `livepeer_stream_started_total`                          | StreamStarted                                                                                                    | tot  | counter   | node_id, node_type                                    |
-| `livepeer_stream_ended_total`                            | StreamEnded                                                                                                      | tot  | counter   | node_id, node_type                                    |
-| `livepeer_max_sessions_total`                            | Max Sessions                                                                                                     | tot  | gauge     | node_id, node_type                                    |
-| `livepeer_current_sessions_total`                        | Number of streams currently transcoding                                                                          | tot  | gauge     | node_id, node_type                                    |
-| `livepeer_discovery_errors_total`                        | Number of discover errors                                                                                        | tot  | counter   | error_code, node_id, node_type, orchestrator_uri      |
-| `livepeer_transcode_retried`                             | Number of times segment transcode was retried                                                                    | tot  | counter   | node_id, node_type, try                               |
-| `livepeer_transcoders_number`                            | Number of transcoders currently connected to orchestrator                                                        | tot  | gauge     | node_id, node_type                                    |
-| `livepeer_transcoders_capacity`                          | Total advertised capacity of transcoders currently connected to orchestrator                                     | tot  | gauge     | node_id, node_type                                    |
-| `livepeer_transcoders_load`                              | Total load of transcoders currently connected to orchestrator                                                    | tot  | gauge     | node_id, node_type                                    |
-| `livepeer_success_rate`                                  | Number of transcoded segments divided on number of source segments                                               | per  | gauge     | node_id, node_type                                    |
-| `livepeer_success_rate_per_stream`                       | Number of transcoded segments divided on number of source segments, per stream                                   | per  | gauge     | node_id, node_type                                    |
-| `livepeer_transcode_time_seconds`                        | TranscodeTime, seconds                                                                                           | sec  | histogram | node_id, node_type, profiles, trusted, verified       |
-| `livepeer_transcode_latency_seconds`                     | Transcoding latency, from source segment emerged from segmenter till transcoded segment apeeared in manifest     | sec  | histogram | node_id, node_type, profile                           |
-| `livepeer_transcode_overall_latency_seconds`             | Transcoding latency, from source segment emerged from segmenter till all transcoded segment apeeared in manifest | sec  | histogram | node_id, node_type, profiles                          |
-| `livepeer_upload_time_seconds`                           | UploadTime, seconds                                                                                              | sec  | histogram | node_id, node_type, orchestrator_uri                  |
-| `livepeer_download_time_seconds`                         | Download time                                                                                                    | sec  | histogram | node_id, node_type                                    |
-| `livepeer_auth_webhook_time_milliseconds`                | Authentication webhook execution time, milliseconds                                                              | ms   | histogram | node_id, node_type                                    |
-| `livepeer_source_segment_duration_seconds`               | Source segment's duration                                                                                        | sec  | histogram | node_id, node_type                                    |
-| `livepeer_http_client_timeout_1`                         | Number of times HTTP connection was dropped before transcoding complete                                          | tot  | counter   | node_id, node_type                                    |
-| `livepeer_http_client_timeout_2`                         | Number of times HTTP connection was dropped before transcoded segments was sent back to client                   | tot  | counter   | node_id, node_type                                    |
-| `livepeer_http_client_segment_transcoded_realtime_ratio` | Ratio of source segment duration / transcode time as measured on HTTP client                                     | rat  | histogram | node_id, node_type                                    |
-| `livepeer_http_client_segment_transcoded_realtime_3x`    | Number of segment transcoded 3x faster than realtime                                                             | tot  | counter   | node_id, node_type                                    |
-| `livepeer_http_client_segment_transcoded_realtime_2x`    | Number of segment transcoded 2x faster than realtime                                                             | tot  | counter   | node_id, node_type                                    |
-| `livepeer_http_client_segment_transcoded_realtime_1x`    | Number of segment transcoded 1x faster than realtime                                                             | tot  | counter   | node_id, node_type                                    |
-| `livepeer_http_client_segment_transcoded_realtime_half`  | Number of segment transcoded no more than two times slower than realtime                                         | tot  | counter   | node_id, node_type                                    |
-| `livepeer_http_client_segment_transcoded_realtime_slow`  | Number of segment transcoded more than two times slower than realtime                                            | tot  | counter   | node_id, node_type                                    |
-| `livepeer_transcode_score`                               | Ratio of source segment duration vs. transcode time                                                              | rat  | histogram | node_id, node_type, profiles, trusted, verified       |
-| `livepeer_recording_save_latency`                        | How long it takes to save segment to the OS                                                                      | sec  | histogram | node_id, node_type                                    |
-| `livepeer_recording_save_errors`                         | Number of errors during save to the recording OS                                                                 | tot  | counter   | node_id, node_type                                    |
-| `livepeer_recording_saved_segments`                      | Number of segments saved to the recording OS                                                                     | tot  | counter   | node_id, node_type                                    |
-| `livepeer_orchestrator_swaps`                            | Number of orchestrator swaps mid-stream                                                                          | tot  | counter   | node_id, node_type                                    |
+| Name                                                     | Description                                                                                                      |
+| -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `livepeer_versions`                                      | Versions used by LivePeer node.                                                                                  |
+| `livepeer_segment_source_appeared_total`                 | SegmentSourceAppeared                                                                                            |
+| `livepeer_segment_source_emerged_total`                  | SegmentEmerged                                                                                                   |
+| `livepeer_segment_source_emerged_unprocessed_total`      | Raw number of segments emerged from segmenter.                                                                   |
+| `livepeer_segment_source_uploaded_total`                 | SegmentUploaded                                                                                                  |
+| `livepeer_segment_source_upload_failed_total`            | SegmentUploadedFailed                                                                                            |
+| `livepeer_segment_transcoded_downloaded_total`           | SegmentDownloaded                                                                                                |
+| `livepeer_segment_transcoded_total`                      | SegmentTranscoded                                                                                                |
+| `livepeer_segment_transcoded_unprocessed_total`          | Raw number of segments successfully transcoded.                                                                  |
+| `livepeer_segment_transcode_failed_total`                | SegmentTranscodeFailed                                                                                           |
+| `livepeer_segment_transcoded_appeared_total`             | SegmentTranscodedAppeared                                                                                        |
+| `livepeer_segment_transcoded_all_appeared_total`         | SegmentTranscodedAllAppeared                                                                                     |
+| `livepeer_broadcast_client_start_failed_total`           | StartBroadcastClientFailed                                                                                       |
+| `livepeer_stream_create_failed_total`                    | StreamCreateFailed                                                                                               |
+| `livepeer_stream_created_total`                          | StreamCreated                                                                                                    |
+| `livepeer_stream_started_total`                          | StreamStarted                                                                                                    |
+| `livepeer_stream_ended_total`                            | StreamEnded                                                                                                      |
+| `livepeer_max_sessions_total`                            | Max Sessions                                                                                                     |
+| `livepeer_current_sessions_total`                        | Number of streams currently transcoding                                                                          |
+| `livepeer_discovery_errors_total`                        | Number of discover errors                                                                                        |
+| `livepeer_transcode_retried`                             | Number of times segment transcode was retried                                                                    |
+| `livepeer_transcoders_number`                            | Number of transcoders currently connected to orchestrator                                                        |
+| `livepeer_transcoders_capacity`                          | Total advertised capacity of transcoders currently connected to orchestrator                                     |
+| `livepeer_transcoders_load`                              | Total load of transcoders currently connected to orchestrator                                                    |
+| `livepeer_success_rate`                                  | Number of transcoded segments divided on number of source segments                                               |
+| `livepeer_success_rate_per_stream`                       | Number of transcoded segments divided on number of source segments, per stream                                   |
+| `livepeer_transcode_time_seconds`                        | TranscodeTime, seconds                                                                                           |
+| `livepeer_transcode_latency_seconds`                     | Transcoding latency, from source segment emerged from segmenter till transcoded segment apeeared in manifest     |
+| `livepeer_transcode_overall_latency_seconds`             | Transcoding latency, from source segment emerged from segmenter till all transcoded segment apeeared in manifest |
+| `livepeer_upload_time_seconds`                           | UploadTime, seconds                                                                                              |
+| `livepeer_download_time_seconds`                         | Download time                                                                                                    |
+| `livepeer_auth_webhook_time_milliseconds`                | Authentication webhook execution time, milliseconds                                                              |
+| `livepeer_source_segment_duration_seconds`               | Source segment's duration                                                                                        |
+| `livepeer_http_client_timeout_1`                         | Number of times HTTP connection was dropped before transcoding complete                                          |
+| `livepeer_http_client_timeout_2`                         | Number of times HTTP connection was dropped before transcoded segments was sent back to client                   |
+| `livepeer_http_client_segment_transcoded_realtime_ratio` | Ratio of source segment duration / transcode time as measured on HTTP client                                     |
+| `livepeer_http_client_segment_transcoded_realtime_3x`    | Number of segment transcoded 3x faster than realtime                                                             |
+| `livepeer_http_client_segment_transcoded_realtime_2x`    | Number of segment transcoded 2x faster than realtime                                                             |
+| `livepeer_http_client_segment_transcoded_realtime_1x`    | Number of segment transcoded 1x faster than realtime                                                             |
+| `livepeer_http_client_segment_transcoded_realtime_half`  | Number of segment transcoded no more than two times slower than realtime                                         |
+| `livepeer_http_client_segment_transcoded_realtime_slow`  | Number of segment transcoded more than two times slower than realtime                                            |
+| `livepeer_transcode_score`                               | Ratio of source segment duration vs. transcode time                                                              |
+| `livepeer_recording_save_latency`                        | How long it takes to save segment to the OS                                                                      |
+| `livepeer_recording_save_errors`                         | Number of errors during save to the recording OS                                                                 |
+| `livepeer_recording_saved_segments`                      | Number of segments saved to the recording OS                                                                     |
+| `livepeer_orchestrator_swaps`                            | Number of orchestrator swaps mid-stream                                                                          |
 
 ### Sending payments
 
-| Name                             | Description                                        | Unit | Type    | Tags               |
-| -------------------------------- | -------------------------------------------------- | ---- | ------- | ------------------ |
-| `livepeer_ticket_value_sent`     | Ticket value sent                                  | gwei | counter | node_id, node_type |
-| `livepeer_tickets_sent`          | Tickets sent                                       | tot  | counter | node_id, node_type |
-| `livepeer_payment_create_errors` | Errors when creating payments                      | tot  | counter | node_id, node_type |
-| `livepeer_broadcaster_deposit`   | Current remaining deposit for the broadcaster node | gwei | gauge   | node_id, node_type |
-| `livepeer_broadcaster_reserve`   | Current remaining reserve for the broadcaster node | gwei | gauge   | node_id, node_type |
-| `livepeer_max_transcoding_price` | Maximum price per pixel to pay for transcoding     | wei  | gauge   | node_id, node_type |
+| Name                             | Description                                        |
+| -------------------------------- | -------------------------------------------------- |
+| `livepeer_ticket_value_sent`     | Ticket value sent                                  |
+| `livepeer_tickets_sent`          | Tickets sent                                       |
+| `livepeer_payment_create_errors` | Errors when creating payments                      |
+| `livepeer_broadcaster_deposit`   | Current remaining deposit for the broadcaster node |
+| `livepeer_broadcaster_reserve`   | Current remaining reserve for the broadcaster node |
+| `livepeer_max_transcoding_price` | Maximum price per pixel to pay for transcoding     |
 
 ### Receiving payments
 
-| Name                                | Description                                        | Unit | Type    | Tags                           |
-| ----------------------------------- | -------------------------------------------------- | ---- | ------- | ------------------------------ |
-| `livepeer_ticket_value_recv`        | Ticket value received                              | gwei | counter | node_id, node_type             |
-| `livepeer_tickets_recv`             | Tickets received                                   | tot  | counter | node_id, node_type             |
-| `livepeer_payment_recv_errors`      | Errors when receiving payments                     | tot  | counter | error_code, node_id, node_type |
-| `livepeer_winning_tickets_recv`     | Winning tickets received                           | tot  | counter | node_id, node_type             |
-| `livepeer_value_redeemed`           | Winning ticket value redeemed                      | gwei | counter | node_id, node_type             |
-| `livepeer_ticket_redemption_errors` | Errors when redeeming tickets                      | tot  | counter | node_id, node_type             |
-| `livepeer_suggested_gas_price`      | Suggested gas price for winning ticket redemption  | gwei | gauge   | node_id, node_type             |
-| `livepeer_min_gas_price`            | Minimum gas price to use for gas price suggestions | gwei | gauge   | node_id, node_type             |
-| `livepeer_max_gas_price`            | Maximum gas price to use for gas price suggestions | gwei | gauge   | node_id, node_type             |
-| `livepeer_transcoding_price`        | Transcoding price per pixel                        | wei  | gauge   | node_id, node_type             |
+| Name                                | Description                                        |
+| ----------------------------------- | -------------------------------------------------- |
+| `livepeer_ticket_value_recv`        | Ticket value received                              |
+| `livepeer_tickets_recv`             | Tickets received                                   |
+| `livepeer_payment_recv_errors`      | Errors when receiving payments                     |
+| `livepeer_winning_tickets_recv`     | Winning tickets received                           |
+| `livepeer_value_redeemed`           | Winning ticket value redeemed                      |
+| `livepeer_ticket_redemption_errors` | Errors when redeeming tickets                      |
+| `livepeer_suggested_gas_price`      | Suggested gas price for winning ticket redemption  |
+| `livepeer_min_gas_price`            | Minimum gas price to use for gas price suggestions |
+| `livepeer_max_gas_price`            | Maximum gas price to use for gas price suggestions |
+| `livepeer_transcoding_price`        | Transcoding price per pixel                        |
 
 ### Pixel accounting
 
-| Name                            | Description              | Unit       | Type    | Tags               |
-| ------------------------------- | ------------------------ | ---------- | ------- | ------------------ |
-| `livepeer_mil_pixels_processed` | Million pixels processed | mil pixels | counter | node_id, node_type |
+| Name                            | Description              |
+| ------------------------------- | ------------------------ |
+| `livepeer_mil_pixels_processed` | Million pixels processed |
 
 ### Fast verification
 
-| Name                                                        | Description                                                                                                             | Unit | Type    | Tags               |
-| ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ---- | ------- | ------------------ |
-| `livepeer_fast_verification_done`                           | Number of fast verifications done                                                                                       | tot  | counter | node_id, node_type |
-| `livepeer_fast_verification_failed`                         | Number of fast verifications failed                                                                                     | tot  | counter | node_id, node_type |
-| `livepeer_fast_verification_enabled_current_sessions_total` | Number of currently transcoded streams that have fast verification enabled                                              | tot  | gauge   | node_id, node_type |
-| `livepeer_fast_verification_using_current_sessions_total`   | Number of currently transcoded streams that have fast verification enabled and that are using an untrusted orchestrator | tot  | gauge   | node_id, node_type |
-
-## Golang metrics
-
-| Name                               | Description                                                                                 | Type    |
-| ---------------------------------- | ------------------------------------------------------------------------------------------- | ------- |
-| `go_gc_duration_seconds`           | A summary of the pause duration of garbage collection cycles.                               | summary |
-| `go_goroutines`                    | Number of goroutines that currently exist.                                                  | gauge   |
-| `go_info`                          | Information about the Go environment.                                                       | gauge   |
-| `go_memstats_alloc_bytes`          | Number of bytes allocated and still in use.                                                 | gauge   |
-| `go_memstats_alloc_bytes_total`    | Total number of bytes allocated, even if freed.                                             | counter |
-| `go_memstats_buck_hash_sys_bytes`  | Number of bytes used by the profiling bucket hash table.                                    | gauge   |
-| `go_memstats_frees_total`          | Total number of frees.                                                                      | counter |
-| `go_memstats_gc_cpu_fraction`      | The fraction of this program's available CPU time used by the GC since the program started. | gauge   |
-| `go_memstats_gc_sys_bytes`         | Number of bytes used for garbage collection system metadata.                                | gauge   |
-| `go_memstats_heap_alloc_bytes`     | Number of heap bytes allocated and still in use.                                            | gauge   |
-| `go_memstats_heap_idle_bytes`      | Number of heap bytes waiting to be used.                                                    | gauge   |
-| `go_memstats_heap_inuse_bytes`     | Number of heap bytes that are in use.                                                       | gauge   |
-| `go_memstats_heap_objects`         | Number of allocated objects.                                                                | gauge   |
-| `go_memstats_heap_released_bytes`  | Number of heap bytes released to OS.                                                        | gauge   |
-| `go_memstats_heap_sys_bytes`       | Number of heap bytes obtained from system.                                                  | gauge   |
-| `go_memstats_last_gc_time_seconds` | Number of seconds since 1970 of last garbage collection.                                    | gauge   |
-| `go_memstats_lookups_total`        | Total number of pointer lookups.                                                            | counter |
-| `go_memstats_mallocs_total`        | Total number of mallocs.                                                                    | counter |
-| `go_memstats_mcache_inuse_bytes`   | Number of bytes in use by mcache structures.                                                | gauge   |
-| `go_memstats_mcache_sys_bytes`     | Number of bytes used for mcache structures obtained from system.                            | gauge   |
-| `go_memstats_mspan_inuse_bytes`    | Number of bytes in use by mspan structures.                                                 | gauge   |
-| `go_memstats_mspan_sys_bytes`      | Number of bytes used for mspan structures obtained from system.                             | gauge   |
-| `go_memstats_next_gc_bytes`        | Number of heap bytes when next garbage collection will take place.                          | gauge   |
-| `go_memstats_other_sys_bytes`      | Number of bytes used for other system allocations.                                          | gauge   |
-| `go_memstats_stack_inuse_bytes`    | Number of bytes in use by the stack allocator.                                              | gauge   |
-| `go_memstats_stack_sys_bytes`      | Number of bytes obtained from system for stack allocator.                                   | gauge   |
-| `go_memstats_sys_bytes`            | Number of bytes obtained from system.                                                       | gauge   |
-| `go_threads`                       | Number of OS threads created.                                                               | gauge   |
+| Name                                                        | Description                                                                                                             |
+| ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `livepeer_fast_verification_done`                           | Number of fast verifications done                                                                                       |
+| `livepeer_fast_verification_failed`                         | Number of fast verifications failed                                                                                     |
+| `livepeer_fast_verification_enabled_current_sessions_total` | Number of currently transcoded streams that have fast verification enabled                                              |
+| `livepeer_fast_verification_using_current_sessions_total`   | Number of currently transcoded streams that have fast verification enabled and that are using an untrusted orchestrator |

--- a/docs/video-miners/reference/metrics.md
+++ b/docs/video-miners/reference/metrics.md
@@ -11,92 +11,87 @@ Livepeer exposes a number of metrics via the Prometheus exporter. This page docu
 
 ### General
 
-| Name                                                     | Description                                                                                                      |
-| -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| `livepeer_versions`                                      | Versions used by LivePeer node.                                                                                  |
-| `livepeer_segment_source_appeared_total`                 | SegmentSourceAppeared                                                                                            |
-| `livepeer_segment_source_emerged_total`                  | SegmentEmerged                                                                                                   |
-| `livepeer_segment_source_emerged_unprocessed_total`      | Raw number of segments emerged from segmenter.                                                                   |
-| `livepeer_segment_source_uploaded_total`                 | SegmentUploaded                                                                                                  |
-| `livepeer_segment_source_upload_failed_total`            | SegmentUploadedFailed                                                                                            |
-| `livepeer_segment_transcoded_downloaded_total`           | SegmentDownloaded                                                                                                |
-| `livepeer_segment_transcoded_total`                      | SegmentTranscoded                                                                                                |
-| `livepeer_segment_transcoded_unprocessed_total`          | Raw number of segments successfully transcoded.                                                                  |
-| `livepeer_segment_transcode_failed_total`                | SegmentTranscodeFailed                                                                                           |
-| `livepeer_segment_transcoded_appeared_total`             | SegmentTranscodedAppeared                                                                                        |
-| `livepeer_segment_transcoded_all_appeared_total`         | SegmentTranscodedAllAppeared                                                                                     |
-| `livepeer_broadcast_client_start_failed_total`           | StartBroadcastClientFailed                                                                                       |
-| `livepeer_stream_create_failed_total`                    | StreamCreateFailed                                                                                               |
-| `livepeer_stream_created_total`                          | StreamCreated                                                                                                    |
-| `livepeer_stream_started_total`                          | StreamStarted                                                                                                    |
-| `livepeer_stream_ended_total`                            | StreamEnded                                                                                                      |
-| `livepeer_max_sessions_total`                            | Max Sessions                                                                                                     |
-| `livepeer_current_sessions_total`                        | Number of streams currently transcoding                                                                          |
-| `livepeer_discovery_errors_total`                        | Number of discover errors                                                                                        |
-| `livepeer_transcode_retried`                             | Number of times segment transcode was retried                                                                    |
-| `livepeer_transcoders_number`                            | Number of transcoders currently connected to orchestrator                                                        |
-| `livepeer_transcoders_capacity`                          | Total advertised capacity of transcoders currently connected to orchestrator                                     |
-| `livepeer_transcoders_load`                              | Total load of transcoders currently connected to orchestrator                                                    |
-| `livepeer_success_rate`                                  | Number of transcoded segments divided on number of source segments                                               |
-| `livepeer_success_rate_per_stream`                       | Number of transcoded segments divided on number of source segments, per stream                                   |
-| `livepeer_transcode_time_seconds`                        | TranscodeTime, seconds                                                                                           |
-| `livepeer_transcode_latency_seconds`                     | Transcoding latency, from source segment emerged from segmenter till transcoded segment apeeared in manifest     |
-| `livepeer_transcode_overall_latency_seconds`             | Transcoding latency, from source segment emerged from segmenter till all transcoded segment apeeared in manifest |
-| `livepeer_upload_time_seconds`                           | UploadTime, seconds                                                                                              |
-| `livepeer_download_time_seconds`                         | Download time                                                                                                    |
-| `livepeer_auth_webhook_time_milliseconds`                | Authentication webhook execution time, milliseconds                                                              |
-| `livepeer_source_segment_duration_seconds`               | Source segment's duration                                                                                        |
-| `livepeer_http_client_timeout_1`                         | Number of times HTTP connection was dropped before transcoding complete                                          |
-| `livepeer_http_client_timeout_2`                         | Number of times HTTP connection was dropped before transcoded segments was sent back to client                   |
-| `livepeer_http_client_segment_transcoded_realtime_ratio` | Ratio of source segment duration / transcode time as measured on HTTP client                                     |
-| `livepeer_http_client_segment_transcoded_realtime_3x`    | Number of segment transcoded 3x faster than realtime                                                             |
-| `livepeer_http_client_segment_transcoded_realtime_2x`    | Number of segment transcoded 2x faster than realtime                                                             |
-| `livepeer_http_client_segment_transcoded_realtime_1x`    | Number of segment transcoded 1x faster than realtime                                                             |
-| `livepeer_http_client_segment_transcoded_realtime_half`  | Number of segment transcoded no more than two times slower than realtime                                         |
-| `livepeer_http_client_segment_transcoded_realtime_slow`  | Number of segment transcoded more than two times slower than realtime                                            |
-| `livepeer_transcode_score`                               | Ratio of source segment duration vs. transcode time                                                              |
-| `livepeer_recording_save_latency`                        | How long it takes to save segment to the OS                                                                      |
-| `livepeer_recording_save_errors`                         | Number of errors during save to the recording OS                                                                 |
-| `livepeer_recording_saved_segments`                      | Number of segments saved to the recording OS                                                                     |
-| `livepeer_orchestrator_swaps`                            | Number of orchestrator swaps mid-stream                                                                          |
+| Name                                                     | Description                                                                                                      | Node Type                                       |
+| -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| `livepeer_versions`                                      | Versions used by LivePeer node.                                                                                  | Broadcaster, Orchestrator, Transcoder, Redeemer |
+| `livepeer_segment_source_appeared_total`                 | SegmentSourceAppeared                                                                                            | Broadcaster                                     |
+| `livepeer_segment_source_emerged_total`                  | SegmentEmerged                                                                                                   | Broadcaster                                     |
+| `livepeer_segment_source_emerged_unprocessed_total`      | Raw number of segments emerged from segmenter.                                                                   | Broadcaster, Orchestrator                       |
+| `livepeer_segment_source_uploaded_total`                 | SegmentUploaded                                                                                                  | Broadcaster, Orchestrator, Transcoder           |
+| `livepeer_segment_source_upload_failed_total`            | SegmentUploadedFailed                                                                                            | Broadcaster                                     |
+| `livepeer_segment_transcoded_downloaded_total`           | SegmentDownloaded                                                                                                | Broadcaster, Orchestrator                       |
+| `livepeer_segment_transcoded_total`                      | SegmentTranscoded                                                                                                | Broadcaster, Orchestrator                       |
+| `livepeer_segment_transcoded_unprocessed_total`          | Raw number of segments successfully transcoded.                                                                  | Broadcaster                                     |
+| `livepeer_segment_transcode_failed_total`                | SegmentTranscodeFailed                                                                                           | Broadcaster                                     |
+| `livepeer_segment_transcoded_all_appeared_total`         | SegmentTranscodedAllAppeared                                                                                     | Broadcaster                                     |
+| `livepeer_stream_created_total`                          | StreamCreated                                                                                                    | Broadcaster                                     |
+| `livepeer_stream_started_total`                          | StreamStarted                                                                                                    | Broadcaster                                     |
+| `livepeer_stream_ended_total`                            | StreamEnded                                                                                                      | Broadcaster                                     |
+| `livepeer_max_sessions_total`                            | Max Sessions                                                                                                     | Broadcaster, Orchestrator, Transcoder, Redeemer |
+| `livepeer_current_sessions_total`                        | Number of streams currently transcoding                                                                          | Broadcaster, Orchestrator                       |
+| `livepeer_discovery_errors_total`                        | Number of discover errors                                                                                        | Broadcaster                                     |
+| `livepeer_transcode_retried`                             | Number of times segment transcode was retried                                                                    | Broadcaster                                     |
+| `livepeer_transcoders_number`                            | Number of transcoders currently connected to orchestrator                                                        | Broadcaster, Orchestrator, Transcoder, Redeemer |
+| `livepeer_transcoders_capacity`                          | Total advertised capacity of transcoders currently connected to orchestrator                                     | Broadcaster, Orchestrator, Transcoder, Redeemer |
+| `livepeer_transcoders_load`                              | Total load of transcoders currently connected to orchestrator                                                    | Broadcaster, Orchestrator, Transcoder, Redeemer |
+| `livepeer_success_rate`                                  | Number of transcoded segments divided on number of source segments                                               | Broadcaster, Orchestrator, Transcoder, Redeemer |
+| `livepeer_success_rate_per_stream`                       | Number of transcoded segments divided on number of source segments, per stream                                   | Broadcaster                                     |
+| `livepeer_transcode_time_seconds`                        | TranscodeTime, seconds                                                                                           | Broadcaster, Orchestrator                       |
+| `livepeer_transcode_overall_latency_seconds`             | Transcoding latency, from source segment emerged from segmenter till all transcoded segment apeeared in manifest | Broadcaster                                     |
+| `livepeer_upload_time_seconds`                           | UploadTime, seconds                                                                                              | Broadcaster, Orchestrator, Transcoder           |
+| `livepeer_download_time_seconds`                         | Download time                                                                                                    | Broadcaster, Orchestrator                       |
+| `livepeer_auth_webhook_time_milliseconds`                | Authentication webhook execution time, milliseconds                                                              | Broadcaster                                     |
+| `livepeer_source_segment_duration_seconds`               | Source segment's duration                                                                                        | Broadcaster, Orchestrator                       |
+| `livepeer_http_client_timeout_1`                         | Number of times HTTP connection was dropped before transcoding complete                                          | Broadcaster                                     |
+| `livepeer_http_client_timeout_2`                         | Number of times HTTP connection was dropped before transcoded segments was sent back to client                   | Broadcaster                                     |
+| `livepeer_http_client_segment_transcoded_realtime_ratio` | Ratio of source segment duration / transcode time as measured on HTTP client                                     | Broadcaster                                     |
+| `livepeer_http_client_segment_transcoded_realtime_3x`    | Number of segment transcoded 3x faster than realtime                                                             | Broadcaster                                     |
+| `livepeer_http_client_segment_transcoded_realtime_2x`    | Number of segment transcoded 2x faster than realtime                                                             | Broadcaster                                     |
+| `livepeer_http_client_segment_transcoded_realtime_1x`    | Number of segment transcoded 1x faster than realtime                                                             | Broadcaster                                     |
+| `livepeer_http_client_segment_transcoded_realtime_half`  | Number of segment transcoded no more than two times slower than realtime                                         | Broadcaster                                     |
+| `livepeer_http_client_segment_transcoded_realtime_slow`  | Number of segment transcoded more than two times slower than realtime                                            | Broadcaster                                     |
+| `livepeer_transcode_score`                               | Ratio of source segment duration vs. transcode time                                                              | Broadcaster, Orchestrator                       |
+| `livepeer_recording_save_latency`                        | How long it takes to save segment to the OS                                                                      | Broadcaster                                     |
+| `livepeer_recording_save_errors`                         | Number of errors during save to the recording OS                                                                 | Broadcaster                                     |
+| `livepeer_recording_saved_segments`                      | Number of segments saved to the recording OS                                                                     | Broadcaster                                     |
+| `livepeer_orchestrator_swaps`                            | Number of orchestrator swaps mid-stream                                                                          | Broadcaster                                     |
 
 ### Sending payments
 
-| Name                             | Description                                        |
-| -------------------------------- | -------------------------------------------------- |
-| `livepeer_ticket_value_sent`     | Ticket value sent                                  |
-| `livepeer_tickets_sent`          | Tickets sent                                       |
-| `livepeer_payment_create_errors` | Errors when creating payments                      |
-| `livepeer_broadcaster_deposit`   | Current remaining deposit for the broadcaster node |
-| `livepeer_broadcaster_reserve`   | Current remaining reserve for the broadcaster node |
-| `livepeer_max_transcoding_price` | Maximum price per pixel to pay for transcoding     |
+| Name                             | Description                                        | Node Type   |
+| -------------------------------- | -------------------------------------------------- | ----------- |
+| `livepeer_ticket_value_sent`     | Ticket value sent                                  | Broadcaster |
+| `livepeer_tickets_sent`          | Tickets sent                                       | Broadcaster |
+| `livepeer_payment_create_errors` | Errors when creating payments                      | Broadcaster |
+| `livepeer_broadcaster_deposit`   | Current remaining deposit for the broadcaster node | Broadcaster |
+| `livepeer_broadcaster_reserve`   | Current remaining reserve for the broadcaster node | Broadcaster |
 
 ### Receiving payments
 
-| Name                                | Description                                        |
-| ----------------------------------- | -------------------------------------------------- |
-| `livepeer_ticket_value_recv`        | Ticket value received                              |
-| `livepeer_tickets_recv`             | Tickets received                                   |
-| `livepeer_payment_recv_errors`      | Errors when receiving payments                     |
-| `livepeer_winning_tickets_recv`     | Winning tickets received                           |
-| `livepeer_value_redeemed`           | Winning ticket value redeemed                      |
-| `livepeer_ticket_redemption_errors` | Errors when redeeming tickets                      |
-| `livepeer_suggested_gas_price`      | Suggested gas price for winning ticket redemption  |
-| `livepeer_min_gas_price`            | Minimum gas price to use for gas price suggestions |
-| `livepeer_max_gas_price`            | Maximum gas price to use for gas price suggestions |
-| `livepeer_transcoding_price`        | Transcoding price per pixel                        |
+| Name                                | Description                                        | Node Type                           |
+| ----------------------------------- | -------------------------------------------------- | ----------------------------------- |
+| `livepeer_ticket_value_recv`        | Ticket value received                              | Orchestrator                        |
+| `livepeer_tickets_recv`             | Tickets received                                   | Orchestrator                        |
+| `livepeer_payment_recv_errors`      | Errors when receiving payments                     | Orchestrator                        |
+| `livepeer_winning_tickets_recv`     | Winning tickets received                           | Orchestrator                        |
+| `livepeer_value_redeemed`           | Winning ticket value redeemed                      | Orchestrator, Redeemer              |
+| `livepeer_ticket_redemption_errors` | Errors when redeeming tickets                      | Orchestrator, Redeemer              |
+| `livepeer_suggested_gas_price`      | Suggested gas price for winning ticket redemption  | Broadcaster, Orchestrator, Redeemer |
+| `livepeer_min_gas_price`            | Minimum gas price to use for gas price suggestions | Broadcaster, Orchestrator, Redeemer |
+| `livepeer_max_gas_price`            | Maximum gas price to use for gas price suggestions | Broadcaster, Orchestrator, Redeemer |
+| `livepeer_transcoding_price`        | Transcoding price per pixel                        | Orchestrator                        |
 
 ### Pixel accounting
 
-| Name                            | Description              |
-| ------------------------------- | ------------------------ |
-| `livepeer_mil_pixels_processed` | Million pixels processed |
+| Name                            | Description              | Node Type                 |
+| ------------------------------- | ------------------------ | ------------------------- |
+| `livepeer_mil_pixels_processed` | Million pixels processed | Broadcaster, Orchestrator |
 
 ### Fast verification
 
-| Name                                                        | Description                                                                                                             |
-| ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `livepeer_fast_verification_done`                           | Number of fast verifications done                                                                                       |
-| `livepeer_fast_verification_failed`                         | Number of fast verifications failed                                                                                     |
-| `livepeer_fast_verification_enabled_current_sessions_total` | Number of currently transcoded streams that have fast verification enabled                                              |
-| `livepeer_fast_verification_using_current_sessions_total`   | Number of currently transcoded streams that have fast verification enabled and that are using an untrusted orchestrator |
+| Name                                                        | Description                                                                                                             | Node Type   |
+| ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ----------- |
+| `livepeer_fast_verification_done`                           | Number of fast verifications done                                                                                       | Broadcaster |
+| `livepeer_fast_verification_failed`                         | Number of fast verifications failed                                                                                     | Broadcaster |
+| `livepeer_fast_verification_enabled_current_sessions_total` | Number of currently transcoded streams that have fast verification enabled                                              | Broadcaster |
+| `livepeer_fast_verification_using_current_sessions_total`   | Number of currently transcoded streams that have fast verification enabled and that are using an untrusted orchestrator | Broadcaster |

--- a/docs/video-miners/reference/metrics.md
+++ b/docs/video-miners/reference/metrics.md
@@ -7,8 +7,96 @@ sidebar_position: 7
 
 Livepeer exposes a number of metrics via the Prometheus exporter. This page documents all metrics that you can scrape via the `/metrics` endpoint when the [monitoring is enabled](/video-miners/how-to-guides/metrics-monitoring).
 
-## General
+## Livepeer metrics
 
-| Name                     | Description                                                                                                 |
-| ----------------------------- | ------------------ |
-| test metrics | Test Description |
+### General
+
+| Name                                                     | Description                                                                                                      | Type |
+| -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | ---- |
+| `livepeer_segment_source_appeared_total`                 | SegmentSourceAppeared                                                                                            | tot  |
+| `livepeer_segment_source_emerged_total`                  | SegmentEmerged                                                                                                   | tot  |
+| `livepeer_segment_source_emerged_unprocessed_total`      | SegmentEmerged, counted by number of transcode profiles                                                          | tot  |
+| `livepeer_segment_source_uploaded_total`                 | SegmentUploaded                                                                                                  | tot  |
+| `livepeer_segment_source_upload_failed_total`            | SegmentUploadedFailed                                                                                            | tot  |
+| `livepeer_segment_transcoded_downloaded_total`           | SegmentDownloaded                                                                                                | tot  |
+| `livepeer_segment_transcoded_total`                      | SegmentTranscoded                                                                                                | tot  |
+| `livepeer_segment_transcoded_unprocessed_total`          | SegmentTranscodedUnprocessed                                                                                     | tot  |
+| `livepeer_segment_transcode_failed_total`                | SegmentTranscodeFailed                                                                                           | tot  |
+| `livepeer_segment_transcoded_appeared_total`             | SegmentTranscodedAppeared                                                                                        | tot  |
+| `livepeer_segment_transcoded_all_appeared_total`         | SegmentTranscodedAllAppeared                                                                                     | tot  |
+| `livepeer_broadcast_client_start_failed_total`           | StartBroadcastClientFailed                                                                                       | tot  |
+| `livepeer_stream_create_failed_total`                    | StreamCreateFailed                                                                                               | tot  |
+| `livepeer_stream_created_total`                          | StreamCreated                                                                                                    | tot  |
+| `livepeer_stream_started_total`                          | StreamStarted                                                                                                    | tot  |
+| `livepeer_stream_ended_total`                            | StreamEnded                                                                                                      | tot  |
+| `livepeer_max_sessions_total`                            | MaxSessions                                                                                                      | tot  |
+| `livepeer_current_sessions_total`                        | Number of currently transcoded streams                                                                           | tot  |
+| `livepeer_discovery_errors_total`                        | Number of discover errors                                                                                        | tot  |
+| `livepeer_transcode_retried`                             | Number of times segment transcode was retried                                                                    | tot  |
+| `livepeer_transcoders_number`                            | Number of transcoders currently connected to orchestrator                                                        | tot  |
+| `livepeer_transcoders_capacity`                          | Total advertised capacity of transcoders currently connected to orchestrator                                     | tot  |
+| `livepeer_transcoders_load`                              | Total load of transcoders currently connected to orchestrator                                                    | tot  |
+| `livepeer_success_rate`                                  | Success rate                                                                                                     | per  |
+| `livepeer_success_rate_per_stream`                       | Success rate, per stream                                                                                         | per  |
+| `livepeer_transcode_time_seconds`                        | Transcoding time                                                                                                 | sec  |
+| `livepeer_transcode_latency_seconds`                     | Transcoding latency, from source segment emerged from segmenter till transcoded segment apeeared in manifest     | sec  |
+| `livepeer_transcode_overall_latency_seconds`             | Transcoding latency, from source segment emerged from segmenter till all transcoded segment apeeared in manifest | sec  |
+| `livepeer_upload_time_seconds`                           | Upload (to Orchestrator) time                                                                                    | sec  |
+| `livepeer_download_time_seconds`                         | Download (from orchestrator) time                                                                                | sec  |
+| `livepeer_auth_webhook_time_milliseconds`                | Authentication webhook execution time                                                                            | ms   |
+| `livepeer_source_segment_duration_seconds`               | Source segment's duration                                                                                        | sec  |
+| `livepeer_http_client_timeout_1`                         | Number of times HTTP connection was dropped before transcoding complete                                          | tot  |
+| `livepeer_http_client_timeout_2`                         | Number of times HTTP connection was dropped before transcoded segments was sent back to client                   | tot  |
+| `livepeer_http_client_segment_transcoded_realtime_ratio` | Ratio of source segment duration / transcode time as measured on HTTP client                                     | rat  |
+| `livepeer_http_client_segment_transcoded_realtime_3x`    | Number of segment transcoded 3x faster than realtime                                                             | tot  |
+| `livepeer_http_client_segment_transcoded_realtime_2x`    | Number of segment transcoded 2x faster than realtime                                                             | tot  |
+| `livepeer_http_client_segment_transcoded_realtime_1x`    | Number of segment transcoded 1x faster than realtime                                                             | tot  |
+| `livepeer_http_client_segment_transcoded_realtime_half`  | Number of segment transcoded no more than two times slower than realtime                                         | tot  |
+| `livepeer_http_client_segment_transcoded_realtime_slow`  | Number of segment transcoded more than two times slower than realtime                                            | tot  |
+| `livepeer_transcode_score`                               | Ratio of source segment duration vs. transcode time                                                              | rat  |
+| `livepeer_recording_save_latency`                        | How long it takes to save segment to the OS                                                                      | sec  |
+| `livepeer_recording_save_errors`                         | Number of errors during save to the recording OS                                                                 | tot  |
+| `livepeer_recording_saved_segments`                      | Number of segments saved to the recording OS                                                                     | tot  |
+| `livepeer_orchestrator_swaps`                            | Number of orchestrator swaps mid-stream                                                                          | tot  |
+
+### Sending payments
+
+| Name                             | Description                                        | Type |
+| -------------------------------- | -------------------------------------------------- | ---- |
+| `livepeer_ticket_value_sent`     | TicketValueSent                                    | gwei |
+| `livepeer_tickets_sent`          | TicketsSent                                        | tot  |
+| `livepeer_payment_create_errors` | PaymentCreateError                                 | tot  |
+| `livepeer_broadcaster_deposit`   | Current remaining deposit for the broadcaster node | gwei |
+| `livepeer_broadcaster_reserve`   | Current remaing reserve for the broadcaster node   | gwei |
+| `livepeer_max_transcoding_price` | MaxTranscodingPrice                                | wei  |
+
+### Receiving payments
+
+| Name                                | Description           | Type |
+| ----------------------------------- | --------------------- | ---- |
+| `livepeer_ticket_value_recv`        | TicketValueRecv       | gwei |
+| `livepeer_tickets_recv`             | TicketsRecv           | tot  |
+| `livepeer_payment_recv_errors`      | PaymentRecvErr        | tot  |
+| `livepeer_winning_tickets_recv`     | WinningTicketsRecv    | tot  |
+| `livepeer_value_redeemed`           | ValueRedeemed         | gwei |
+| `livepeer_ticket_redemption_errors` | TicketRedemptionError | tot  |
+| `livepeer_suggested_gas_price`      | SuggestedGasPrice     | gwei |
+| `livepeer_min_gas_price`            | MinGasPrice           | gwei |
+| `livepeer_max_gas_price`            | MaxGasPrice           | gwei |
+| `livepeer_transcoding_price`        | TranscodingPrice      | wei  |
+
+### Pixel accounting
+
+| Name                            | Description        | Type       |
+| ------------------------------- | ------------------ | ---------- |
+| `livepeer_mil_pixels_processed` | MilPixelsProcessed | mil pixels |
+
+### Fast verification
+
+| Name                                                        | Description                                                                                                             | Type |
+| ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ---- |
+| `livepeer_fast_verification_done`                           | FastVerificationDone                                                                                                    | tot  |
+| `livepeer_fast_verification_failed`                         | FastVerificationFailed                                                                                                  | tot  |
+| `livepeer_fast_verification_enabled_current_sessions_total` | Number of currently transcoded streams that have fast verification enabled                                              | tot  |
+| `livepeer_fast_verification_using_current_sessions_total`   | Number of currently transcoded streams that have fast verification enabled and that are using an untrusted orchestrator | tot  |
+

--- a/docs/video-miners/reference/metrics.md
+++ b/docs/video-miners/reference/metrics.md
@@ -11,125 +11,125 @@ Livepeer exposes a number of metrics via the Prometheus exporter. This page docu
 
 ### General
 
-| Name                                                     | Description                                                                                                      | Unit |
-| -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | ---- |
-| `livepeer_versions`                                      | Version information.                                                                                             | Num  |
-| `livepeer_segment_source_appeared_total`                 | SegmentSourceAppeared                                                                                            | tot  |
-| `livepeer_segment_source_emerged_total`                  | SegmentEmerged                                                                                                   | tot  |
-| `livepeer_segment_source_emerged_unprocessed_total`      | SegmentEmerged, counted by number of transcode profiles                                                          | tot  |
-| `livepeer_segment_source_uploaded_total`                 | SegmentUploaded                                                                                                  | tot  |
-| `livepeer_segment_source_upload_failed_total`            | SegmentUploadedFailed                                                                                            | tot  |
-| `livepeer_segment_transcoded_downloaded_total`           | SegmentDownloaded                                                                                                | tot  |
-| `livepeer_segment_transcoded_total`                      | SegmentTranscoded                                                                                                | tot  |
-| `livepeer_segment_transcoded_unprocessed_total`          | SegmentTranscodedUnprocessed                                                                                     | tot  |
-| `livepeer_segment_transcode_failed_total`                | SegmentTranscodeFailed                                                                                           | tot  |
-| `livepeer_segment_transcoded_appeared_total`             | SegmentTranscodedAppeared                                                                                        | tot  |
-| `livepeer_segment_transcoded_all_appeared_total`         | SegmentTranscodedAllAppeared                                                                                     | tot  |
-| `livepeer_broadcast_client_start_failed_total`           | StartBroadcastClientFailed                                                                                       | tot  |
-| `livepeer_stream_create_failed_total`                    | StreamCreateFailed                                                                                               | tot  |
-| `livepeer_stream_created_total`                          | StreamCreated                                                                                                    | tot  |
-| `livepeer_stream_started_total`                          | StreamStarted                                                                                                    | tot  |
-| `livepeer_stream_ended_total`                            | StreamEnded                                                                                                      | tot  |
-| `livepeer_max_sessions_total`                            | MaxSessions                                                                                                      | tot  |
-| `livepeer_current_sessions_total`                        | Number of currently transcoded streams                                                                           | tot  |
-| `livepeer_discovery_errors_total`                        | Number of discover errors                                                                                        | tot  |
-| `livepeer_transcode_retried`                             | Number of times segment transcode was retried                                                                    | tot  |
-| `livepeer_transcoders_number`                            | Number of transcoders currently connected to orchestrator                                                        | tot  |
-| `livepeer_transcoders_capacity`                          | Total advertised capacity of transcoders currently connected to orchestrator                                     | tot  |
-| `livepeer_transcoders_load`                              | Total load of transcoders currently connected to orchestrator                                                    | tot  |
-| `livepeer_success_rate`                                  | Success rate                                                                                                     | per  |
-| `livepeer_success_rate_per_stream`                       | Success rate, per stream                                                                                         | per  |
-| `livepeer_transcode_time_seconds`                        | Transcoding time                                                                                                 | sec  |
-| `livepeer_transcode_latency_seconds`                     | Transcoding latency, from source segment emerged from segmenter till transcoded segment apeeared in manifest     | sec  |
-| `livepeer_transcode_overall_latency_seconds`             | Transcoding latency, from source segment emerged from segmenter till all transcoded segment apeeared in manifest | sec  |
-| `livepeer_upload_time_seconds`                           | Upload (to Orchestrator) time                                                                                    | sec  |
-| `livepeer_download_time_seconds`                         | Download (from orchestrator) time                                                                                | sec  |
-| `livepeer_auth_webhook_time_milliseconds`                | Authentication webhook execution time                                                                            | ms   |
-| `livepeer_source_segment_duration_seconds`               | Source segment's duration                                                                                        | sec  |
-| `livepeer_http_client_timeout_1`                         | Number of times HTTP connection was dropped before transcoding complete                                          | tot  |
-| `livepeer_http_client_timeout_2`                         | Number of times HTTP connection was dropped before transcoded segments was sent back to client                   | tot  |
-| `livepeer_http_client_segment_transcoded_realtime_ratio` | Ratio of source segment duration / transcode time as measured on HTTP client                                     | rat  |
-| `livepeer_http_client_segment_transcoded_realtime_3x`    | Number of segment transcoded 3x faster than realtime                                                             | tot  |
-| `livepeer_http_client_segment_transcoded_realtime_2x`    | Number of segment transcoded 2x faster than realtime                                                             | tot  |
-| `livepeer_http_client_segment_transcoded_realtime_1x`    | Number of segment transcoded 1x faster than realtime                                                             | tot  |
-| `livepeer_http_client_segment_transcoded_realtime_half`  | Number of segment transcoded no more than two times slower than realtime                                         | tot  |
-| `livepeer_http_client_segment_transcoded_realtime_slow`  | Number of segment transcoded more than two times slower than realtime                                            | tot  |
-| `livepeer_transcode_score`                               | Ratio of source segment duration vs. transcode time                                                              | rat  |
-| `livepeer_recording_save_latency`                        | How long it takes to save segment to the OS                                                                      | sec  |
-| `livepeer_recording_save_errors`                         | Number of errors during save to the recording OS                                                                 | tot  |
-| `livepeer_recording_saved_segments`                      | Number of segments saved to the recording OS                                                                     | tot  |
-| `livepeer_orchestrator_swaps`                            | Number of orchestrator swaps mid-stream                                                                          | tot  |
+| Name                                                     | Description                                                                                                      | Unit | Type      | Tags                                              |
+| -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | ---- | --------- | ------------------------------------------------- |
+| `livepeer_versions`                                      | Versions used by LivePeer node.                                                                                  | Num  | gauge     | compiler,goos,goversion,livepeerversion,node_type |
+| `livepeer_segment_source_appeared_total`                 | SegmentSourceAppeared                                                                                            | tot  | counter   | node_id,node_type,profile,seg_type                |
+| `livepeer_segment_source_emerged_total`                  | SegmentEmerged                                                                                                   | tot  | counter   | node_id,node_type                                 |
+| `livepeer_segment_source_emerged_unprocessed_total`      | Raw number of segments emerged from segmenter.                                                                   | tot  | counter   | node_id,node_type                                 |
+| `livepeer_segment_source_uploaded_total`                 | SegmentUploaded                                                                                                  | tot  | counter   | node_id,node_type,orchestrator_uri                |
+| `livepeer_segment_source_upload_failed_total`            | SegmentUploadedFailed                                                                                            | tot  | counter   | error_code,node_id,node_type,orchestrator_uri     |
+| `livepeer_segment_transcoded_downloaded_total`           | SegmentDownloaded                                                                                                | tot  | counter   | node_id,node_type                                 |
+| `livepeer_segment_transcoded_total`                      | SegmentTranscoded                                                                                                | tot  | counter   | node_id,node_type,profiles,trusted,verified       |
+| `livepeer_segment_transcoded_unprocessed_total`          | Raw number of segments successfully transcoded.                                                                  | tot  | counter   | node_id,node_type,profiles                        |
+| `livepeer_segment_transcode_failed_total`                | SegmentTranscodeFailed                                                                                           | tot  | counter   | error_code,node_id,node_type                      |
+| `livepeer_segment_transcoded_appeared_total`             | SegmentTranscodedAppeared                                                                                        | tot  | counter   | node_id,node_type,profile,seg_type                |
+| `livepeer_segment_transcoded_all_appeared_total`         | SegmentTranscodedAllAppeared                                                                                     | tot  | counter   | node_id,node_type,profiles                        |
+| `livepeer_broadcast_client_start_failed_total`           | StartBroadcastClientFailed                                                                                       | tot  | counter   | node_id,node_type                                 |
+| `livepeer_stream_create_failed_total`                    | StreamCreateFailed                                                                                               | tot  | counter   | node_id,node_type                                 |
+| `livepeer_stream_created_total`                          | StreamCreated                                                                                                    | tot  | counter   | node_id,node_type                                 |
+| `livepeer_stream_started_total`                          | StreamStarted                                                                                                    | tot  | counter   | node_id,node_type                                 |
+| `livepeer_stream_ended_total`                            | StreamEnded                                                                                                      | tot  | counter   | node_id,node_type                                 |
+| `livepeer_max_sessions_total`                            | Max Sessions                                                                                                     | tot  | gauge     | node_id,node_type                                 |
+| `livepeer_current_sessions_total`                        | Number of streams currently transcoding                                                                          | tot  | gauge     | node_id,node_type                                 |
+| `livepeer_discovery_errors_total`                        | Number of discover errors                                                                                        | tot  | counter   | error_code,node_id,node_type,orchestrator_uri     |
+| `livepeer_transcode_retried`                             | Number of times segment transcode was retried                                                                    | tot  | counter   | node_id,node_type,try                             |
+| `livepeer_transcoders_number`                            | Number of transcoders currently connected to orchestrator                                                        | tot  | gauge     | node_id,node_type                                 |
+| `livepeer_transcoders_capacity`                          | Total advertised capacity of transcoders currently connected to orchestrator                                     | tot  | gauge     | node_id,node_type                                 |
+| `livepeer_transcoders_load`                              | Total load of transcoders currently connected to orchestrator                                                    | tot  | gauge     | node_id,node_type                                 |
+| `livepeer_success_rate`                                  | Number of transcoded segments divided on number of source segments                                               | per  | gauge     | node_id,node_type                                 |
+| `livepeer_success_rate_per_stream`                       | Number of transcoded segments divided on number of source segments, per stream                                   | per  | gauge     | node_id,node_type                                 |
+| `livepeer_transcode_time_seconds`                        | TranscodeTime, seconds                                                                                           | sec  | histogram | node_id,node_type,profiles,trusted,verified       |
+| `livepeer_transcode_latency_seconds`                     | Transcoding latency, from source segment emerged from segmenter till transcoded segment apeeared in manifest     | sec  | histogram | node_id,node_type,profile                         |
+| `livepeer_transcode_overall_latency_seconds`             | Transcoding latency, from source segment emerged from segmenter till all transcoded segment apeeared in manifest | sec  | histogram | node_id,node_type,profiles                        |
+| `livepeer_upload_time_seconds`                           | UploadTime, seconds                                                                                              | sec  | histogram | node_id,node_type,orchestrator_uri                |
+| `livepeer_download_time_seconds`                         | Download time                                                                                                    | sec  | histogram | node_id,node_type                                 |
+| `livepeer_auth_webhook_time_milliseconds`                | Authentication webhook execution time, milliseconds                                                              | ms   | histogram | node_id,node_type                                 |
+| `livepeer_source_segment_duration_seconds`               | Source segment's duration                                                                                        | sec  | histogram | node_id,node_type                                 |
+| `livepeer_http_client_timeout_1`                         | Number of times HTTP connection was dropped before transcoding complete                                          | tot  | counter   | node_id,node_type                                 |
+| `livepeer_http_client_timeout_2`                         | Number of times HTTP connection was dropped before transcoded segments was sent back to client                   | tot  | counter   | node_id,node_type                                 |
+| `livepeer_http_client_segment_transcoded_realtime_ratio` | Ratio of source segment duration / transcode time as measured on HTTP client                                     | rat  | histogram | node_id,node_type                                 |
+| `livepeer_http_client_segment_transcoded_realtime_3x`    | Number of segment transcoded 3x faster than realtime                                                             | tot  | counter   | node_id,node_type                                 |
+| `livepeer_http_client_segment_transcoded_realtime_2x`    | Number of segment transcoded 2x faster than realtime                                                             | tot  | counter   | node_id,node_type                                 |
+| `livepeer_http_client_segment_transcoded_realtime_1x`    | Number of segment transcoded 1x faster than realtime                                                             | tot  | counter   | node_id,node_type                                 |
+| `livepeer_http_client_segment_transcoded_realtime_half`  | Number of segment transcoded no more than two times slower than realtime                                         | tot  | counter   | node_id,node_type                                 |
+| `livepeer_http_client_segment_transcoded_realtime_slow`  | Number of segment transcoded more than two times slower than realtime                                            | tot  | counter   | node_id,node_type                                 |
+| `livepeer_transcode_score`                               | Ratio of source segment duration vs. transcode time                                                              | rat  | histogram | node_id,node_type,profiles,trusted,verified       |
+| `livepeer_recording_save_latency`                        | How long it takes to save segment to the OS                                                                      | sec  | histogram | node_id,node_type                                 |
+| `livepeer_recording_save_errors`                         | Number of errors during save to the recording OS                                                                 | tot  | counter   | node_id,node_type                                 |
+| `livepeer_recording_saved_segments`                      | Number of segments saved to the recording OS                                                                     | tot  | counter   | node_id,node_type                                 |
+| `livepeer_orchestrator_swaps`                            | Number of orchestrator swaps mid-stream                                                                          | tot  | counter   | node_id,node_type                                 |
 
 ### Sending payments
 
-| Name                             | Description                                        | Unit |
-| -------------------------------- | -------------------------------------------------- | ---- |
-| `livepeer_ticket_value_sent`     | TicketValueSent                                    | gwei |
-| `livepeer_tickets_sent`          | TicketsSent                                        | tot  |
-| `livepeer_payment_create_errors` | PaymentCreateError                                 | tot  |
-| `livepeer_broadcaster_deposit`   | Current remaining deposit for the broadcaster node | gwei |
-| `livepeer_broadcaster_reserve`   | Current remaing reserve for the broadcaster node   | gwei |
-| `livepeer_max_transcoding_price` | MaxTranscodingPrice                                | wei  |
+| Name                             | Description                                        | Unit | Type    | Tags              |
+| -------------------------------- | -------------------------------------------------- | ---- | ------- | ----------------- |
+| `livepeer_ticket_value_sent`     | Ticket value sent                                  | gwei | counter | node_id,node_type |
+| `livepeer_tickets_sent`          | Tickets sent                                       | tot  | counter | node_id,node_type |
+| `livepeer_payment_create_errors` | Errors when creating payments                      | tot  | counter | node_id,node_type |
+| `livepeer_broadcaster_deposit`   | Current remaining deposit for the broadcaster node | gwei | gauge   | node_id,node_type |
+| `livepeer_broadcaster_reserve`   | Current remaining reserve for the broadcaster node | gwei | gauge   | node_id,node_type |
+| `livepeer_max_transcoding_price` | Maximum price per pixel to pay for transcoding     | wei  | gauge   | node_id,node_type |
 
 ### Receiving payments
 
-| Name                                | Description           | Unit |
-| ----------------------------------- | --------------------- | ---- |
-| `livepeer_ticket_value_recv`        | TicketValueRecv       | gwei |
-| `livepeer_tickets_recv`             | TicketsRecv           | tot  |
-| `livepeer_payment_recv_errors`      | PaymentRecvErr        | tot  |
-| `livepeer_winning_tickets_recv`     | WinningTicketsRecv    | tot  |
-| `livepeer_value_redeemed`           | ValueRedeemed         | gwei |
-| `livepeer_ticket_redemption_errors` | TicketRedemptionError | tot  |
-| `livepeer_suggested_gas_price`      | SuggestedGasPrice     | gwei |
-| `livepeer_min_gas_price`            | MinGasPrice           | gwei |
-| `livepeer_max_gas_price`            | MaxGasPrice           | gwei |
-| `livepeer_transcoding_price`        | TranscodingPrice      | wei  |
+| Name                                | Description                                        | Unit | Type    | Tags                         |
+| ----------------------------------- | -------------------------------------------------- | ---- | ------- | ---------------------------- |
+| `livepeer_ticket_value_recv`        | Ticket value received                              | gwei | counter | node_id,node_type            |
+| `livepeer_tickets_recv`             | Tickets received                                   | tot  | counter | node_id,node_type            |
+| `livepeer_payment_recv_errors`      | Errors when receiving payments                     | tot  | counter | error_code,node_id,node_type |
+| `livepeer_winning_tickets_recv`     | Winning tickets received                           | tot  | counter | node_id,node_type            |
+| `livepeer_value_redeemed`           | Winning ticket value redeemed                      | gwei | counter | node_id,node_type            |
+| `livepeer_ticket_redemption_errors` | Errors when redeeming tickets                      | tot  | counter | node_id,node_type            |
+| `livepeer_suggested_gas_price`      | Suggested gas price for winning ticket redemption  | gwei | gauge   | node_id,node_type            |
+| `livepeer_min_gas_price`            | Minimum gas price to use for gas price suggestions | gwei | gauge   | node_id,node_type            |
+| `livepeer_max_gas_price`            | Maximum gas price to use for gas price suggestions | gwei | gauge   | node_id,node_type            |
+| `livepeer_transcoding_price`        | Transcoding price per pixel                        | wei  | gauge   | node_id,node_type            |
 
 ### Pixel accounting
 
-| Name                            | Description        | Unit       |
-| ------------------------------- | ------------------ | ---------- |
-| `livepeer_mil_pixels_processed` | MilPixelsProcessed | mil pixels |
+| Name                            | Description              | Unit       | Type    | Tags              |
+| ------------------------------- | ------------------------ | ---------- | ------- | ----------------- |
+| `livepeer_mil_pixels_processed` | Million pixels processed | mil pixels | counter | node_id,node_type |
 
 ### Fast verification
 
-| Name                                                        | Description                                                                                                             | Unit |
-| ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ---- |
-| `livepeer_fast_verification_done`                           | FastVerificationDone                                                                                                    | tot  |
-| `livepeer_fast_verification_failed`                         | FastVerificationFailed                                                                                                  | tot  |
-| `livepeer_fast_verification_enabled_current_sessions_total` | Number of currently transcoded streams that have fast verification enabled                                              | tot  |
-| `livepeer_fast_verification_using_current_sessions_total`   | Number of currently transcoded streams that have fast verification enabled and that are using an untrusted orchestrator | tot  |
+| Name                                                        | Description                                                                                                             | Unit | Type    | Tags              |
+| ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ---- | ------- | ----------------- |
+| `livepeer_fast_verification_done`                           | Number of fast verifications done                                                                                       | tot  | counter | node_id,node_type |
+| `livepeer_fast_verification_failed`                         | Number of fast verifications failed                                                                                     | tot  | counter | node_id,node_type |
+| `livepeer_fast_verification_enabled_current_sessions_total` | Number of currently transcoded streams that have fast verification enabled                                              | tot  | gauge   | node_id,node_type |
+| `livepeer_fast_verification_using_current_sessions_total`   | Number of currently transcoded streams that have fast verification enabled and that are using an untrusted orchestrator | tot  | gauge   | node_id,node_type |
 
 ## Golang metrics
 
-| Name                               | Description                                                                                 |
-| ---------------------------------- | ------------------------------------------------------------------------------------------- |
-| `go_gc_duration_seconds`           | A summary of the pause duration of garbage collection cycles.                               |
-| `go_goroutines`                    | Number of goroutines that currently exist.                                                  |
-| `go_info`                          | Information about the Go environment.                                                       |
-| `go_memstats_alloc_bytes`          | Number of bytes allocated and still in use.                                                 |
-| `go_memstats_alloc_bytes_total`    | Total number of bytes allocated, even if freed.                                             |
-| `go_memstats_buck_hash_sys_bytes`  | Number of bytes used by the profiling bucket hash table.                                    |
-| `go_memstats_frees_total`          | Total number of frees.                                                                      |
-| `go_memstats_gc_cpu_fraction`      | The fraction of this program's available CPU time used by the GC since the program started. |
-| `go_memstats_gc_sys_bytes`         | Number of bytes used for garbage collection system metadata.                                |
-| `go_memstats_heap_alloc_bytes`     | Number of heap bytes allocated and still in use.                                            |
-| `go_memstats_heap_idle_bytes`      | Number of heap bytes waiting to be used.                                                    |
-| `go_memstats_heap_inuse_bytes`     | Number of heap bytes that are in use.                                                       |
-| `go_memstats_heap_objects`         | Number of allocated objects.                                                                |
-| `go_memstats_heap_released_bytes`  | Number of heap bytes released to OS.                                                        |
-| `go_memstats_heap_sys_bytes`       | Number of heap bytes obtained from system.                                                  |
-| `go_memstats_last_gc_time_seconds` | Number of seconds since 1970 of last garbage collection.                                    |
-| `go_memstats_lookups_total`        | Total number of pointer lookups.                                                            |
-| `go_memstats_mallocs_total`        | Total number of mallocs.                                                                    |
-| `go_memstats_mcache_inuse_bytes`   | Number of bytes in use by mcache structures.                                                |
-| `go_memstats_mcache_sys_bytes`     | Number of bytes used for mcache structures obtained from system.                            |
-| `go_memstats_mspan_inuse_bytes`    | Number of bytes in use by mspan structures.                                                 |
-| `go_memstats_mspan_sys_bytes`      | Number of bytes used for mspan structures obtained from system.                             |
-| `go_memstats_next_gc_bytes`        | Number of heap bytes when next garbage collection will take place.                          |
-| `go_memstats_other_sys_bytes`      | Number of bytes used for other system allocations.                                          |
-| `go_memstats_stack_inuse_bytes`    | Number of bytes in use by the stack allocator.                                              |
-| `go_memstats_stack_sys_bytes`      | Number of bytes obtained from system for stack allocator.                                   |
-| `go_memstats_sys_bytes`            | Number of bytes obtained from system.                                                       |
-| `go_threads`                       | Number of OS threads created.                                                               |
+| Name                               | Description                                                                                 | Type    |
+| ---------------------------------- | ------------------------------------------------------------------------------------------- | ------- |
+| `go_gc_duration_seconds`           | A summary of the pause duration of garbage collection cycles.                               | summary |
+| `go_goroutines`                    | Number of goroutines that currently exist.                                                  | gauge   |
+| `go_info`                          | Information about the Go environment.                                                       | gauge   |
+| `go_memstats_alloc_bytes`          | Number of bytes allocated and still in use.                                                 | gauge   |
+| `go_memstats_alloc_bytes_total`    | Total number of bytes allocated, even if freed.                                             | counter |
+| `go_memstats_buck_hash_sys_bytes`  | Number of bytes used by the profiling bucket hash table.                                    | gauge   |
+| `go_memstats_frees_total`          | Total number of frees.                                                                      | counter |
+| `go_memstats_gc_cpu_fraction`      | The fraction of this program's available CPU time used by the GC since the program started. | gauge   |
+| `go_memstats_gc_sys_bytes`         | Number of bytes used for garbage collection system metadata.                                | gauge   |
+| `go_memstats_heap_alloc_bytes`     | Number of heap bytes allocated and still in use.                                            | gauge   |
+| `go_memstats_heap_idle_bytes`      | Number of heap bytes waiting to be used.                                                    | gauge   |
+| `go_memstats_heap_inuse_bytes`     | Number of heap bytes that are in use.                                                       | gauge   |
+| `go_memstats_heap_objects`         | Number of allocated objects.                                                                | gauge   |
+| `go_memstats_heap_released_bytes`  | Number of heap bytes released to OS.                                                        | gauge   |
+| `go_memstats_heap_sys_bytes`       | Number of heap bytes obtained from system.                                                  | gauge   |
+| `go_memstats_last_gc_time_seconds` | Number of seconds since 1970 of last garbage collection.                                    | gauge   |
+| `go_memstats_lookups_total`        | Total number of pointer lookups.                                                            | counter |
+| `go_memstats_mallocs_total`        | Total number of mallocs.                                                                    | counter |
+| `go_memstats_mcache_inuse_bytes`   | Number of bytes in use by mcache structures.                                                | gauge   |
+| `go_memstats_mcache_sys_bytes`     | Number of bytes used for mcache structures obtained from system.                            | gauge   |
+| `go_memstats_mspan_inuse_bytes`    | Number of bytes in use by mspan structures.                                                 | gauge   |
+| `go_memstats_mspan_sys_bytes`      | Number of bytes used for mspan structures obtained from system.                             | gauge   |
+| `go_memstats_next_gc_bytes`        | Number of heap bytes when next garbage collection will take place.                          | gauge   |
+| `go_memstats_other_sys_bytes`      | Number of bytes used for other system allocations.                                          | gauge   |
+| `go_memstats_stack_inuse_bytes`    | Number of bytes in use by the stack allocator.                                              | gauge   |
+| `go_memstats_stack_sys_bytes`      | Number of bytes obtained from system for stack allocator.                                   | gauge   |
+| `go_memstats_sys_bytes`            | Number of bytes obtained from system.                                                       | gauge   |
+| `go_threads`                       | Number of OS threads created.                                                               | gauge   |


### PR DESCRIPTION
Document all Prometheus metrics that are exposed from Livepeer.

fix https://github.com/livepeer/go-livepeer/issues/2139

**Things to consider**:
1. Maybe there is too much info (maybe we don't need `unit`, `type`, or `tags`)?
2. Maybe we don't want to include Golang metrics? They are standard for any Golang app.
3. I grouped Livepeer metrics the same as they are grouped in the code (General, Sending payments, Receiving payments, Pixel accounting, Fast verification), but maybe we want some other grouping?
4. I took the description for each metric from the code. Some of descriptions may be improved. If we want to do it, then I suggest creating a separate GH Issue.
5. We can consider adding an example for each metrics, but I'm afraid that these tables are already too wide
6. Not all metrics are available for all node types (Broadcaster, Orchestrator, Transcoder, Redeemer) and all network types (offchain does not have a lot of metrics). We could try to mark which node type uses which metrics, but it can take a few days to get it sorted out, so I suggest creating a separate GH Issue if needed.