### PR TITLE
docs: guides: access control section

### DIFF
--- a/developers/guides/access-control-jwt.mdx
+++ b/developers/guides/access-control-jwt.mdx
@@ -1,10 +1,11 @@
 ---
-title: "Control access to livestreams"
-description: "Learn how to add access control to a stream with livepeer.js"
+title: "Control access using JWTs"
+description: "Learn how to add access control to a content with livepeer.js, using JWTs"
 ---
 
-Adding access control to a stream only takes a few lines of code. The example below uses [`useCreateStream`](/sdks/livepeer-js/stream/useCreateStream)
-and [`useStream`](/sdks/livepeer-js/stream/useStream) to create and watch a gated livestream.
+Using JSON Web Tokens (JWTs) provides a robust way to control access to both your assets and livestreams. The JWTs can be signed and validated to ensure that only authorized users can access the content. Below are examples for both assets and livestreams.
+
+Adding access control to a content only takes a few lines of code.
 
 <Info>
   This guide is written for developers using `@livepeer/react` in a React
@@ -15,9 +16,11 @@ and [`useStream`](/sdks/livepeer-js/stream/useStream) to create and watch a gate
 
 First, we [create a new livepeer.js client and wrap the app with `LivepeerConfig`](/sdks/livepeer-js/getting-started).
 
-### Create a Gated Stream
+### Create a Gated Content
 
-We then can create our gated stream, with the stream key returned once we create it (styling has been removed for simplicity)
+- For livestreams
+
+Create your gated stream, with the stream key returned once we create it (styling has been removed for simplicity)
 
 ```tsx accessControl.tsx
 import { useCreateStream, useStream } from "@livepeer/react";
@@ -63,6 +66,32 @@ export const AccessControl = () => {
       </button>
     </div>
   );
+};
+```
+
+- For assets
+
+```tsx accessControl.tsx
+import { useCreateAsset, useAsset } from "@livepeer/react";
+
+import { useMemo, useState } from "react";
+
+export const AccessControlAssets = () => {
+  const [assetName, setAssetName] = useState<string>("");
+  const {
+    mutate: createAsset,
+    data: createdAsset,
+    status,
+  } = useCreateAsset(
+    assetName
+      ? {
+          name: assetName,
+          playbackPolicy: { type: "jwt" },
+        }
+      : null
+  );
+
+  // ... Rest of the code for managing and playing assets with JWT
 };
 ```
 
@@ -159,13 +188,13 @@ const handler = async (
 export default handler;
 ```
 
-### Stream Content
+### Configure the Player with the JWT
 
-Lastly, when the stream is created, we make a POST request to the `/api/create-signed-jwt` API route we created in the previous step
+Lastly, when the content is created, we make a POST request to the `/api/create-signed-jwt` API route we created in the previous step
 (using [React Query](https://tanstack.com/query/v4/docs/overview) to manage the mutation state handling).
-We pass along the `playbackId` for the stream, which is used to create the JWT.
+We pass along the `playbackId` for the content, which is used to create the JWT.
 
-Then, we pass the JWT to the Player using the [`jwt`](/sdks/livepeer-js/Player#jwt) prop, which will use that JWT to prove access to the streaming content!
+Then, we pass the JWT to the Player using the [`jwt`](/sdks/livepeer-js/Player#jwt) prop, which will use that JWT to prove access to the content!
 
 ```tsx access-control.tsx
 import { Player, useCreateStream, useStream } from "@livepeer/react";
@@ -265,3 +294,8 @@ export const AccessControl = () => {
   );
 };
 ```
+
+If you are not using the player, you will need to manually append the jwt to the URL as a query parameter, similar to:
+
+```
+https://playback.livepeer.studio/asset/hls/abcd1234/index.m3u8?jwt=your-jwt

--- a/developers/guides/access-control-webhooks.mdx
+++ b/developers/guides/access-control-webhooks.mdx
@@ -1,16 +1,18 @@
 ---
-title: "Control access to assets"
-description: "Learn how to add access control to an asset with livepeer.js"
+title: "Control access using webhooks"
+description: "Learn how to add access control to a content with livepeer.js, using webhooks"
 ---
 
