### PR TITLE
docs: add a section about authentication in api references

### DIFF
--- a/components/APIReferences.tsx
+++ b/components/APIReferences.tsx
@@ -4,6 +4,8 @@ import { OpenAPIV3_1 } from 'openapi-types';
 
 import React from 'react';
 
+import Authentication from './openapi/Authentication';
+
 import Endpoint from './openapi/Endpoint';
 
 import Pre from './openapi/shared/Pre';
@@ -84,6 +86,7 @@ const APIReference: React.FC<APIReferenceProps> = ({ openApiData }) => {
       {openApiData && (
         <>
           {renderGettingStarted()}
+          <Authentication />
           {renderEndpoints()}
         </>
       )}

--- a/components/openapi/Authentication.tsx
+++ b/components/openapi/Authentication.tsx
@@ -3,6 +3,7 @@ import { Code } from 'nextra/components';
 import React from 'react';
 
 import Pre from './shared/Pre';
+import Link from 'next/link';
 
 const Authentication: React.FC = () => {
   return (
@@ -14,18 +15,38 @@ const Authentication: React.FC = () => {
         <div className=" lg:w-1/2">
           <h2 className="font-medium text-2xl">Authentication</h2>
           <p className="mt-4">
-            Livepeer API uses API keys to verify and authorize requests. You can
-            manage and review your API keys through Livepeer Studio.
-            <br /> <br />
-            You need to pass your API key in the header with <Code>
-              Bearer
-            </Code>{' '}
-            prefix while sending a request
-            <br /> <br />
+            Livepeer API uses API keys (
+            <Link
+              href={
+                'https://swagger.io/docs/specification/authentication/bearer-authentication/'
+              }
+              className="dark:text-green-400 text-blue-500"
+            >
+              Bearer Authentication
+            </Link>
+            ) to verify and authorize requests. You can manage and review your
+            API keys through Livepeer Studio. You need to pass your API key in
+            the header with <Code>Bearer</Code> prefix while sending a request
+          </p>
+          <p className="mt-4">
             It's important to note that your API keys come with significant
             privileges, so it's essential to keep them safe and secure! Refrain
             from sharing your secret API keys in GitHub or other publicly
             accessible places
+          </p>
+          <p className="mt-4">
+            By default, API keys can only be used from a backend server. This is
+            to ensure maximum security and prevent that you accidentally expose
+            your account by including the secret API key in some public web
+            page. More info about enabling CORS can be found{' '}
+            <Link
+              className="dark:text-green-400 text-blue-500"
+              href={
+                'https://docs.livepeer.org/guides/developing/quickstart.en-US#enable-cors-optional'
+              }
+            >
+              here.
+            </Link>
           </p>
         </div>
         <div className="mt-2 lg:w-2/5 lg:ml-20">

--- a/components/openapi/Authentication.tsx
+++ b/components/openapi/Authentication.tsx
@@ -20,7 +20,7 @@ const Authentication: React.FC = () => {
             You need to pass your API key in the header with <Code>
               Bearer
             </Code>{' '}
-            prefex while sending a request
+            prefix while sending a request
             <br /> <br />
             It's important to note that your API keys come with significant
             privileges, so it's essential to keep them safe and secure! Refrain

--- a/components/openapi/Authentication.tsx
+++ b/components/openapi/Authentication.tsx
@@ -1,0 +1,39 @@
+import { Code } from 'nextra/components';
+
+import React from 'react';
+
+import Pre from './shared/Pre';
+
+const Authentication: React.FC = () => {
+  return (
+    <div
+      id={'authentication'}
+      className="border-t py-14 border-gray-200 dark:border-zinc-800"
+    >
+      <div className="flex flex-col lg:flex-row">
+        <div className=" lg:w-1/2">
+          <h2 className="font-medium text-2xl">Authentication</h2>
+          <p className="mt-4">
+            Livepeer API uses API keys to verify and authorize requests. You can
+            manage and review your API keys through Livepeer Studio.
+            <br /> <br />
+            You need to pass your API key in the header with <Code>
+              Bearer
+            </Code>{' '}
+            prefex while sending a request
+            <br /> <br />
+            It's important to note that your API keys come with significant
+            privileges, so it's essential to keep them safe and secure! Refrain
+            from sharing your secret API keys in GitHub or other publicly
+            accessible places
+          </p>
+        </div>
+        <div className="mt-2 lg:w-2/5 lg:ml-20">
+          <Pre filename="Your API Key">Authorization: Bearer API_KEY</Pre>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Authentication;

--- a/components/openapi/Authentication.tsx
+++ b/components/openapi/Authentication.tsx
@@ -1,9 +1,10 @@
+import Link from 'next/link';
+
 import { Code } from 'nextra/components';
 
 import React from 'react';
 
 import Pre from './shared/Pre';
-import Link from 'next/link';
 
 const Authentication: React.FC = () => {
   return (

--- a/generate-api-reference.js
+++ b/generate-api-reference.js
@@ -16,7 +16,12 @@ async function fetchAPISchema() {
 }
 
 function generateJSONOutput(schema) {
-  const jsonOutput = {};
+  const jsonOutput = {
+    authentication: {
+      title: 'Authentication',
+      href: `/reference/api/#authentication`,
+    },
+  };
 
   for (const path in schema.paths) {
     const methods = schema.paths[path];


### PR DESCRIPTION
## Description

Added new section in API references about authentications and api keys

<img width="1443" alt="image" src="https://github.com/livepeer/docs/assets/56798748/c3996261-32c2-4f60-af38-b953faf277aa">
