### PR TITLE
webrtc: fix vanilla WHIP example

### DIFF
--- a/pages/guides/developing/stream-via-browser.en-US.mdx
+++ b/pages/guides/developing/stream-via-browser.en-US.mdx
@@ -168,7 +168,33 @@ const iceServers = [
   },
 ];
 
+// get user media from the browser (which are camera/audio sources)
+const mediaStream = await navigator.mediaDevices.getUserMedia({
+  video: true,
+  audio: true,
+});
+
 const peerConnection = new RTCPeerConnection({ iceServers });
+
+// set the media stream on the video element
+element.srcObject = mediaStream;
+
+const newVideoTrack = mediaStream?.getVideoTracks?.()?.[0] ?? null;
+const newAudioTrack = mediaStream?.getAudioTracks?.()?.[0] ?? null;
+
+if (newVideoTrack) {
+  videoTransceiver =
+    peerConnection?.addTransceiver(newVideoTrack, {
+      direction: "sendonly",
+    }) ?? null;
+}
+
+if (newAudioTrack) {
+  audioTransceiver =
+    peerConnection?.addTransceiver(newAudioTrack, {
+      direction: "sendonly",
+    }) ?? null;
+}
 
 /**
  * https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/createOffer
@@ -179,7 +205,7 @@ const offer = await peerConnection.createOffer();
 await peerConnection.setLocalDescription(offer);
 
 /** Wait for ICE gathering to complete */
-const ofr = await new Promise<RTCSessionDescription | null>((resolve) => {
+const ofr = await new Promise((resolve) => {
   /** Wait at most five seconds for ICE gathering. */
   setTimeout(() => {
     resolve(peerConnection.localDescription);
@@ -212,18 +238,6 @@ if (sdpResponse.ok) {
     new RTCSessionDescription({ type: 'answer', sdp: answerSDP }),
   );
 }
-
-// get user media from the browser (which are camera/audio sources)
-const mediaStream = await navigator.mediaDevices.getUserMedia({
-  video: true,
-  audio: true,
-});
-// add the tracks to the peer connection
-for (const track of mediaStream.getTracks()) {
-  peerConnection.addTrack(track);
-}
-// set the media stream on the video element
-element.srcObject = mediaStream;
 ```
 
 We just negotiated following the WHIP spec (which outlines the structure for the POST requests seen above)


### PR DESCRIPTION
## Description

The previous example added the media streams after negotiating. That doesn't work, they need to be added earlier.

Adapted from a quick example I put together that I'll preserve here I guess:
```html
<!DOCTYPE html>
<html lang="en">
  <head>
    <meta charset="UTF-8" />
    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
    <title>WebRTC Demo</title>
    <script>
      const fetchServer = async (entryUrl) => {
        const res = await fetch(entryUrl);
        return res.url;
      };
      const start = async () => {
        // the redirect URL from the above GET request
        const entryUrl = `https://livepeer.studio/webrtc/STREAM-KEY`;

        const redirectUrl = await fetchServer(entryUrl);
        // we use the host from the redirect URL in the ICE server configuration
        const host = new URL(redirectUrl).host;

        const iceServers = [
          {
            urls: `stun:${host}`,
          },
          {
            urls: `turn:${host}`,
            username: "livepeer",
            credential: "livepeer",
          },
        ];

        const peerConnection = new RTCPeerConnection({ iceServers });

        // get user media from the browser (which are camera/audio sources)
        const mediaStream = await navigator.mediaDevices.getUserMedia({
          video: true,
          audio: true,
        });

        const element = document.querySelector("video");
        element.srcObject = mediaStream;

        const newVideoTrack = mediaStream?.getVideoTracks?.()?.[0] ?? null;
        const newAudioTrack = mediaStream?.getAudioTracks?.()?.[0] ?? null;

        if (newVideoTrack) {
          videoTransceiver =
            peerConnection?.addTransceiver(newVideoTrack, {
              direction: "sendonly",
            }) ?? null;
        }

        if (newAudioTrack) {
          audioTransceiver =
            peerConnection?.addTransceiver(newAudioTrack, {
              direction: "sendonly",
            }) ?? null;
        }

        const ofrProm = new Promise((resolve) => {
          /** Wait at most five seconds for ICE gathering. */
          setTimeout(() => {
            resolve(peerConnection.localDescription);
          }, 5000);
          peerConnection.onicegatheringstatechange = (_ev) => {
            console.log(
              "onicegatheringstatechange",
              peerConnection.iceGatheringState
            );
            if (peerConnection.iceGatheringState === "complete") {
              resolve(peerConnection.localDescription);
            }
          };
        });

        peerConnection.addEventListener("connectionstatechange", (event) => {
          console.log(
            `connectionstatechange peerConnection.connectionState=${peerConnection.connectionState}`
          );
        });

        /**
         * https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/createOffer
         * We create an SDP offer here which will be shared with the server
         */
        const offer = await peerConnection.createOffer();
        /** https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/setLocalDescription */
        await peerConnection.setLocalDescription(offer);

        /** Wait for ICE gathering to complete */
        const ofr = await ofrProm;
        if (!ofr) {
          throw Error("failed to gather ICE candidates for offer");
        }

        /**
         * This response contains the server's SDP offer.
         * This specifies how the client should communicate,
         * and what kind of media client and server have negotiated to exchange.
         */
        const sdpResponse = await fetch(redirectUrl, {
          method: "POST",
          mode: "cors",
          headers: {
            "content-type": "application/sdp",
          },
          body: ofr.sdp,
        });
        if (sdpResponse.ok) {
          const answerSDP = await sdpResponse.text();
          await peerConnection.setRemoteDescription(
            new RTCSessionDescription({ type: "answer", sdp: answerSDP })
          );
        }

        // add the tracks to the peer connection
        // for (const track of mediaStream.getTracks()) {
        //   peerConnection.addTrack(track);
        // }
        // set the media stream on the video element
      };
      (async () => {
        start();
      })();
    </script>
  </head>
  <body>
    <video autoplay muted></video>
  </body>
</html>
```