### PR TITLE
Update viewership docs for custom player setup.

### DIFF
--- a/pages/guides/developing/viewer-engagement.en-US.mdx
+++ b/pages/guides/developing/viewer-engagement.en-US.mdx
@@ -198,6 +198,12 @@ export default function VideoPlayer() {
   );
 }
 ```
+    
+If `addMediaMetrics` is not found in import statement then try the following:
+
+```
+import { addMediaMetrics } from 'livepeer/media/browser';
+```
 
   </Tab>
 </Tabs>

--- a/pages/guides/developing/viewer-engagement.en-US.mdx
+++ b/pages/guides/developing/viewer-engagement.en-US.mdx
@@ -101,7 +101,7 @@ Here's how to configure your player:
   <Tab>
 
 ```js
-import { addMediaMetrics } from 'livepeer';
+import { addMediaMetrics } from 'livepeer/media/browser';
 
 const source =
   'https://livepeercdn.studio/recordings/bd600224-d93a-4ddc-a6ac-2d71e3c36768/index.m3u8';
@@ -116,7 +116,7 @@ addMediaMetrics(video, source, (e) => console.error('Error adding metrics', e));
   <Tab>
 
 ```js
-import { addMediaMetrics } from 'livepeer';
+import { addMediaMetrics } from 'livepeer/media/browser';
 import React, { useEffect, useRef, useState } from 'react';
 
 export default function VideoPlayer() {
@@ -154,7 +154,7 @@ export default function VideoPlayer() {
   <Tab>
 
 ```js
-import { addMediaMetrics } from 'livepeer';
+import { addMediaMetrics } from 'livepeer/media/browser';
 
 const source =
   'https://livepeercdn.studio/recordings/bd600224-d93a-4ddc-a6ac-2d71e3c36768/index.m3u8';
@@ -169,7 +169,7 @@ addMediaMetrics(video, source, (e) => console.error('Error adding metrics', e));
   <Tab>
 
 ```js
-import { addMediaMetrics } from 'livepeer';
+import { addMediaMetrics } from 'livepeer/media/browser';
 import React, { useEffect, useRef, useState } from 'react';
 
 export default function VideoPlayer() {
@@ -197,12 +197,6 @@ export default function VideoPlayer() {
     />
   );
 }
-```
-    
-If `addMediaMetrics` is not found in import statement then try the following:
-
-```
-import { addMediaMetrics } from 'livepeer/media/browser';
 ```
 
   </Tab>


### PR DESCRIPTION
## Description

The import statement doesn't seem to find addMediaMetrics. We can alternatively import from 'livepeer/media/browser'.

As mentioned in discussion below:

https://github.com/livepeer/studio/issues/1262