-Adding access control to a video on-demand only takes a few lines of code.
+Webhooks offer a versatile and dynamic approach to access control for both assets and livestreams. By setting up a webhook, you can validate access requests on the fly, allowing for real-time, context-sensitive decisions.
+
+When a user requests access to content, the webhook you've specified will be called. This webhook can then decide whether to grant or deny access based on custom logic, such as user authentication, subscription status, or any other criteria.
 
 <Info>
   This guide is written for developers using `@livepeer/react` in a React
   application.
 </Info>
 
-The example below uses `useCreateAsset` and a webhook to create and watch a gated video on-demand.
+The example below uses webhook to create and watch a gated content.
 
 ### Create an Access Control Webhook Handler
 
@@ -38,11 +40,13 @@ Use the [Livepeer Studio dashboard](https://livepeer.studio/dashboard/developers
 
 You can then use the ID of the webhook in the next step.
 
-### Create an asset with a playback policy webhook
+### Create a content with a playback policy webhook
 
-You can now create an asset with a playback policy webhook, passing the ID of the webhook you created in Step 2.
+#### For assets
 
-```tsx
+Create an asset with a playback policy webhook, passing the ID of the webhook you created in Step 2.
+
+```tsx accessControl.tsx
 import { useCreateAsset } from "@livepeer/react";
 
 import { useCallback, useState, useMemo } from "react";
@@ -131,6 +135,65 @@ export const CreateAndViewAsset = () => {
 };
 ```
 
+#### For livestreams
+
+Create a stream with a playback policy webhook, passing the ID of the webhook you created in Step 2.
+
+```tsx accessControl.tsx
+import { useCreateStream, useStream } from "@livepeer/react";
+
+import { useMemo, useState } from "react";
+
+export const AccessControl = () => {
+  const [streamName, setStreamName] = useState<string>("");
+  const {
+    mutate: createStream,
+    data: createdStream,
+    status,
+  } = useCreateStream(
+    streamName
+      ? {
+          name: streamName,
+          playbackPolicy: {
+            type: "webhook",
+            // This is the id of the webhook you created in step 2
+            webhookId: "<webhook_id>",
+            webhookContext: {
+              // This is the context you want to pass to your webhook
+              // It can be anything you want, and it will be passed back to your webhook
+            },
+          }
+        }
+      : null
+  );
+
+  const { data: stream } = useStream({
+    streamId: createdStream?.id,
+    refetchInterval: (stream) => (!stream?.isActive ? 5000 : false),
+  });
+
+  const isLoading = useMemo(() => status === "loading", [status]);
+
+  return (
+    <div>
+      <input
+        placeholder="Stream Name"
+        onChange={(e) => setStreamName(e.target.value)}
+      />
+
+      <button
+        onClick={() => {
+          createStream?.();
+        }}
+        disabled={isLoading || !createStream || Boolean(stream)}
+      >
+        Create Gated Stream
+      </button>
+    </div>
+  );
+};
+```
+
 ### Configure the Player with an Access Key
 
 If you are using the Livepeer.js Player, you can use the [`accessKey`](/sdks/livepeer-js/Player#accesskey)
@@ -154,7 +217,7 @@ https://playback.livepeer.studio/asset/hls/abcd1234/index.m3u8?accessKey=your-ac
 
 ### Receive the Webhook from Livepeer
 
-When a user attempts to access the VOD asset, Livepeer will call your access control endpoint with the access key and webhook context.
+When a user attempts to access the content, Livepeer will call your access control endpoint with the access key and webhook context.
 Your endpoint should process the request and return a response indicating whether the stream access should be allowed or disallowed.
 
 Here is an example request sent to your access control endpoint:
@@ -168,5 +231,5 @@ Here is an example request sent to your access control endpoint:
 }
 ```
 
-In your access control endpoint, implement the logic to verify the access key and decide whether to grant access to the VOD asset.
+In your access control endpoint, implement the logic to verify the access key and decide whether to grant access to the content.
 If the access is allowed, return a `2XX` response. Otherwise, the playback will be disallowed.

--- a/developers/guides/overview.mdx
+++ b/developers/guides/overview.mdx
@@ -35,13 +35,6 @@ description: "Practical step-by-step guides to help you achieve a specific goal.
     Mint video assets as NFTs.
   </Card>
   <Card
-    href="/developers/guides/access-control-vod"
-    title="Control access to video assets"
-    icon="lock"
-  >
-    Manage who can view your videos.
-  </Card>
-  <Card
     href="/developers/guides/encrypted-vod"
     title="Upload encrypted files"
     icon="lock"
@@ -123,13 +116,6 @@ description: "Practical step-by-step guides to help you achieve a specific goal.
     Keep track of the livestream's health
   </Card>
   <Card
-    href="/developers/guides/access-control-stream"
-    title="Control access to livestreams"
-    icon="lock"
-  >
-    Manage who can view your livestream.
-  </Card>
-  <Card
     href="/developers/guides/listen-to-stream-events"
     title="Listen for stream events"
     icon="bell"
@@ -142,6 +128,25 @@ description: "Practical step-by-step guides to help you achieve a specific goal.
     icon="arrow-right-arrow-left"
   >
     Live stream to multiple platform at once.
+  </Card>
+</CardGroup>
+
+### Access control
+
+<CardGroup cols={2}>
+  <Card
+    href="/developers/guides/access-control-webhooks"
+    title="Control access using webhooks"
+    icon="lock"
+  >
+    Control access using webhooks
+  </Card>
+  <Card
+    href="/developers/guides/access-control-jwt"
+    title="Control access using JWTs"
+    icon="lock"
+  >
+    Control access using JWTs
   </Card>
 </CardGroup>
 

--- a/mint.json
+++ b/mint.json
@@ -117,7 +117,6 @@
             "developers/guides/upload-video-asset",
             "developers/guides/playback-an-asset",
             "developers/guides/dstorage-playback",
-            "developers/guides/access-control-asset",
             "developers/guides/listen-to-asset-events",
             "developers/guides/encrypted-asset",
             "developers/guides/mint-video-nft",
@@ -147,7 +146,6 @@
             "developers/guides/stream-via-obs",
             "developers/guides/livestream-from-browser",
             "developers/guides/monitor-stream-health",
-            "developers/guides/access-control-stream",
             "developers/guides/listen-to-stream-events",
             "developers/guides/multistream"
           ]
