### PR TITLE
access-control: guide for vod access control

### DIFF
--- a/pages/guides/developing/_meta.en-US.json
+++ b/pages/guides/developing/_meta.en-US.json
@@ -47,6 +47,12 @@
     "description": "Add access control to a stream with livepeer.js",
     "href": "/guides/developing/access-control"
   },
+  "access-control-vod": {
+    "title": "VOD w/ Access Control",
+    "icon": "🔐",
+    "description": "Add access control to a vod with livepeer.js",
+    "href": "/guides/developing/access-control-vod"
+  },
   "listen-for-webhooks": {
     "title": "Listen for Webhooks",
     "icon": "📻",

--- a/pages/guides/developing/access-control-vod.en-US.mdx
+++ b/pages/guides/developing/access-control-vod.en-US.mdx
@@ -8,11 +8,6 @@ import { AccessControl } from '@components/react/examples';
 
 # VOD with Access Control
 
-Adding access control to a video on-demand only takes a few lines of code. The example below uses [`useCreateStream`](/reference/livepeer-js/hooks/useCreateStream)
-and [`useStream`](/reference/livepeer-js/hooks/useStream) to create and watch a gated livestream.
-
-<AccessControl />
-
 ## Step 1: Create an Access Control webhook handler
 
 Set up an endpoint (e.g., https://yourdomain.com/check-access) to handle the logic for granting or denying access to your VOD assets. This endpoint should accept a POST request with a JSON payload containing the access key and webhook context.

--- a/pages/guides/developing/access-control-vod.en-US.mdx
+++ b/pages/guides/developing/access-control-vod.en-US.mdx
@@ -8,15 +8,22 @@ import { AccessControl } from '@components/react/examples';
 
 # VOD with Access Control
 
-Adding access control to a video on-demand only takes a few lines of code. The example below uses useCreateAsset and a webhook to create and watch a gated video on-demand.
+Adding access control to a video on-demand only takes a few lines of code.
+The example below uses `useCreateAsset` and a webhook to create and watch a gated video on-demand.
 
-## Step 1: Create an Access Control webhook handler
+<Callout>
+  The `webhook` access control flow also works the same with Streams - this
+  example just shows it being used with Assets as a demonstration.
+</Callout>
 
-Set up an endpoint (e.g., https://yourdomain.com/check-access) to handle the logic for granting or denying access to your VOD assets. This endpoint should accept a POST request with a JSON payload containing the access key and webhook context.
+## Step 1: Create an Access Control Webhook Handler
+
+Set up an endpoint (e.g., https://yourdomain.com/api/check-access) to handle the logic for granting or denying access to your VOD assets.
+This endpoint should accept a POST request with a JSON payload containing the access key and webhook context.
 
 This is an example of a payload this endpoint would receive:
 
-```tsx
+```json filename="POST /api/check-access"
 {
   "accessKey": "your-access-key",
   "context": {
@@ -27,16 +34,18 @@ This is an example of a payload this endpoint would receive:
 }
 ```
 
-## Step 2: Register a playback.accessControl webhook
+The payload in `context` is defined by your application.
 
-Use the Livepeer Studio dashboard to create a new webhook with the type playback.accessControl and specify the URL of your access control endpoint.
+## Step 2: Register an Access Control Webhook
+
+Use the Livepeer Studio dashboard to create a new webhook with the type `playback.accessControl` and specify the URL of your access control endpoint.
 https://livepeer.studio/dashboard/developers/webhooks
 
-You can then take the id of the webhook you created and use it in the next step.
+You can then take the ID of the webhook you created and use it in the next step.
 
 ## Step 3: Create an asset with a playback policy webhook
 
-You can now create an asset with a playback policy webhook, passing the id of the webhook you created in step 2.
+You can now create an asset with a playback policy webhook, passing the ID of the webhook you created in Step 2.
 
 ```tsx
 import { useCreateAsset } from '@livepeer/react';
@@ -127,27 +136,46 @@ export const CreateAndViewAsset = () => {
 };
 ```
 
-## Step 4: Configure the player with an access key
+## Step 4: Configure the Player with an Access Key
 
-When setting up the player, append the access key to the m3u8 URL as a query parameter, like https://playback.livepeer.studio/asset/hls/abcd1234/index.m3u8?accessKey=your-access-key.
+If you are using the Livepeer.js Player, you can use the [`accessKey`](/reference/livepeer-js/Player#accesskey)
+prop to provide your custom access key, which is then passed to the webhook you created to verify that it is valid.
 
-## Step 5: Receive the webhook call from Livepeer
+```tsx
+import { Player } from '@livepeer/react';
 
-When a user attempts to access the VOD asset, Livepeer will call your access control endpoint with the access key and webhook context. Your endpoint should process the request and return a response indicating whether the stream access should be allowed or disallowed.
-Example request sent to your access control endpoint:
+export const CreateAndViewAsset = () => {
+  const accessKey = getAccessKeyForYourApplication();
+
+  return <Player playbackId={playbackId} accessKey={accessKey} />;
+};
+```
+
+If you are not using the player, you will need to manually append the access key to the m3u8 URL as a query parameter, similar to:
 
 ```
-POST ${webhook URL}
+https://playback.livepeer.studio/asset/hls/abcd1234/index.m3u8?accessKey=your-access-key
+```
+
+## Step 5: Receive the Webhook from Livepeer
+
+When a user attempts to access the VOD asset, Livepeer will call your access control endpoint with the access key and webhook context.
+Your endpoint should process the request and return a response indicating whether the stream access should be allowed or disallowed.
+
+Here is an example request sent to your access control endpoint:
+
+```json filename="POST /api/check-access"
 {
-  context: {
+  "context": {
     // Same value from the `asset.playbackPolicy.webhookContext` field
   },
-	accessKey: "<access_key> (exact value of the query string in the playbackURL)"
+  "accessKey": "<access_key>" // this is exact value of the prop passed to the Player, or the query parameter
 }
 ```
 
-In your access control endpoint, implement the logic to verify the access key and decide whether to grant access to the VOD asset. If the access is allowed, return a 2XX response. Otherwise, the playback will be disallowed.
+In your access control endpoint, implement the logic to verify the access key and decide whether to grant access to the VOD asset.
+If the access is allowed, return a `2XX` response. Otherwise, the playback will be disallowed.
 
 ## Wrap Up
 
-That's it! Access control, added. You now have a solution for gating on-demand content!
+That's it! Access control, added. You now have a solution for gating on-demand content with webhooks! This also works for streams as well.

--- a/pages/guides/developing/access-control-vod.en-US.mdx
+++ b/pages/guides/developing/access-control-vod.en-US.mdx
@@ -1,0 +1,186 @@
+---
+title: 'VOD with Access Control'
+description: 'Learn how to add access control to a VOD with livepeer.js'
+---
+
+import { Callout } from 'nextra-theme-docs';
+import { AccessControl } from '@components/react/examples';
+
+# VOD with Access Control
+
+Adding access control to a video on-demand only takes a few lines of code. The example below uses [`useCreateStream`](/reference/livepeer-js/hooks/useCreateStream)
+and [`useStream`](/reference/livepeer-js/hooks/useStream) to create and watch a gated livestream.
+
+<AccessControl />
+
+## Step 1: Create an Access Control webhook handler
+
+Set up an endpoint (e.g., https://yourdomain.com/check-access) to handle the logic for granting or denying access to your VOD assets. This endpoint should accept a POST request with a JSON payload containing the access key and webhook context.
+
+This is an example of a payload this endpoint would receive:
+
+```tsx
+{
+  "accessKey": "your-access-key",
+  "context": {
+    "assetId": "abcd1234",
+    "userId": "user5678"
+  },
+  "timestamp": 1680530722502
+}
+```
+
+## Step 2: Register a playback.accessControl webhook
+
+Use the Livepeer API to create a new webhook with the type playback.accessControl and specify the URL of your access control endpoint.
+
+```tsx
+import fetch from 'node-fetch';
+
+const createWebhook = async () => {
+  try {
+    const response = await fetch('https://livepeer.studio/api/webhook', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer XXXXXXX',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        events: ['playback.accessControl'],
+        url: 'https://yourdomain.com/check-access',
+        name: 'Token gate webhook',
+      }),
+    });
+
+    if (response.ok) {
+      console.log('Request sent successfully!');
+    } else {
+      console.log('Error sending request.');
+    }
+  } catch (error) {
+    console.error('Error:', error);
+  }
+};
+
+createWebhook();
+```
+
+You are going to receive back a JSON containing the id of the webhook.
+
+## Step 3: Create an asset with a playback policy webhook
+
+You can now create an asset with a playback policy webhook, passing the id of the webhook you created in step 2.
+
+```tsx
+import { useCreateAsset } from '@livepeer/react';
+
+import { useCallback, useState } from 'react';
+import { useDropzone } from 'react-dropzone';
+
+export const CreateAndViewAsset = () => {
+  const [video, setVideo] = useState<File | undefined>();
+  const {
+    mutate: createAsset,
+    data: asset,
+    status,
+    progress,
+    error,
+  } = useCreateAsset(
+    video
+      ? {
+          sources: [
+            {
+              name: video.name,
+              file: video,
+              playbackPolicy: {
+                type: 'webhook',
+                // This is the id of the webhook you created in step 2
+                webhookId: '<webhook_id>',
+                webhookContext: {
+                  // This is the context you want to pass to your webhook
+                  // It can be anything you want, and it will be passed back to your webhook
+                },
+              },
+            },
+          ] as const,
+        }
+      : null,
+  );
+
+  const onDrop = useCallback(async (acceptedFiles: File[]) => {
+    if (acceptedFiles && acceptedFiles.length > 0 && acceptedFiles?.[0]) {
+      setVideo(acceptedFiles[0]);
+    }
+  }, []);
+
+  const { getRootProps, getInputProps } = useDropzone({
+    accept: {
+      'video/*': ['*.mp4'],
+    },
+    maxFiles: 1,
+    onDrop,
+  });
+
+  const progressFormatted = useMemo(
+    () =>
+      progress?.[0].phase === 'failed'
+        ? 'Failed to process video.'
+        : progress?.[0].phase === 'waiting'
+        ? 'Waiting'
+        : progress?.[0].phase === 'uploading'
+        ? `Uploading: ${Math.round(progress?.[0]?.progress * 100)}%`
+        : progress?.[0].phase === 'processing'
+        ? `Processing: ${Math.round(progress?.[0].progress * 100)}%`
+        : null,
+    [progress],
+  );
+
+  return (
+    <>
+      <div {...getRootProps()}>
+        <input {...getInputProps()} />
+        <p>Drag and drop or browse files</p>
+      </div>
+
+      {createError?.message && <p>{createError.message}</p>}
+
+      {video ? <p>{video.name}</p> : <p>Select a video file to upload.</p>}
+      {progressFormatted && <p>{progressFormatted}</p>}
+
+      <button
+        onClick={() => {
+          createAsset?.();
+        }}
+        disabled={!createAsset || createStatus === 'loading'}
+      >
+        Upload
+      </button>
+    </>
+  );
+};
+```
+
+## Step 4: Configure the player with an access key
+
+When setting up the player, append the access key to the m3u8 URL as a query parameter, like https://playback.livepeer.studio/asset/hls/abcd1234/index.m3u8?accessKey=your-access-key.
+
+## Step 5: Receive the webhook call from Livepeer
+
+When a user attempts to access the VOD asset, Livepeer will call your access control endpoint with the access key and webhook context. Your endpoint should process the request and return a response indicating whether the stream access should be allowed or disallowed.
+Example request sent to your access control endpoint:
+
+```
+POST ${webhook URL}
+{
+  context: {
+    // Same value from the `asset.playbackPolicy.webhookContext` field
+  },
+	accessKey: "<access_key> (exact value of the query string in the playbackURL)"
+}
+```
+
+In your access control endpoint, implement the logic to verify the access key and decide whether to grant access to the VOD asset. If the access is allowed, return a 2XX response. Otherwise, the playback will be disallowed.
+
+## Wrap Up
+
+That's it! Access control, added. You now have a solution for gating on-demand content!

--- a/pages/guides/developing/access-control-vod.en-US.mdx
+++ b/pages/guides/developing/access-control-vod.en-US.mdx
@@ -29,40 +29,10 @@ This is an example of a payload this endpoint would receive:
 
 ## Step 2: Register a playback.accessControl webhook
 
-Use the Livepeer API to create a new webhook with the type playback.accessControl and specify the URL of your access control endpoint.
+Use the Livepeer Studio dashboard to create a new webhook with the type playback.accessControl and specify the URL of your access control endpoint.
+https://livepeer.studio/dashboard/developers/webhooks
 
-```tsx
-import fetch from 'node-fetch';
-
-const createWebhook = async () => {
-  try {
-    const response = await fetch('https://livepeer.studio/api/webhook', {
-      method: 'POST',
-      headers: {
-        Authorization: 'Bearer XXXXXXX',
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        events: ['playback.accessControl'],
-        url: 'https://yourdomain.com/check-access',
-        name: 'Token gate webhook',
-      }),
-    });
-
-    if (response.ok) {
-      console.log('Request sent successfully!');
-    } else {
-      console.log('Error sending request.');
-    }
-  } catch (error) {
-    console.error('Error:', error);
-  }
-};
-
-createWebhook();
-```
-
-You are going to receive back a JSON containing the id of the webhook.
+You can then take the id of the webhook you created and use it in the next step.
 
 ## Step 3: Create an asset with a playback policy webhook
 

--- a/pages/guides/developing/access-control-vod.en-US.mdx
+++ b/pages/guides/developing/access-control-vod.en-US.mdx
@@ -8,6 +8,8 @@ import { AccessControl } from '@components/react/examples';
 
 # VOD with Access Control
 
+Adding access control to a video on-demand only takes a few lines of code. The example below uses useCreateAsset and a webhook to create and watch a gated video on-demand.
+
 ## Step 1: Create an Access Control webhook handler
 
 Set up an endpoint (e.g., https://yourdomain.com/check-access) to handle the logic for granting or denying access to your VOD assets. This endpoint should accept a POST request with a JSON payload containing the access key and webhook context.

--- a/pages/guides/developing/access-control.en-US.mdx
+++ b/pages/guides/developing/access-control.en-US.mdx
@@ -6,7 +6,12 @@ description: 'Learn how to add access control to a stream with livepeer.js'
 import { Callout } from 'nextra-theme-docs';
 import { AccessControl } from '@components/react/examples';
 
-# VOD with Access Control
+# Stream with Access Control
+
+Adding access control to a stream only takes a few lines of code. The example below uses [`useCreateStream`](/reference/livepeer-js/hooks/useCreateStream)
+and [`useStream`](/reference/livepeer-js/hooks/useStream) to create and watch a gated livestream.
+
+<AccessControl />
 
 ## Step 1: Configuring Providers
 

--- a/pages/guides/developing/access-control.en-US.mdx
+++ b/pages/guides/developing/access-control.en-US.mdx
@@ -6,12 +6,7 @@ description: 'Learn how to add access control to a stream with livepeer.js'
 import { Callout } from 'nextra-theme-docs';
 import { AccessControl } from '@components/react/examples';
 
-# Stream with Access Control
-
-Adding access control to a stream only takes a few lines of code. The example below uses [`useCreateStream`](/reference/livepeer-js/hooks/useCreateStream)
-and [`useStream`](/reference/livepeer-js/hooks/useStream) to create and watch a gated livestream.
-
-<AccessControl />
+# VOD with Access Control
 
 ## Step 1: Configuring Providers
 

--- a/pages/reference/api/update-stream.en-US.mdx
+++ b/pages/reference/api/update-stream.en-US.mdx
@@ -73,6 +73,7 @@ A `playbackPolicy` `type` can be either:
 
 - public - No access control is applied to the stream
 - jwt - A JWT is required to playback the stream
+- webhook - A webhook is called to determine if the stream can be played back
 
 If you set your stream playback policy to JWT, you will need to sign a token with a signing key
 and put it in the playback URL to be able to playback your stream.

--- a/pages/reference/api/update-stream.en-US.mdx
+++ b/pages/reference/api/update-stream.en-US.mdx
@@ -75,8 +75,8 @@ A `playbackPolicy` `type` can be either:
 - jwt - A JWT is required to playback the stream
 - webhook - A webhook is called to determine if the stream can be played back
 
-If you set your stream playback policy to JWT, you will need to sign a token with a signing key
-and put it in the playback URL to be able to playback your stream.
+If you set your stream playback policy to JWT or webhook, you will need to sign a token with a signing key or
+get a secret (which is passed along to your webhook) and put it in the playback URL to be able to play back your stream.
 
 ### Request
 

--- a/pages/reference/livepeer-js/Player.en-US.mdx
+++ b/pages/reference/livepeer-js/Player.en-US.mdx
@@ -213,15 +213,23 @@ function PlayerComponent() {
 }
 ```
 
-### jwt
+### jwt or accessKey
 
-The JSON Web Token (JWT) used to access the media. This is used to gate content based on a playback policy.
+<Callout>
+  This section defines ways to play back a video which has a playback policy
+  applied to it. Your application can prevent playback unless the user meets
+  application-specific requirements (this can be done either with JWTs or
+  webhooks, and solves use-cases like restricting viewership to users who own an
+  NFT, have created an account on your platform, are part of a multisig, etc).
+</Callout>
+
+#### jwt
+
+The JSON Web Token (JWT) used to access media gated by a `jwt` playback policy.
+Alternatively, `accessKey` can be used for a `webhook` playback policy.
 See the [Access Control example](/guides/developing/access-control) for more details.
 
-<Callout type="warning" emoji="⚠️">
-  Currently, access control is only supported with Streams. Access control for
-  Asset playback is coming soon!
-</Callout>
+<Callout>Access control is now supported for both streams and assets!</Callout>
 
 ```tsx filename="React & React Native" {6}
 function PlayerComponent() {
@@ -230,6 +238,45 @@ function PlayerComponent() {
       title="Agent 327: Operation Barbershop"
       playbackId="f5eese9wwl88k4g8"
       jwt={jwt}
+    />
+  );
+}
+```
+
+#### accessKey
+
+The access key used to access media behind a `webhook` playback policy.
+Alternatively, `onAccessKeyRequest` can be used to return this access key in a callback.
+See the [Access Control example](/guides/developing/access-control) for more details.
+
+```tsx filename="React & React Native" {6}
+function PlayerComponent() {
+  return (
+    <Player
+      title="Agent 327: Operation Barbershop"
+      playbackId="f5eese9wwl88k4g8"
+      accessKey="access-key"
+    />
+  );
+}
+```
+
+#### onAccessKeyRequest
+
+A callback which returns the access key used to gate access to media. Similar to `accessKey` above,
+this is used to gate content based on a `webhook` playback policy. This is used instead of the `accessKey` prop, and can
+be asynchronous and accepts any Promise or simple callback which returns a string.
+See the [Access Control example](/guides/developing/access-control) for more details.
+
+```tsx filename="React & React Native" {6-8}
+function PlayerComponent() {
+  return (
+    <Player
+      title="Agent 327: Operation Barbershop"
+      playbackId="f5eese9wwl88k4g8"
+      onAccessKeyRequest={async () => {
+        return 'access-key';
+      }}
     />
   );
 }

--- a/pages/reference/livepeer-js/stream/useCreateStream.en-US.mdx
+++ b/pages/reference/livepeer-js/stream/useCreateStream.en-US.mdx
@@ -115,9 +115,10 @@ type PlaybackPolicy = {
   /**
    * The type of playback policy to apply. `jwt` requires a signed JWT for
    * playback. `public` indicates no access control will be applied (anyone
-   * with the `playbackId` can view without a JWT).
+   * with the `playbackId` can view without a JWT). `webhook` indicates that
+   * a webhook will be used to determine whether a user can view the stream.
    */
-  type: 'jwt' | 'public';
+  type: 'jwt' | 'public' | 'webhook';
 };
 ```
 

--- a/pages/reference/livepeer-js/stream/useCreateStream.en-US.mdx
+++ b/pages/reference/livepeer-js/stream/useCreateStream.en-US.mdx
@@ -114,11 +114,20 @@ Configuration for stream playback access-control policy. Defaults to `public`.
 type PlaybackPolicy = {
   /**
    * The type of playback policy to apply. `jwt` requires a signed JWT for
-   * playback. `public` indicates no access control will be applied (anyone
-   * with the `playbackId` can view without a JWT). `webhook` indicates that
-   * a webhook will be used to determine whether a user can view the stream.
+   * playback. `webhook` requires that a webhook is configured and passed during the
+   * creation of the asset. `public` indicates no
+   * access control will be applied (anyone with the `playbackId` can
+   * view without a JWT or webhook).
    */
-  type: 'jwt' | 'public' | 'webhook';
+  type: 'webhook' | 'jwt' | 'public';
+};
+
+type WebhookPlaybackPolicy<TContext extends object> = PlaybackPolicy & {
+  type: 'webhook';
+  /** The ID of the webhook which has already been created. */
+  webhookId: string;
+  /** The context which is passed to the webhook when it is called on playback. */
+  webhookContext: TContext;
 };
 ```
 

--- a/pages/reference/livepeer-js/stream/useUpdateStream.en-US.mdx
+++ b/pages/reference/livepeer-js/stream/useUpdateStream.en-US.mdx
@@ -159,10 +159,20 @@ Configuration for stream playback access-control policy. Defaults to `public`.
 type PlaybackPolicy = {
   /**
    * The type of playback policy to apply. `jwt` requires a signed JWT for
-   * playback. `public` indicates no access control will be applied (anyone
-   * with the `playbackId` can view without a JWT).
+   * playback. `webhook` requires that a webhook is configured and passed during the
+   * creation of the asset. `public` indicates no
+   * access control will be applied (anyone with the `playbackId` can
+   * view without a JWT or webhook).
    */
-  type: 'jwt' | 'public';
+  type: 'webhook' | 'jwt' | 'public';
+};
+
+type WebhookPlaybackPolicy<TContext extends object> = PlaybackPolicy & {
+  type: 'webhook';
+  /** The ID of the webhook which has already been created. */
+  webhookId: string;
+  /** The context which is passed to the webhook when it is called on playback. */
+  webhookContext: TContext;
 };
 ```
 


### PR DESCRIPTION
## Description

 New guide to add access control to video on-demand (VOD) assets using livepeer.js. The guide covers creating an access control webhook handler, registering a playback.accessControl webhook, creating an asset with a playback policy webhook, configuring the player with an access key, and receiving the webhook call from Livepeer.

Changes:

- New guide: Add Access Control to VOD (pages/guides/developing/access-control-vod.en-US.mdx)
- Add VOD w/ Access Control to _meta.en-US.json
- Remove unnecessary examples from access-control.en-US.mdx and access-control-vod.en-US.mdx
- Add short description to access-control-vod.en-US.mdx



