### PR TITLE
docs: grouped the apis by category

### DIFF
--- a/api-reference/stream/create.mdx
+++ b/api-reference/stream/create.mdx
@@ -1,4 +1,4 @@
 ---
-title: "Create a stream"
+title: "Create a livestream"
 openapi: "POST /stream"
 ---

--- a/api-reference/stream/delete.mdx
+++ b/api-reference/stream/delete.mdx
@@ -1,4 +1,4 @@
 ---
-title: "Delete a stream"
+title: "Delete a livestream"
 openapi: "DELETE /stream/{id}"
 ---

--- a/api-reference/stream/get-all.mdx
+++ b/api-reference/stream/get-all.mdx
@@ -1,4 +1,4 @@
 ---
-title: "Retrieve all streams"
+title: "Retrieve all livestreams"
 openapi: "GET /stream"
 ---

--- a/api-reference/stream/get-clip.mdx
+++ b/api-reference/stream/get-clip.mdx
@@ -1,4 +1,4 @@
 ---
-title: "Retrieve clips of a livestream"
+title: "Retrieve clips of a Livestream"
 openapi: "GET /stream/{id}/clips"
 ---

--- a/api-reference/stream/get-clip.mdx
+++ b/api-reference/stream/get-clip.mdx
@@ -1,4 +1,4 @@
 ---
-title: "Retrieve clips of a Livestream"
+title: "Retrieve clips of a livestream"
 openapi: "GET /stream/{id}/clips"
 ---

--- a/api-reference/stream/get.mdx
+++ b/api-reference/stream/get.mdx
@@ -1,4 +1,4 @@
 ---
-title: "Retrieve a stream"
+title: "Retrieve a livestream"
 openapi: "GET /stream/{id}"
 ---

--- a/api-reference/stream/overview.mdx
+++ b/api-reference/stream/overview.mdx
@@ -1,6 +1,6 @@
 ---
 description:
-  "The Streams API is used to create, retrieve, update, delete stream object
+  "The Livestream API is used to create, retrieve, update, delete stream object
   from pipeline."
 ---
 

--- a/api-reference/stream/terminate.mdx
+++ b/api-reference/stream/terminate.mdx
@@ -1,4 +1,4 @@
 ---
-title: "Terminates a  stream"
+title: "Terminates a livestream"
 openapi: "DELETE /stream/{id}/terminate"
 ---

--- a/api-reference/stream/update.mdx
+++ b/api-reference/stream/update.mdx
@@ -1,4 +1,4 @@
 ---
-title: "Update a stream"
+title: "Update a livestream"
 openapi: "PATCH /stream/{id}"
 ---

--- a/mint.json
+++ b/mint.json
@@ -372,7 +372,11 @@
   "navigation": [
     {
       "group": "Getting Started",
-      "pages": ["developers/introduction", "developers/quick-start", "developers/livepeer-studio-cli"]
+      "pages": [
+        "developers/introduction",
+        "developers/quick-start",
+        "developers/livepeer-studio-cli"
+      ]
     },
     {
       "group": "Guides",
@@ -607,103 +611,122 @@
       ]
     },
     {
-      "group": "Stream",
+      "group": "APIs",
       "pages": [
-        "api-reference/stream/overview",
-        "api-reference/stream/create",
-        "api-reference/stream/get",
-        "api-reference/stream/update",
-        "api-reference/stream/terminate",
-        "api-reference/stream/add-multistream-target",
-        "api-reference/stream/delete-multistream-target",
-        "api-reference/stream/delete",
-        "api-reference/stream/get-all",
-        "api-reference/stream/create-clip",
-        "api-reference/stream/get-clip"
-      ]
-    },
-    {
-      "group": "Multistream target",
-      "pages": [
-        "api-reference/multistream/overview",
-        "api-reference/multistream/create",
-        "api-reference/multistream/get",
-        "api-reference/multistream/update",
-        "api-reference/multistream/delete",
-        "api-reference/multistream/get-all"
-      ]
-    },
-    {
-      "group": "Webhook",
-      "pages": [
-        "api-reference/webhook/overview",
-        "api-reference/webhook/create",
-        "api-reference/webhook/get",
-        "api-reference/webhook/update",
-        "api-reference/webhook/delete",
-        "api-reference/webhook/get-all"
-      ]
-    },
-    {
-      "group": "Asset",
-      "pages": [
-        "api-reference/asset/overview",
-        "api-reference/asset/upload",
-        "api-reference/asset/upload-via-url",
-        "api-reference/asset/get",
-        "api-reference/asset/update",
-        "api-reference/asset/delete",
-        "api-reference/asset/get-all"
-      ]
-    },
+        {
+          "group": "Asset",
+          "icon": "video",
+          "pages": [
+            "api-reference/asset/overview",
+            "api-reference/asset/upload",
+            "api-reference/asset/upload-via-url",
+            "api-reference/asset/get",
+            "api-reference/asset/update",
+            "api-reference/asset/delete",
+            "api-reference/asset/get-all"
+          ]
+        },
+        {
+          "group": "Livestream",
+          "icon": "camera",
+          "pages": [
+            "api-reference/stream/overview",
+            "api-reference/stream/create",
+            "api-reference/stream/get",
+            "api-reference/stream/update",
+            "api-reference/stream/terminate",
+            "api-reference/stream/add-multistream-target",
+            "api-reference/stream/delete-multistream-target",
+            "api-reference/stream/delete",
+            "api-reference/stream/get-all",
+            "api-reference/stream/create-clip",
+            "api-reference/stream/get-clip"
+          ]
+        },
+        {
+          "group": "Multistream target",
+          "icon": "arrows-split-up-and-left",
+          "pages": [
+            "api-reference/multistream/overview",
+            "api-reference/multistream/create",
+            "api-reference/multistream/get",
+            "api-reference/multistream/update",
+            "api-reference/multistream/delete",
+            "api-reference/multistream/get-all"
+          ]
+        },
 
