### PR TITLE
Replace -broadcaster flag with -gateway in AI subnet documentation

### DIFF
--- a/ai/gateways/start-gateway.mdx
+++ b/ai/gateways/start-gateway.mdx
@@ -40,7 +40,7 @@ Please follow the steps below to start your AI Subnet Gateway node:
                     --network host \
                     livepeer/go-livepeer:ai-video \
                     -datadir ~/.lpData2 \
-                    -broadcaster \
+                    -gateway \
                     -orchAddr <ORCH_LIST> \
                     -httpAddr 0.0.0.0:8937 \
                     -v 6 \
@@ -92,7 +92,7 @@ Please follow the steps below to start your AI Subnet Gateway node:
                 ```bash
                 ./livepeer \
                     -datadir ~/.lpData2 \
-                    -broadcaster \
+                    -gateway \
                     -orchAddr <ORCH_LIST> \
                     -httpAddr 0.0.0.0:8937 \
                     -v 6 \


### PR DESCRIPTION
Docs update for https://github.com/livepeer/go-livepeer/pull/3048

Updates the AI gateway documentation to use `-gateway` instead of `-broadcaster`.