### PR TITLE
Fix typo in the docs regarding the instantiation of NodeJS library

### DIFF
--- a/developers/guides/create-livestream.mdx
+++ b/developers/guides/create-livestream.mdx
@@ -19,7 +19,7 @@ We can use the Livepeer SDK to create a stream. The example below uses the
 
     const apiKey = 'YOUR_API_KEY';
 
-    const livepeer = new Livepeer(apiKey);
+    const livepeer = new Livepeer({apiKey});
 
     const streamData = {
       name: "test_stream"

--- a/developers/guides/monitor-stream-health.mdx
+++ b/developers/guides/monitor-stream-health.mdx
@@ -32,7 +32,7 @@ or
     const apiKey = 'YOUR_API_KEY';
     const streamId = 'STREAM_ID';
 
-    const livepeer = new Livepeer(apiKey);
+    const livepeer = new Livepeer({apiKey});
 
     livepeer.stream.get(streamId)
       .then((response) => {
@@ -158,7 +158,7 @@ or
     const apiKey = 'YOUR_API_KEY';
     const sessionId = 'SESSION_ID';
 
-    const livepeer = new Livepeer(apiKey);
+    const livepeer = new Livepeer({apiKey});
 
     livepeer
       .session.get(sessionId)
@@ -412,7 +412,7 @@ The stream ID is the same one as used in the Livestream API.
     const apiKey = 'YOUR_API_KEY';
     const streamId = 'STREAM_ID';
 
-    const livepeer = new Livepeer(apiKey);
+    const livepeer = new Livepeer({apiKey});
 
     livepeer
       .getStreamHealth(streamId)
@@ -643,7 +643,7 @@ The stream ID is the same one used in the Livestream API.
     const apiKey = 'YOUR_API_KEY';
     const streamId = 'STREAM_ID';
 
-    const livepeer = new Livepeer(apiKey);
+    const livepeer = new Livepeer({apiKey});
 
     livepeer
       .getStreamEvents(streamId)

--- a/developers/guides/upload-video-asset.mdx
+++ b/developers/guides/upload-video-asset.mdx
@@ -34,7 +34,7 @@ We can then use Tus on the frontend to directly upload the asset to Livepeer.
     const apiKey = 'YOUR_API_KEY';
     const fileName = 'filename.mp4';
 
-    const livepeer = new Livepeer(apiKey);
+    const livepeer = new Livepeer({apiKey});
 
     const assetData = {
       name: fileName


### PR DESCRIPTION
The nodejs library constructor takes an object {apiKey: apiKey} instead of the string, fixed the typo in the docs regarding the same