### PR TITLE
docs: update the child params logic and fix the wrong request body for /transcode

### DIFF
--- a/components/openapi/Parameters.tsx
+++ b/components/openapi/Parameters.tsx
@@ -19,15 +19,18 @@ interface ParametersProps {
 }
 
 const RecursiveParameters: React.FC<ParametersProps> = ({ params }) => {
-  const [showChildren, setShowChildren] = useState(false);
+  const [showChildren, setShowChildren] = useState<number | null>(null);
 
-  const toggleChildren = () => {
-    setShowChildren(!showChildren);
+  const toggleChildren = (index: number) => {
+    setShowChildren((prevIndex) => (prevIndex === index ? null : index));
   };
 
   return (
     <>
       {params?.map((param, index) => {
+        const hasChildren =
+          param.objectProperties || param?.arraySchema?.objectProperties;
+
         return (
           <div
             key={index}
@@ -42,13 +45,14 @@ const RecursiveParameters: React.FC<ParametersProps> = ({ params }) => {
                   {param.type}
                 </span>
               </p>
-              {(param.objectProperties ||
-                param?.arraySchema?.objectProperties) && (
+              {hasChildren && (
                 <button
                   className="nx-text-gray-500  rounded-full px-4 py-1 text-xs "
-                  onClick={toggleChildren}
+                  onClick={() => toggleChildren(index)}
                 >
-                  {showChildren ? 'Hide child params' : 'Show child params'}
+                  {showChildren === index
+                    ? 'Hide child params'
+                    : 'Show child params'}
                 </button>
               )}
             </div>
@@ -67,24 +71,24 @@ const RecursiveParameters: React.FC<ParametersProps> = ({ params }) => {
                 </span>
               )}
             </p>
-            {(param.objectProperties || param?.arraySchema?.objectProperties) &&
-              showChildren && (
-                <div className="m-3 border p-3 border-gray-200 rounded-lg dark:border-neutral-700">
-                  <p className="mb-2 text-sm font-semibold">Child parameters</p>
-                  <RecursiveParameters
-                    params={
-                      param.objectProperties ||
-                      param.arraySchema?.objectProperties
-                    }
-                  />
-                </div>
-              )}
+            {hasChildren && showChildren === index && (
+              <div className="m-3 border p-3 border-gray-200 rounded-lg dark:border-neutral-700">
+                <p className="mb-2 text-sm font-semibold">Child parameters</p>
+                <RecursiveParameters
+                  params={
+                    param.objectProperties ||
+                    param.arraySchema?.objectProperties
+                  }
+                />
+              </div>
+            )}
           </div>
         );
       })}
     </>
   );
 };
+
 
 const Parameters: React.FC<ParametersProps> = ({ params }) => {
   return (

--- a/components/openapi/Parameters.tsx
+++ b/components/openapi/Parameters.tsx
@@ -89,7 +89,6 @@ const RecursiveParameters: React.FC<ParametersProps> = ({ params }) => {
   );
 };
 
-
 const Parameters: React.FC<ParametersProps> = ({ params }) => {
   return (
     <div className="mt-6">

--- a/hooks/openapi/useRequestParameters.tsx
+++ b/hooks/openapi/useRequestParameters.tsx
@@ -129,18 +129,17 @@ export function useRequestParameters(
 
       if (parameterSchema?.type === 'object' && parameterSchema?.properties) {
         info.object = true;
-        info.objectProperties = Object.entries(parameterSchema.properties).map(
-          ([property, propertySchema]: [
-            property: string,
-            propertySchema: any,
-          ]) => {
+        info.objectProperties = Object.entries(parameterSchema.properties)
+          .filter(([property, propertySchema]: [string, any]) => {
+            return !propertySchema.readOnly; // Filter out readOnly properties
+          })
+          .map(([property, propertySchema]: [string, any]) => {
             const resolvedSchema = propertySchema.$ref
               ? resolveRef(propertySchema.$ref)
               : propertySchema;
             resolvedSchema.property = property;
             return extractParameterInfo(resolvedSchema);
-          },
-        );
+          });
       }
 
       return info;


### PR DESCRIPTION
## Description

- Previously, whenever a user clicked on the "open child params" button, it would expand all the child parameters, causing a messy display. Now only the clicked parameter's child parameters are expanded

- Also, fixed the wrong request body for /transcode