### PR TITLE
Fix broken link

### DIFF
--- a/pages/reference/livepeer-js/Player.en-US.mdx
+++ b/pages/reference/livepeer-js/Player.en-US.mdx
@@ -216,7 +216,7 @@ function PlayerComponent() {
 ### jwt
 
 The JSON Web Token (JWT) used to access the media. This is used to gate content based on a playback policy.
-See the [Access Control example](/examples/react/access-control) for more details.
+See the [Access Control example](/guides/developing/access-control) for more details.
 
 <Callout type="warning" emoji="⚠️">
   Currently, access control is only supported with Streams. Access control for


### PR DESCRIPTION
## Description

The `access-control` link to the example was a broken link
