### PR TITLE
Removed sandbox-allow-scripts from embed code example

### DIFF
--- a/pages/guides/developing/player.en-US.mdx
+++ b/pages/guides/developing/player.en-US.mdx
@@ -234,7 +234,6 @@ You can replace the `PLAYBACK_ID` with your video's playback id.
   frameborder="0"
   allowfullscreen
   allow="autoplay; encrypted-media; picture-in-picture"
-  sandbox="allow-scripts">
 </iframe>
 ```
 


### PR DESCRIPTION
## Description
This attribute is not required and was causing issues for some developers

