### PR TITLE
Add info about transcoding resolution

### DIFF
--- a/pages/reference/api-support-matrix.en-US.mdx
+++ b/pages/reference/api-support-matrix.en-US.mdx
@@ -11,7 +11,9 @@ import { Callout } from 'nextra-theme-docs';
 ### Inputs
 
 <Callout type="info" emoji="ℹ️">
-  Currently, only file sizes up to 10GB are supported.
+  - Currently, only file sizes up to 10GB are supported.
+
+  - The highest resolution an asset will get transcoded is 1440p (QHD). Ex. If a 4K asset is uploaded, then it will be downsized to 1440p.
 </Callout>
 
 #### Video


### PR DESCRIPTION
Right now the highest resolution an asset can get transcoded is 1440p. Anything higher will get downsized to it.

## Description

_Concise description of proposed changes_
