### PR TITLE
Move warning msg to the bottom

### DIFF
--- a/pages/guides/developing/dstorage-playback.en-US.mdx
+++ b/pages/guides/developing/dstorage-playback.en-US.mdx
@@ -10,15 +10,6 @@ import { DecentralizedStoragePlayback } from '@components/react/examples';
 
 Playing back transcoded video from IPFS or Arweave is easy with livepeer.js! The example below uses the Player's built-in capabilities to transcode IPFS/Arweave content without any additional configuration.
 
-<Callout type="warning" emoji="⚠️">
-  **This example illustrates how Livepeer can be used as a video processing and
-  caching layer on top of content available on IPFS or the Arweave gateway for
-  optimized video playback.** We support fallback to play directly from
-  IPFS/Arweave while the video is being uploaded to Livepeer. However, we
-  recommend uploading via `useCreateAsset` before displaying it in the player
-  for best performance.
-</Callout>
-
 IPFS is a network of nodes that allow you to read content from the network using a content identifier unique to the data you’re requesting, ensuring you are able to securely and verifiably get exactly what you are asking for, regardless of where the data is physically stored. Arweave is a set of nodes that are incentivized to store data permanently; content stored on the network is pulled through an Arweave gateway.
 
 <DecentralizedStoragePlayback />
@@ -99,6 +90,16 @@ export const DecentralizedStoragePlayback = () => {
 };
 ```
 
+<Callout type="warning" emoji="⚠️">
+  **This example illustrates how Livepeer can be used as a video processing and
+  caching layer on top of content available on IPFS or the Arweave gateway for
+  optimized video playback.** We support fallback to play directly from
+  IPFS/Arweave while the video is being uploaded to Livepeer. However, when possible, we
+  recommend uploading via `useCreateAsset` before displaying it in the player
+  for best performance.
+</Callout>
+
 ## Wrap Up
 
 That's it! You just configured a caching & transcoding layer on top of IPFS and Arweave with a few lines of code!
+


### PR DESCRIPTION
## Description

When reaching out to prospects with this tutorial as a core assets, the scary warning msg at the top makes it feels like the product is not ready.  For now, moving the warning msg to the bottom looks a little better.
