### PR TITLE
docs: add syntax highlighter to code blocks (api references)

### DIFF
--- a/components/openapi/Request.tsx
+++ b/components/openapi/Request.tsx
@@ -23,7 +23,6 @@ const Request: React.FC<RequestProps> = ({
 
   return (
     <Pre
-      dark
       method={method}
       filename={path}
       fromRequest={true}

--- a/components/openapi/Response.tsx
+++ b/components/openapi/Response.tsx
@@ -13,7 +13,11 @@ const Response: React.FC<ResponseProps> = ({ response }) => {
     : JSON.stringify(response, null, 2);
 
   return (
-    <Pre className={is204Response ? 'italic' : ''} filename={`RESPONSE`}>
+    <Pre
+      className={is204Response ? 'italic' : ''}
+      filename={`RESPONSE`}
+      language="json"
+    >
       {formattedResponse}
     </Pre>
   );

--- a/components/openapi/shared/Pre.tsx
+++ b/components/openapi/shared/Pre.tsx
@@ -14,7 +14,14 @@ import 'prismjs/components/prism-java';
 
 import 'prismjs/components/prism-go';
 
+import 'prismjs/components/prism-markup-templating';
+
+import 'prismjs/components/prism-php';
+
 import 'prismjs/components/prism-bash';
+
+import 'prismjs/components/prism-csharp';
+
 import type { ComponentProps, ReactElement, RefObject } from 'react';
 
 import { useEffect, useRef, useState } from 'react';
@@ -128,6 +135,8 @@ const Pre = ({
           filename ? 'nx-pt-12 nx-pb-4' : 'nx-py-4',
           selectedLanguage && selectedLanguage == 'cURL'
             ? `language-bash`
+            : selectedLanguage == '.NET'
+            ? 'language-csharp'
             : `language-${selectedLanguage}`,
           className,
         )}

--- a/components/openapi/shared/Pre.tsx
+++ b/components/openapi/shared/Pre.tsx
@@ -1,29 +1,44 @@
 import cn from 'clsx';
 
+import Prism from 'prismjs';
+
+import 'prismjs/components/prism-javascript';
+
+import 'prismjs/components/prism-ruby';
+
+import 'prismjs/components/prism-python';
+
+import 'prismjs/components/prism-json';
+
+import 'prismjs/components/prism-java';
+
+import 'prismjs/components/prism-go';
+
+import 'prismjs/components/prism-bash';
 import type { ComponentProps, ReactElement, RefObject } from 'react';
 
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 interface PreProps extends ComponentProps<'pre'> {
   filename?: string;
-  dark?: boolean;
   method?: string;
   fromRequest?: boolean;
   requestSamples?: { languageName: string; request: string }[];
+  language?: string;
 }
 
 const Pre = ({
   children,
   className,
   filename,
-  dark,
   method,
   fromRequest,
   requestSamples,
+  language,
   ...props
 }: PreProps): ReactElement => {
   const preRef: RefObject<HTMLPreElement> = useRef(null);
-  const [selectedLanguage, setSelectedLanguage] = useState('');
+  const [selectedLanguage, setSelectedLanguage] = useState(language);
 
   const getFilenameSection = () => {
     if (!filename) {
@@ -33,7 +48,7 @@ const Pre = ({
     return (
       <div
         className={cn(
-          dark ? 'text-white' : 'nx-text-gray-700 dark:nx-text-gray-200',
+          'nx-text-gray-700 dark:nx-text-gray-200',
           'nx-absolute nx-top-0 nx-z-[1] nx-w-full nx-truncate nx-rounded-t-xl nx-bg-primary-700/5 nx-py-2 nx-px-4 nx-text-xs dark:nx-bg-primary-300/10 flex flex-row justify-between',
         )}
       >
@@ -97,15 +112,23 @@ const Pre = ({
     return children;
   };
 
+  useEffect(() => {
+    if (preRef.current) {
+      Prism.highlightElement(preRef.current);
+    }
+  }, [children, selectedLanguage]);
+
   return (
     <div className="nextra-code-block nx-relative nx-mt-6 first:nx-mt-0">
       {getFilenameSection()}
       <pre
         className={cn(
-          'nx-mb-4 nx-overflow-x-auto nx-rounded-xl nx-font-medium nx-subpixel-antialiased dark:nx-bg-primary-300/10 nx-text-[.9em]',
+          'nx-mb-4 nx-overflow-x-auto nx-rounded-xl nx-font-medium nx-subpixel-antialiased dark:nx-bg-primary-300/10 nx-bg-primary-700/5 nx-text-[.9em]',
           'contrast-more:nx-border contrast-more:nx-border-primary-900/20 contrast-more:nx-contrast-150 contrast-more:dark:nx-border-primary-100/40',
           filename ? 'nx-pt-12 nx-pb-4' : 'nx-py-4',
-          dark ? 'bg-slate-800 text-gray-300' : 'nx-bg-primary-700/5',
+          selectedLanguage && selectedLanguage == 'cURL'
+            ? `language-bash`
+            : `language-${selectedLanguage}`,
           className,
         )}
         ref={preRef}

--- a/hooks/openapi/useCodeSnippets.tsx
+++ b/hooks/openapi/useCodeSnippets.tsx
@@ -304,6 +304,11 @@ class Program
     });
 
     snippets.push({
+      languageName: 'PHP',
+      request: generatePhpSnippet(),
+    });
+
+    snippets.push({
       languageName: 'Java',
       request: generateJavaSnippet(),
     });
@@ -316,6 +321,11 @@ class Program
     snippets.push({
       languageName: 'Go',
       request: generateGoSnippet(),
+    });
+
+    snippets.push({
+      languageName: '.NET',
+      request: generateDotNetSnippet(),
     });
 
     setCodeSnippets(snippets);

--- a/hooks/openapi/useCodeSnippets.tsx
+++ b/hooks/openapi/useCodeSnippets.tsx
@@ -19,8 +19,9 @@ function useCodeSnippets(
       // Generate cURL command
       const requestBody = constructRequestBody(params);
 
-      const curlCommand = `curl -X ${method.toUpperCase()} -H 'content-type: application/json' -d '${requestBody}' ${baseUrl ? baseUrl + path : path
-        }`;
+      const curlCommand = `curl -X ${method.toUpperCase()} -H 'content-type: application/json' -d '${requestBody}' ${
+        baseUrl ? baseUrl + path : path
+      }`;
       return curlCommand;
     };
 
@@ -33,8 +34,9 @@ require 'uri'
 url = URI.parse('${baseUrl ? baseUrl + path : path}')
 http = Net::HTTP.new(url.host, url.port)
 
-request = Net::HTTP::${method.charAt(0).toUpperCase() + method.slice(1)
-        }(url.path)
+request = Net::HTTP::${
+        method.charAt(0).toUpperCase() + method.slice(1)
+      }(url.path)
 request.add_field('Content-Type', 'application/json')
 request.body = '${requestBody}'
 
@@ -302,28 +304,18 @@ class Program
     });
 
     snippets.push({
-      languageName: 'PHP',
-      request: generatePhpSnippet(),
-    });
-
-    snippets.push({
       languageName: 'Java',
       request: generateJavaSnippet(),
     });
 
     snippets.push({
-      languageName: 'Node.js',
+      languageName: 'JavaScript',
       request: generateNodejsSnippet(),
     });
 
     snippets.push({
       languageName: 'Go',
       request: generateGoSnippet(),
-    });
-
-    snippets.push({
-      languageName: '.NET',
-      request: generateDotNetSnippet(),
     });
 
     setCodeSnippets(snippets);

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "nextra": "^2.7.0",
     "nextra-theme-docs": "^2.7.0",
     "openapi-types": "^12.1.3",
+    "prismjs": "^1.29.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-dropzone": "^14.2.3",
@@ -37,6 +38,7 @@
     "redoc": "^2.0.0",
     "remark-gfm": "^3.0.1",
     "sharp": "^0.31.3",
+    "shiki": "^0.14.3",
     "styled-components": "^5.3.10",
     "video.js": "^7.21.1",
     "wagmi": "^0.10.15"
@@ -47,6 +49,7 @@
     "@preconstruct/next": "^4.0.0",
     "@types/formidable": "^2.0.5",
     "@types/node": "^18.11.18",
+    "@types/prismjs": "^1.26.0",
     "@types/react": "^18.0.27",
     "@types/react-dom": "^18.0.10",
     "@types/video.js": "^7.3.50",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -8,6 +8,8 @@ import * as React from 'react';
 
 import { Providers } from '../components/core';
 
+import '../styles/prism.css';
+
 import '../styles/globals.css';
 
 import * as gtag from '../lib/gtag';

--- a/pages/reference/_meta.en-US.json
+++ b/pages/reference/_meta.en-US.json
@@ -6,10 +6,11 @@
     "title": "Livepeer.js"
   },
   "api": {
-    "title": "API Reference", 
+    "title": "API Reference",
     "theme": {
       "breadcrumb": false,
-      "toc": false
+      "toc": false,
+      "layout": "full"
     }
   },
   "go-livepeer": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ dependencies:
   openapi-types:
     specifier: ^12.1.3
     version: 12.1.3
+  prismjs:
+    specifier: ^1.29.0
+    version: 1.29.0
   react:
     specifier: ^18.2.0
     version: 18.2.0
@@ -89,6 +92,9 @@ dependencies:
   sharp:
     specifier: ^0.31.3
     version: 0.31.3
+  shiki:
+    specifier: ^0.14.3
+    version: 0.14.3
   styled-components:
     specifier: ^5.3.10
     version: 5.3.11(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
@@ -115,6 +121,9 @@ devDependencies:
   '@types/node':
     specifier: ^18.11.18
     version: 18.14.4
+  '@types/prismjs':
+    specifier: ^1.26.0
+    version: 1.26.0
   '@types/react':
     specifier: ^18.0.27
     version: 18.0.28
@@ -1737,7 +1746,7 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.22.6
       '@radix-ui/react-visually-hidden': 1.0.1(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -1749,7 +1758,7 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.22.6
       '@radix-ui/primitive': 1.0.0
       '@radix-ui/react-collapsible': 1.0.0(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-collection': 1.0.0(react-dom@18.2.0)(react@18.2.0)
@@ -1768,7 +1777,7 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.22.6
       '@radix-ui/primitive': 1.0.0
       '@radix-ui/react-compose-refs': 1.0.0(react@18.2.0)
       '@radix-ui/react-context': 1.0.0(react@18.2.0)
@@ -1832,7 +1841,7 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.22.6
       '@radix-ui/react-primitive': 1.0.0(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -1844,7 +1853,7 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.22.6
       '@radix-ui/react-context': 1.0.0(react@18.2.0)
       '@radix-ui/react-primitive': 1.0.0(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-use-callback-ref': 1.0.0(react@18.2.0)
@@ -1859,7 +1868,7 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.22.6
       '@radix-ui/primitive': 1.0.0
       '@radix-ui/react-compose-refs': 1.0.0(react@18.2.0)
       '@radix-ui/react-context': 1.0.0(react@18.2.0)
@@ -1898,7 +1907,7 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.22.6
       '@radix-ui/primitive': 1.0.0
       '@radix-ui/react-compose-refs': 1.0.0(react@18.2.0)
       '@radix-ui/react-context': 1.0.0(react@18.2.0)
@@ -1994,7 +2003,7 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.22.6
       '@radix-ui/primitive': 1.0.0
       '@radix-ui/react-context': 1.0.0(react@18.2.0)
       '@radix-ui/react-menu': 1.0.0(@types/react@18.0.28)(react-dom@18.2.0)(react@18.2.0)
@@ -2036,7 +2045,7 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.22.6
       '@radix-ui/primitive': 1.0.0
       '@radix-ui/react-compose-refs': 1.0.0(react@18.2.0)
       '@radix-ui/react-context': 1.0.0(react@18.2.0)
@@ -2177,7 +2186,7 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.22.6
       '@radix-ui/primitive': 1.0.0
       '@radix-ui/react-compose-refs': 1.0.0(react@18.2.0)
       '@radix-ui/react-context': 1.0.0(react@18.2.0)
@@ -2271,7 +2280,7 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.22.6
       '@radix-ui/primitive': 1.0.0
       '@radix-ui/react-compose-refs': 1.0.0(react@18.2.0)
       '@radix-ui/react-context': 1.0.0(react@18.2.0)
@@ -2326,7 +2335,7 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.22.6
       '@radix-ui/react-compose-refs': 1.0.0(react@18.2.0)
       '@radix-ui/react-context': 1.0.0(react@18.2.0)
       '@radix-ui/react-id': 1.0.0(react@18.2.0)
@@ -2341,7 +2350,7 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.22.6
       '@radix-ui/primitive': 1.0.0
       '@radix-ui/react-collection': 1.0.0(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-compose-refs': 1.0.0(react@18.2.0)
@@ -2411,7 +2420,7 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.22.6
       '@radix-ui/primitive': 1.0.0
       '@radix-ui/react-compose-refs': 1.0.0(react@18.2.0)
       '@radix-ui/react-context': 1.0.0(react@18.2.0)
@@ -2548,7 +2557,7 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.22.6
       '@radix-ui/react-primitive': 1.0.0(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -2649,7 +2658,7 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.22.6
       '@radix-ui/react-slot': 1.0.1(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -2682,7 +2691,7 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.22.6
       '@radix-ui/react-context': 1.0.0(react@18.2.0)
       '@radix-ui/react-primitive': 1.0.0(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
@@ -2695,7 +2704,7 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.22.6
       '@radix-ui/primitive': 1.0.0
       '@radix-ui/react-compose-refs': 1.0.0(react@18.2.0)
       '@radix-ui/react-context': 1.0.0(react@18.2.0)
@@ -2757,7 +2766,7 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.22.6
       '@radix-ui/number': 1.0.0
       '@radix-ui/primitive': 1.0.0
       '@radix-ui/react-compose-refs': 1.0.0(react@18.2.0)
@@ -2818,7 +2827,7 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.22.6
       '@radix-ui/react-primitive': 1.0.0(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -2830,7 +2839,7 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.22.6
       '@radix-ui/number': 1.0.0
       '@radix-ui/primitive': 1.0.0
       '@radix-ui/react-collection': 1.0.0(react-dom@18.2.0)(react@18.2.0)
@@ -2851,7 +2860,7 @@ packages:
     peerDependencies:
       react: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.22.6
       '@radix-ui/react-compose-refs': 1.0.0(react@18.2.0)
       react: 18.2.0
     dev: false
@@ -2887,7 +2896,7 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.22.6
       '@radix-ui/primitive': 1.0.0
       '@radix-ui/react-compose-refs': 1.0.0(react@18.2.0)
       '@radix-ui/react-context': 1.0.0(react@18.2.0)
@@ -2906,7 +2915,7 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.22.6
       '@radix-ui/primitive': 1.0.0
       '@radix-ui/react-context': 1.0.0(react@18.2.0)
       '@radix-ui/react-direction': 1.0.0(react@18.2.0)
@@ -2937,7 +2946,7 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.22.6
       '@radix-ui/primitive': 1.0.0
       '@radix-ui/react-primitive': 1.0.0(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-use-controllable-state': 1.0.0(react@18.2.0)
@@ -2951,7 +2960,7 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.22.6
       '@radix-ui/primitive': 1.0.0
       '@radix-ui/react-compose-refs': 1.0.0(react@18.2.0)
       '@radix-ui/react-context': 1.0.0(react@18.2.0)
@@ -3075,7 +3084,7 @@ packages:
     peerDependencies:
       react: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.22.6
       react: 18.2.0
     dev: false
 
@@ -3705,6 +3714,10 @@ packages:
 
   /@types/parse-json@4.0.0:
     resolution: {integrity: sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==}
+    dev: true
+
+  /@types/prismjs@1.26.0:
+    resolution: {integrity: sha512-ZTaqn/qSqUuAq1YwvOFQfVW1AR/oQJlLSZVustdjwI+GZ8kr0MSHBj0tsXPW1EqHubx50gtBEjbPGsdZwQwCjQ==}
     dev: true
 
   /@types/prop-types@15.7.5:
@@ -10296,7 +10309,7 @@ packages:
       react: '>=16.6.0'
       react-dom: '>=16.6.0'
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.22.6
       dom-helpers: 5.2.1
       loose-envify: 1.4.0
       prop-types: 15.8.1

--- a/styles/prism.css
+++ b/styles/prism.css
@@ -1,0 +1,74 @@
+.comment,
+.prolog,
+.doctype,
+.cdata {
+  color: var(--shiki-token-comment);
+}
+
+.punctuation {
+  color: var(--shiki-token-punctuation);
+}
+
+.namespace {
+  opacity: 0.7;
+}
+
+.property,
+.tag,
+.constant,
+.symbol,
+.deleted {
+  color: var(--shiki-token-keyword);
+}
+
+.boolean,
+.number {
+  color: var(--shiki-token-constant);
+}
+
+.selector,
+.attr-name,
+.string,
+.char,
+.builtin,
+.inserted {
+  color: var(--shiki-token-string);
+}
+
+.operator,
+.entity,
+.url,
+.language-css .string,
+.style .string,
+.variable {
+  color: var(--shiki-token-text);
+}
+
+.atrule,
+.attr-value,
+.function,
+.class-name {
+  color: var(--shiki-token-function);
+}
+
+.keyword {
+  color: var(--shiki-token-keyword);
+}
+
+.regex,
+.important {
+  color: var(--shiki-token-parameter);
+}
+
+.important,
+.bold {
+  font-weight: bold;
+}
+
+.italic {
+  font-style: italic;
+}
+
+.entity {
+  cursor: help;
+}


### PR DESCRIPTION
## Description

Added syntax highlighter to the `Pre` component in the API references page. I've used [Prism](https://github.com/PrismJS/prism) with a custom theme and colors from [Shiki](https://github.com/shikijs/shiki), which is the same colors used by Nextra, ensuring consistency across all code blocks throughout the docs.

Examples:
<img width="500" src="https://github.com/livepeer/docs/assets/56798748/3cbf6e80-a71a-4cf1-999c-d64d6aad008e">

<img width="500" src="https://github.com/livepeer/docs/assets/56798748/679d26bd-f262-4c6f-ae6d-9a811d59901d">