-    {
-      "group": "Session",
-      "pages": [
-        "api-reference/session/overview",
-        "api-reference/session/get",
-        "api-reference/session/get-all",
-        "api-reference/session/get-recording",
-        "api-reference/session/get-clip"
-      ]
-    },
-    {
-      "group": "Access control",
-      "pages": [
-        "api-reference/signing-key/overview",
-        "api-reference/signing-key/create",
-        "api-reference/signing-key/get",
-        "api-reference/signing-key/update",
-        "api-reference/signing-key/delete",
-        "api-reference/signing-key/get-all"
-      ]
-    },
-    {
-      "group": "Task",
-      "pages": [
-        "api-reference/task/overview",
-        "api-reference/task/get-all",
-        "api-reference/task/get"
-      ]
-    },
-    {
-      "group": "Playback",
-      "pages": ["api-reference/playback/overview", "api-reference/playback/get"]
-    },
-    {
-      "group": "Transcode",
-      "pages": [
-        "api-reference/transcode/overview",
-        "api-reference/transcode/create"
-      ]
-    },
-    {
-      "group": "Viewership",
-      "pages": [
-        "api-reference/viewership/get-viewership-metrics",
-        "api-reference/viewership/get-usage-metrics",
-        "api-reference/viewership/get-public-total-views",
-        "api-reference/viewership/get-creators-metrics"
+        {
+          "group": "Session",
+          "icon": "film",
+          "pages": [
+            "api-reference/session/overview",
+            "api-reference/session/get",
+            "api-reference/session/get-all",
+            "api-reference/session/get-recording",
+            "api-reference/session/get-clip"
+          ]
+        },
+        {
+          "group": "Access control",
+          "icon": "lock",
+          "pages": [
+            "api-reference/signing-key/overview",
+            "api-reference/signing-key/create",
+            "api-reference/signing-key/get",
+            "api-reference/signing-key/update",
+            "api-reference/signing-key/delete",
+            "api-reference/signing-key/get-all"
+          ]
+        },
+        {
+          "group": "Webhook",
+          "icon": "bell",
+          "pages": [
+            "api-reference/webhook/overview",
+            "api-reference/webhook/create",
+            "api-reference/webhook/get",
+            "api-reference/webhook/update",
+            "api-reference/webhook/delete",
+            "api-reference/webhook/get-all"
+          ]
+        },
+
+        {
+          "group": "Task",
+          "icon": "gear",
+          "pages": [
+            "api-reference/task/overview",
+            "api-reference/task/get-all",
+            "api-reference/task/get"
+          ]
+        },
+        {
+          "group": "Playback",
+          "icon": "play",
+          "pages": [
+            "api-reference/playback/overview",
+            "api-reference/playback/get"
+          ]
+        },
+        {
+          "group": "Transcode",
+          "icon": "photo-film",
+          "pages": [
+            "api-reference/transcode/overview",
+            "api-reference/transcode/create"
+          ]
+        },
+        {
+          "group": "Viewership",
+          "icon": "chart-bar",
+          "pages": [
+            "api-reference/viewership/get-viewership-metrics",
+            "api-reference/viewership/get-usage-metrics",
+            "api-reference/viewership/get-public-total-views",
+            "api-reference/viewership/get-creators-metrics"
+          ]
+        }
       ]
     }
   ],


### PR DESCRIPTION
- grouped the apis by category
- replaced the word `stream` with `livestream` on api reference because we are referencing `livestream` on guides as well