### PR TITLE
Add note for creating signing keys

### DIFF
--- a/pages/guides/developing/access-control.en-US.mdx
+++ b/pages/guides/developing/access-control.en-US.mdx
@@ -50,7 +50,12 @@ function App() {
 
 ## Step 2: Create a Gated Stream
 
-We then can create our gated stream, with the stream key returned once we create it (styling has been removed for simplicity):
+<Callout>
+  Make sure to also create your signing keys.
+  [Create signing key](/reference/api/create-signing-keys)
+</Callout>
+
+We then can create our gated stream, with the stream key returned once we create it (styling has been removed for simplicity)
 
 ```tsx filename="AccessControl.tsx"
 import { useCreateStream, useStream } from '@livepeer/react';

--- a/pages/guides/developing/access-control.en-US.mdx
+++ b/pages/guides/developing/access-control.en-US.mdx
@@ -50,11 +50,6 @@ function App() {
 
 ## Step 2: Create a Gated Stream
 
-<Callout>
-  Make sure to also create your signing keys.
-  [Create signing key](/reference/api/create-signing-keys)
-</Callout>
-
 We then can create our gated stream, with the stream key returned once we create it (styling has been removed for simplicity)
 
 ```tsx filename="AccessControl.tsx"
@@ -105,6 +100,12 @@ export const AccessControl = () => {
 
 Next, we add an API route - since we are using Next.JS, we add a custom [Next.js API route](https://nextjs.org/docs/api-routes/introduction).
 We add a check in the API route for a special "secret" that must be passed in the POST body for the user to gain access to the stream.
+
+<Callout>
+  Make sure to [create a signing key](/reference/api/create-signing-keys) -
+  those values will be used as the environment variables
+  `ACCESS_CONTROL_PRIVATE_KEY` and `NEXT_PUBLIC_ACCESS_CONTROL_PUBLIC_KEY`.
+</Callout>
 
 ```typescript filename="/api/sign-jwt.ts"
 // use the signAccessJwt export from `livepeer` in Node.JS


### PR DESCRIPTION
Some users didn't realize that a signing key was required when using following this guide

>Also the internal links are broken on this page `useCreateStream`, `useStream`, and `Create signing key` links are not working. I followed the path for those pages but still went to 404.

## Description

_Concise description of proposed changes_