@@ -156,6 +154,14 @@
           "group": "Multiparticipant stream",
           "icon": "people-group",
           "pages": ["developers/guides/multiparticipant-stream"]
+        },
+        {
+          "group": "Access control",
+          "icon": "lock",
+          "pages": [
+            "developers/guides/access-control-webhooks", 
+            "developers/guides/access-control-jwt"
+          ]
         },
         {
           "group": "Webhooks",

--- a/sdks/livepeer-js/Player.mdx
+++ b/sdks/livepeer-js/Player.mdx
@@ -227,7 +227,7 @@ function PlayerComponent() {
 
 The JSON Web Token (JWT) used to access media gated by a `jwt` playback policy.
 Alternatively, `accessKey` can be used for a `webhook` playback policy.
-See the [Access Control example](/developers/guides/access-control-vod) for more details.
+See the [Access Control example](/developers/guides/access-control-jwt) for more details.
 
 <Tip>Access control is now supported for both streams and assets!</Tip>
 
@@ -247,7 +247,7 @@ function PlayerComponent() {
 
 The access key used to access media behind a `webhook` playback policy.
 Alternatively, `onAccessKeyRequest` can be used to return this access key in a callback.
-See the [Access Control example](/developers/guides/access-control-vod) for more details.
+See the [Access Control example](/developers/guides/access-control-webhooks) for more details.
 
 ```tsx
 function PlayerComponent() {
@@ -266,7 +266,7 @@ function PlayerComponent() {
 A callback which returns the access key used to gate access to media. Similar to `accessKey` above,
 this is used to gate content based on a `webhook` playback policy. This is used instead of the `accessKey` prop, and can
 be asynchronous and accepts any Promise or simple callback which returns a string.
-See the [Access Control example](/developers/guides/access-control-vod) for more details.
+See the [Access Control example](/developers/guides/access-control-webhooks) for more details.
 
 ```tsx
 function PlayerComponent() {


### PR DESCRIPTION
## Description

Proposal PR for access control docs

Proposed changes:
- Move the access control guide under a separate group
- Divide the two guides into `jwt` and `webhook` instead of `assets` and `livestreams`. This is because both type of playback policy are applicable to both type of content
- Include examples for both type of content in each guide
