### PR TITLE
Add note on IPFS HTTP subdomain gateway URLs

### DIFF
--- a/pages/guides/developing/dstorage-playback.en-US.mdx
+++ b/pages/guides/developing/dstorage-playback.en-US.mdx
@@ -52,7 +52,7 @@ function App() {
 
 Now that our providers are set up, we can add a text input for an IPFS CID or an IPFS/Arweave HTTP gateway URL.
 
-Note: For IPFS HTTP gateway URLs, the Studio provider currently only supports “path style” URLs and does not support “subdomain style” URLs. The Studio provider will support both styles of URLs in a future update.
+<Callout>For IPFS HTTP gateway URLs, the Studio provider currently only supports “path style” URLs and does not support “subdomain style” URLs. The Studio provider will support both styles of URLs in a future update.</Callout>
 
 The raw input is passed to the [`Player`](/reference/livepeer-js/Player), which automatically detects if it is a valid CID and attempts
 to fetch the playback info for that CID. If the provider does not have an `Asset` with that CID, the Player will automatically attempt

--- a/pages/guides/developing/dstorage-playback.en-US.mdx
+++ b/pages/guides/developing/dstorage-playback.en-US.mdx
@@ -52,6 +52,8 @@ function App() {
 
 Now that our providers are set up, we can add a text input for an IPFS CID or an IPFS/Arweave HTTP gateway URL.
 
+Note: For IPFS HTTP gateway URLs, the Studio provider currently only supports “path style” URLs and does not support “subdomain style” URLs. The Studio provider will support both styles of URLs in a future update.
+
 The raw input is passed to the [`Player`](/reference/livepeer-js/Player), which automatically detects if it is a valid CID and attempts
 to fetch the playback info for that CID. If the provider does not have an `Asset` with that CID, the Player will automatically attempt
 to upload the CID from IPFS, and then play the transcoded content back, without any additional code on the frontend. To ensure that there is no delay in playback, we recommend uploading via `useCreateAsset` before displaying it in the player.

--- a/pages/reference/api/create-asset-via-url.en-US.mdx
+++ b/pages/reference/api/create-asset-via-url.en-US.mdx
@@ -7,6 +7,8 @@ title: Create Asset via URL
 Import a video `Asset` from an external URL through the
 `POST /api/asset/import` API.
 
+Note: For IPFS HTTP gateway URLs, the API currently only supports “path style” URLs and does not support “subdomain style” URLs. The API will support both styles of URLs in a future update.
+
 ## Request
 
 ```bash

--- a/pages/reference/api/create-asset-via-url.en-US.mdx
+++ b/pages/reference/api/create-asset-via-url.en-US.mdx
@@ -2,12 +2,14 @@
 title: Create Asset via URL
 ---
 
+import { Callout } from 'nextra-theme-docs';
+
 # Create Asset via URL
 
 Import a video `Asset` from an external URL through the
 `POST /api/asset/import` API.
 
-Note: For IPFS HTTP gateway URLs, the API currently only supports “path style” URLs and does not support “subdomain style” URLs. The API will support both styles of URLs in a future update.
+<Callout>For IPFS HTTP gateway URLs, the API currently only supports “path style” URLs and does not support “subdomain style” URLs. The API will support both styles of URLs in a future update.</Callout>
 
 ## Request
 

--- a/pages/reference/livepeer-js/Player.en-US.mdx
+++ b/pages/reference/livepeer-js/Player.en-US.mdx
@@ -579,7 +579,7 @@ function PlayerComponent() {
 
 Enables automatic upload and playback from decentralized storage providers. Currently supports IPFS CIDs and IPFS/Arweave URLs. Defaults to `true`.
 
-Note: For IPFS HTTP gateway URLs, the player currently only supports “path style” URLs and does not support “subdomain style” URLs. The player will support both styles of URLs in a future update.
+<Callout>For IPFS HTTP gateway URLs, the player currently only supports “path style” URLs and does not support “subdomain style” URLs. The player will support both styles of URLs in a future update.</Callout>
 
 If `fallback` is specified, while the URL upload is being processed in the background, the video will start non-transcoded playback immediately
 (defaulting to `w3s.link` for IPFS and `arweave.net` for Arweave). Once this finishes, the Player will switch to playing from the transcoded version

--- a/pages/reference/livepeer-js/Player.en-US.mdx
+++ b/pages/reference/livepeer-js/Player.en-US.mdx
@@ -579,6 +579,8 @@ function PlayerComponent() {
 
 Enables automatic upload and playback from decentralized storage providers. Currently supports IPFS CIDs and IPFS/Arweave URLs. Defaults to `true`.
 
+Note: For IPFS HTTP gateway URLs, the player currently only supports “path style” URLs and does not support “subdomain style” URLs. The player will support both styles of URLs in a future update.
+
 If `fallback` is specified, while the URL upload is being processed in the background, the video will start non-transcoded playback immediately
 (defaulting to `w3s.link` for IPFS and `arweave.net` for Arweave). Once this finishes, the Player will switch to playing from the transcoded version
 from the Livepeer provider. To show/hide the indicator of current upload progress, see [`showUploadingIndicator`](#showuploadingindicator).


### PR DESCRIPTION
## Description

_Concise description of proposed changes_

Until https://github.com/livepeer/catalyst-api/issues/485 is addressed, it appears that IPFS HTTP subdomain gateway URLs cannot be used as input URLs (although their "path style" equivalent gateway URLs can be used instead).

AFAICT the docs reference IPFS HTTP gateway URLs in the following areas:

- https://docs.livepeer.org/reference/api/create-asset-via-url
- https://docs.livepeer.org/guides/developing/dstorage-playback
- https://docs.livepeer.org/reference/livepeer-js/Player#autourlupload

This PR adds a note to each of the above sections saying that IPFS HTTP subdomain gateway URLs are currently not supported and will be supported in a future update. These notes can be removed once https://github.com/livepeer/catalyst-api/issues/485 is addressed.
