### PR TITLE
docs: add warning regarding sdk issue

### DIFF
--- a/sdks/introduction.mdx
+++ b/sdks/introduction.mdx
@@ -7,7 +7,7 @@ sidebarTitle: "Introduction"
 ---
 
 <Warning>
-We're aware that some of API request through the SDKs are not working as expected. We're working on a fix and will update the documentation once it's resolved. In the meantime, please use the REST API directly.
+We're aware that some API requests through the SDKs are not working as expected. We're working on a fix and will update the documentation once it's resolved. In the meantime, please use the REST API directly.
 </Warning>
 
 ## Server-side SDKs

--- a/sdks/introduction.mdx
+++ b/sdks/introduction.mdx
@@ -6,6 +6,10 @@ description:
 sidebarTitle: "Introduction"
 ---
 
+<Warning>
+We're aware that some of API request through the SDKs are not working as expected. We're working on a fix and will update the documentation once it's resolved. In the meantime, please use the REST API directly.
+</Warning>
+
 ## Server-side SDKs
 
 Server-side SDKs reduce the amount of work required to use the Livepeer REST


### PR DESCRIPTION
Added a warning callout to address the SDK issue regarding Studio schema. 

<img width="766" alt="image" src="https://github.com/livepeer/docs/assets/56798748/dfb94807-1b85-4f2c-ba6e-c77b9e3ecaaa">
