### PR TITLE
Fix typos

### DIFF
--- a/pages/reference/api/_meta.en-US.json
+++ b/pages/reference/api/_meta.en-US.json
@@ -3,5 +3,5 @@
   "create-asset-via-url": "POST Create asset via URL",
   "create-stream": "POST Create stream",
   "create-signing-keys": "POST Create signing key",
-  "create-mulistream-tarket": "POST Create multistream target"
+  "create-multistream-target": "POST Create multistream target"
 }


### PR DESCRIPTION
## Description

Link to `POST create multistream target` is broken on API page
