### PR TITLE
api-reference: added mp4 outputs to playback endpoint example

### DIFF
--- a/pages/reference/api/get-playback.en-US.mdx
+++ b/pages/reference/api/get-playback.en-US.mdx
@@ -22,9 +22,27 @@ curl 'https://livepeer.studio/api/playback/{id}'
   "meta": {
     "source": [
       {
+          "hrn": "MP4",
+          "type": "html5/video/mp4",
+          "url": "https://asset-cdn.lp-playback.monster/hls/1bde4o2i6xycudoy/static360p0.mp4",
+          "size": 494778,
+          "width": 204,
+          "height": 360,
+          "bitrate": 449890
+      },
+      {
+          "hrn": "MP4",
+          "type": "html5/video/mp4",
+          "url": "https://asset-cdn.lp-playback.monster/hls/1bde4o2i6xycudoy/static720p0.mp4",
+          "size": 1869154,
+          "width": 406,
+          "height": 720,
+          "bitrate": 1996936
+      },
+      {
         "hrn": "HLS (TS)",
         "type": "html5/application/vnd.apple.mpegurl",
-        "url": "https://lp-playback.com/hls/b865nt7lyv07irgb/index.m3u8"
+        "url": "https://asset-cdn.lp-playback.monster/hls/1bde4o2i6xycudoy/index.m3u8"
       }
     ]
   }


### PR DESCRIPTION
## Description

To the API reference, added the mp4 outputs object to the `playback` info endpoint example, for when short-form MP4 is merged.
