### PR TITLE
docs: Update introduction.mdx

### DIFF
--- a/developers/introduction.mdx
+++ b/developers/introduction.mdx
@@ -32,7 +32,7 @@ platforms, and viewers a choice in their experience.
 <CardGroup cols={3}>
   <Card title="JavaScript" icon="js" href="/sdks/javascript">
     Seamlessly integrate video streaming and asset playback in your JavaScript
-    app
+    app.
   </Card>
   <Card title="React & React Native" icon="react" href="/sdks/livepeer-react">
     Seamlessly integrate video streaming and asset playback in your React app.


### PR DESCRIPTION
# Why

Currently, the first card under [Explore Livepeer SDKs](https://docs.livepeer.org/developers/introduction#explore-the-livepeer-sdks) is missing a period at the end of the sentence. This PR fixes it.