### PR TITLE
Update CLI descriptions

### DIFF
--- a/pages/reference/go-livepeer/cli-reference.en-US.mdx
+++ b/pages/reference/go-livepeer/cli-reference.en-US.mdx
@@ -78,7 +78,7 @@ sceneClassificationModelPath: Path to scene classification model. No default
 ### Onchain
 
 ```
-ethAcctAddr: Existing Eth account address. For use when multiple ETH accounts exist in keystore directory
+ethAcctAddr: Existing Eth account address. For use when multiple ETH accounts exist in the keystore directory
 
 ethPassword: Password for existing Eth account address or path to file
 

--- a/pages/reference/go-livepeer/cli-reference.en-US.mdx
+++ b/pages/reference/go-livepeer/cli-reference.en-US.mdx
@@ -56,7 +56,7 @@ transcoder: Set to true to be an transcoder. Default `false`
 
 broadcaster: Set to true to be an broadcaster. Default `false`
 
-orchSecret: Shared secret with the orchestrator as a standalone transcoder. No default
+orchSecret: Shared secret with the orchestrator as a standalone transcoder or path to file
 
 transcodingOptions: Transcoding options for broadcast job, or path to json config. Default `P240p30fps16x9,P360p30fps16x9`
 
@@ -78,11 +78,11 @@ sceneClassificationModelPath: Path to scene classification model. No default
 ### Onchain
 
 ```
-ethAcctAddr: Existing Eth account address. No default
+ethAcctAddr: Existing Eth account address. For use when multiple ETH accounts exist in keystore directory
 
-ethPassword: Password for existing Eth account address. No default
+ethPassword: Password for existing Eth account address or path to file
 
-ethKeystorePath: Path for the Eth Key. No default
+ethKeystorePath: Path to ETH keystore directory or keyfile. If keyfile, overrides -ethAcctAddr and uses parent directory
 
 ethOrchAddr: address of an on-chain registered orchestrator. No default
 
@@ -113,6 +113,8 @@ pricePerUnit: The price per 'pixelsPerUnit' amount pixels. Must be greater than 
 maxPricePerUnit: The maximum transcoding price (in wei) per 'pixelsPerUnit' a broadcaster is willing to accept. If not set explicitly, broadcaster is willing to accept ANY price. Default `0`
 
 pixelsPerUnit: Amount of pixels per unit. Set to '> 1' to have smaller price granularity than 1 wei / pixel. Default `1`
+
+pricePerBroadcaster: json list of price per broadcaster or path to json config file. Example: {"broadcasters":[{"ethaddress":"address1","priceperunit":1000,"pixelsperunit":1},{"ethaddress":"address2","priceperunit":1200,"pixelsperunit":1}]}
 
 autoAdjustPrice: Enable/disable automatic price adjustments based on the overhead for redeeming tickets. Default `true`
 


### PR DESCRIPTION
Update to docs from https://github.com/livepeer/go-livepeer/pull/2713

- Updated descriptions for `ethAcctAddr`, `ethPassword`, `ethKeystorePath` and `orchSecret`
- Added description for `pricePerBroadcaster`, which was missing from docs.