### PR TITLE
docs: add playback endpoint to API reference

### DIFF
--- a/pages/reference/api/get-playback.en-US.mdx
+++ b/pages/reference/api/get-playback.en-US.mdx
@@ -1,0 +1,32 @@
+---
+title: 'GET Playback Info'
+---
+
+# `GET` Playback
+
+You can retrieve the playback information by calling the `GET` playback endpoint with the `playbackId`.
+
+### Request
+
+```bash
+curl 'https://livepeer.studio/api/playback/{id}'
+```
+
+### Response
+
+200 OK
+
+```json
+{
+  "type": "vod",
+  "meta": {
+    "source": [
+      {
+        "hrn": "HLS (TS)",
+        "type": "html5/application/vnd.apple.mpegurl",
+        "url": "https://lp-playback.com/hls/b865nt7lyv07irgb/index.m3u8"
+      }
+    ]
+  }
+}
+```


### PR DESCRIPTION
## Description

Added the playback info endpoint (`/api/playback/id`) to the API references