### PR TITLE
docs: update livestream guide

### DIFF
--- a/developers/guides/create-livestream.mdx
+++ b/developers/guides/create-livestream.mdx
@@ -144,6 +144,19 @@ We can use the Livepeer SDK to create a stream. The example below uses the
   </Tab>
 </Tabs>
 
+You can find all the information required to broadcast to the stream in the
+[response object](/api-reference/stream/overview).
+
+The RTMP ingest URL of Livepeer Studio is `rtmp://rtmp.livepeer.com/live`, and
+the `streamKey` is present in the response object. You can use these two values
+to broadcast to the stream.
+
+<Info>
+  To learn more about other stream functions such as stopping a stream,
+  recording a stream, and more, see the [Stream
+  API](/api-reference/stream/overview).
+</Info>
+
 ### Play a Stream
 
 To learn how to play a stream, see the


### PR DESCRIPTION
Updated the livestream guide to include more information (feedback from Track Tennis team)

From Track Tennis:
```
 'Create a livestream' tutorial looks incomplete. It jumps from stream creation directly to stream playing.
  Since developers are often 'documentation first' people, it would be great to also see here:

* how to start/stop the stream on livepeer side
* how to construct RTMP ingest link (it was hard for me to find this, it's completely missing in docs)
```