### PR TITLE
docs(catalyst): fix small typo

### DIFF
--- a/catalyst/introduction.mdx
+++ b/catalyst/introduction.mdx
@@ -19,7 +19,7 @@ hackers to start working on it!
   [livepeer.studio](https://livepeer.studio) when you're ready to go to
   production.
 - Bundles a fully-local offchain go-livepeer broadcaster and orchestrator, so
-  that you may test transcoding with no external dependencie.s
+  that you may test transcoding with no external dependencies.
 
 ### Current limitations:
 


### PR DESCRIPTION
This pull request fixes a minor typo on the [introduction page](https://docs.livepeer.org/catalyst/introduction) of the catalyst docs.