### PR TITLE
Remove the mention of assets

### DIFF
--- a/pages/reference/api/update-stream.en-US.mdx
+++ b/pages/reference/api/update-stream.en-US.mdx
@@ -72,10 +72,10 @@ curl -X PATCH 'https://livepeer.studio/api/stream/{id}' \
 
 A `playbackPolicy` `type` can be either:
 
-- public - No access control is applied to the asset
-- jwt - A JWT is required to playback the asset
+- public - No access control is applied to the stream
+- jwt - A JWT is required to playback the stream
 
-If you set your stream or asset's playback policy to JWT, you will need to sign a token with a signing key
+If you set your stream playback policy to JWT, you will need to sign a token with a signing key
 and put it in the playback URL to be able to playback your stream.
 
 ### Request
@@ -93,4 +93,4 @@ curl --location --request PATCH 'https://livepeer.studio/api/stream/{id}' \
 
 ### Response
 
-A `204 No Content` status response indicates the `asset` was successfully updated.
+A `204 No Content` status response indicates the `stream` was successfully updated.


### PR DESCRIPTION
## Description

Remove `assets` from the docs as we only support playback policy for live streams at the moment.
