### PR TITLE
refactor: replace 'Broadcaster' with 'Gateway'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 node_modules
 .DS_Store
+
+# IDEs
+.vscode

--- a/catalyst/deploying-catalyst.mdx
+++ b/catalyst/deploying-catalyst.mdx
@@ -65,12 +65,12 @@ The easiest way to create a wallet and deposit funds is to use the go-livepeer
 node itself along with the `livepeer_cli` command-line tool. Both are
 downloadable from the
 [go-livepeer releases page on GitHub](https://github.com/livepeer/go-livepeer/releases).
-Once you have those binaries, you can boot up a temporary livepeer broadcaster
+Once you have those binaries, you can boot up a temporary livepeer gateway
 locally:
 
 ```
 ./livepeer \
-  -broadcaster \
+  -gateway \
   -network arbitrum-one-mainnet \
   -ethUrl https://ETH_RPC_PROVIDER_HERE
 ```
@@ -116,7 +116,7 @@ interface. You will be shown output something like this:
 |        LivepeerTokenFaucet Address | 0x0000000000000000000000000000000000000000 |
 | FOR REFERENCE - DO NOT SEND TOKENS |                                            |
 *------------------------------------*--------------------------------------------*
-|                Broadcaster Account | YOUR WALLET HERE                           |
+|                Gateway Account | YOUR WALLET HERE                           |
 |          YOUR WALLET FOR ETH & LPT |                                            |
 *------------------------------------*--------------------------------------------*
 |                        LPT Balance |                                     0 LPTU |
@@ -129,7 +129,7 @@ interface. You will be shown output something like this:
 *------------------------------------*--------------------------------------------*
 ```
 
-At this point you may deposit your Eth into the "Broadcaster Account" address
+At this point you may deposit your Eth into the "Gateway Account" address
 provided here. Once that transaction has posted to the Arbitrum One network, you
 can then invoke option 11: `Invoke "deposit broadcasting funds" (ETH)`. For
 example, if you intend to deposit 0.1 Eth in your deposit and 0.1 Eth in your

--- a/catalyst/introduction.mdx
+++ b/catalyst/introduction.mdx
@@ -19,7 +19,7 @@ hackers to start working on it!
   that can then transfer to the hosted version at
   [livepeer.studio](https://livepeer.studio) when you're ready to go to
   production.
-- Bundles a fully-local offchain go-livepeer broadcaster and orchestrator, so
+- Bundles a fully-local offchain go-livepeer gateway and orchestrator, so
   that you may test transcoding with no external dependencies.
 
 ### Current limitations:

--- a/developers/core-concepts/livepeer-network/orchestrators.mdx
+++ b/developers/core-concepts/livepeer-network/orchestrators.mdx
@@ -1,6 +1,6 @@
 An Orchestrator on the Livepeer network is an entity or node that facilitates
 the video processing tasks such as transcoding. Orchestrators provide their
-computational resources to assist broadcasters and developers in
+computational resources to assist gateways and developers in
 transcoding/delivering videos. By running the
 [`go-livepeer` client](https://github.com/livepeer/go-livepeer), individuals can
 join the Livepeer network as Orchestrators.

--- a/developers/guides/livestream-from-browser.mdx
+++ b/developers/guides/livestream-from-browser.mdx
@@ -251,7 +251,7 @@ the WHIP spec):
 
 <Info>
   The final HTTP DELETE is not needed for our media server, since we detect the
-  end of broadcast by the lack of incoming packets from the broadcaster.
+  end of broadcast by the lack of incoming packets from the gateway.
 </Info>
 
 ```txt WHIP Outline

--- a/developers/guides/optimize-latency-of-a-livestream.mdx
+++ b/developers/guides/optimize-latency-of-a-livestream.mdx
@@ -36,7 +36,7 @@ HLS (HTTP Live Streaming), initially developed by Apple for iOS devices, serves
 video with a series of segmented `.ts` files. It is broadly supported across
 many device types and is extremely well-optimized for serving multiple
 renditions; these characteristics position HLS as the default choice for many
-broadcasters.
+gateways.
 
 However, HLS has very high overhead and latency. Specifically, its chunked
 segment delivery means that viewers must wait for the current segment to finish

--- a/mint.json
+++ b/mint.json
@@ -227,8 +227,8 @@
       "destination": "/orchestrators/guides/migrate-from-contract-wallet"
     },
     {
-      "source": "/guides/orchestrating/broadcaster-introspection",
-      "destination": "/orchestrators/guides/broadcaster-introspection"
+      "source": "/guides/orchestrating/gateway-introspection",
+      "destination": "/orchestrators/guides/gateway-introspection"
     },
     {
       "source": "/guides/orchestrating/troubleshoot",
@@ -488,7 +488,7 @@
         "orchestrators/guides/o-t-split",
         "orchestrators/guides/migrate-to-arbitrum",
         "orchestrators/guides/migrate-from-contract-wallet",
-        "orchestrators/guides/broadcaster-introspection",
+        "orchestrators/guides/gateway-introspection",
         "orchestrators/guides/troubleshoot"
       ],
       "version": "Orchestrators"

--- a/orchestrators/guides/gateway-introspection.mdx
+++ b/orchestrators/guides/gateway-introspection.mdx
@@ -1,17 +1,17 @@
 ---
-title: Broadcaster Introspection
+title: Gateway Introspection
 icon: tower-broadcast
 ---
 
-We launched a public API to enable Broadcaster introspection. Users of the API
-will be able to review the activity inside the Livepeer Broadcaster nodes and
+We launched a public API to enable Gateway introspection. Users of the API
+will be able to review the activity inside the Livepeer Gateway nodes and
 understand the selection algorithms used to assign work to Orchestrator nodes.
 
 This is the initial release of the API, and only a few log lines have been
 enabled in the public logs. Orchestrators are encouraged to open pull requests
 to enable additional logs, which will be closely reviewed by the Livepeer team.
 Additionally, the core Livepeer team will publish more logs from Livepeer
-Broadcasters that may aid in understanding the selection algorithms.
+Gateways that may aid in understanding the selection algorithms.
 
 This API uses Grafana's Loki for log aggregation. Examples of API usage are
 provided below. For more guidance, refer to
@@ -19,7 +19,7 @@ provided below. For more guidance, refer to
 
 ### API usage
 
-- Public logs from Livepeer Broadcasters are available through the public Loki
+- Public logs from Livepeer Gateways are available through the public Loki
   instance.
 - Example queries:
 

--- a/orchestrators/guides/migrate-from-contract-wallet.mdx
+++ b/orchestrators/guides/migrate-from-contract-wallet.mdx
@@ -13,7 +13,7 @@ This guide is designed to be used in conjunction with the
 to support migrating to Arbitrum:
 
 - Orchestrators - Migrate stake and fees
-- Broadcasters - Migrate your deposit and reserve
+- Gateways - Migrate your deposit and reserve
 - Delegators - Migrate undelegated stake
 
 The migration process will transfer ownership of funds (i.e., stake) owned by

--- a/orchestrators/guides/migrate-to-arbitrum.mdx
+++ b/orchestrators/guides/migrate-to-arbitrum.mdx
@@ -246,7 +246,7 @@ used for mainnet, and it is finding a conflict on `chainId`.
    `Set orchestrator config`:
 
 To receive work, you must register your service URI and fees so that
-broadcasters can discover your orchestrator.
+gateways can discover your orchestrator.
 
 > 6a. Select the following option using `livepeer_cli`:
 

--- a/orchestrators/guides/o-t-split.mdx
+++ b/orchestrators/guides/o-t-split.mdx
@@ -61,4 +61,4 @@ The `transcoder` field indicates the IP of the connecting transcoder and the
 `capacity` field indicates the number of simultaneous transcoding jobs that the
 transcoder can handle. Once the orchestrator has at least one transcoder
 connected, it will be able to send transcoding jobs to the transcoder when it
-receives a stream from a broadcaster.
+receives a stream from a gateway.

--- a/orchestrators/guides/set-pricing.mdx
+++ b/orchestrators/guides/set-pricing.mdx
@@ -4,14 +4,14 @@ icon: tag
 ---
 
 In this guide we'll go over how to set and configure pricing to charge for
-transcoding advertised to broadcasters off-chain.
+transcoding advertised to gateways off-chain.
 
-# Setting WEI Price 
+# Setting WEI Price
 
 ## Choose a Price
 
 To charge for transcoding orchestrators set a price per pixel denominated in Wei
-(1 ETH = 1e18 Wei), advertised to broadcasters off-chain.
+(1 ETH = 1e18 Wei), advertised to gateways off-chain.
 
 To get support for setting a price that will allow you to receive work on the
 network, contact us on our [Discord](https://discord.gg/uaPhtyrWsF) channel.
@@ -86,7 +86,7 @@ To set a price in USD, one just needs to add the `USD` suffix to the value provi
 
 Given the price per pixel in USD is going to be a really low number, the recommendation is to also set the `-pixelsPerUnit` flag so a more human-friendly number can be specified on the price per unit. The `-pixelsPerUnit` acts as a denominator on the `-pricePerUnit` and the recommendation is to keep it constant over time, updating only the price per unit as seen fit.
 
-e.g.: 
+e.g.:
 
 - To set a price of **$4.10 E -13**
 
@@ -104,7 +104,7 @@ e.g.:
 
 Notice that the `-pixelsPerUnit` flag supports the exponential notation, so it’s easier to understand the value being set. The `-pricePerUnit` does not support it though, so a standard decimal notation must be used. This is also an incentive to use the `-pixelsPerUnit` value in order to keep the `-pricePerUnit` as an easily readable value.
 
-This feature is also supported by broadcasters, with the `-pixelsPerUnit` flag staying the same, while the `-maxPricePerUnit` should be set instead for the max price. The currency is specified in the same format.
+This feature is also supported by gateways, with the `-pixelsPerUnit` flag staying the same, while the `-maxPricePerUnit` should be set instead for the max price. The currency is specified in the same format.
 
 ### Advanced
 

--- a/orchestrators/guides/set-session-limits.mdx
+++ b/orchestrators/guides/set-session-limits.mdx
@@ -28,7 +28,7 @@ this guide to fine tune your configuration:
 
 The **default limit of concurrent sessions is set to 10**. When this limit is
 exceeded, the orchestrator returns an error, `OrchestratorCapped`, to the
-broadcaster and transcoders and they will stop receiving work from
+gateway and transcoders and they will stop receiving work from
 orchestrators. The session limit should then be set depending on available
 hardware and bandwidth.
 

--- a/orchestrators/guides/troubleshoot.mdx
+++ b/orchestrators/guides/troubleshoot.mdx
@@ -9,7 +9,7 @@ most common issues that a video miner might encounter.
 ## OrchestratorCapped error
 
 This error means that your orchestrator has hit its session limit so it is not
-longer accepting work from broadcasters. See the
+longer accepting work from gateways. See the
 [session limit guide](/orchestrators/guides/set-session-limits) for information
 on setting the session limit.
 
@@ -45,7 +45,7 @@ transcoding completes.
 
 These errors occur when a source video segment with certain properties that
 prevent it from being transcoded. There are no actionable steps for an operator
-in this scenario since the broadcaster is responsible for sending video segments
+in this scenario since the gateway is responsible for sending video segments
 that are supported by the Livepeer network.
 
 ## My node is still calling the reward claims function and spending gas, even though I have set `reward` to false
@@ -59,13 +59,13 @@ actions on behalf of your orchestrator if using the same wallet.
 
 ## TicketParams expired
 
-This error indicates that the broadcaster sent a payment ticket with too old
-parameters. This may be caused by the broadcaster's delay (between getting the
+This error indicates that the gateway sent a payment ticket with too old
+parameters. This may be caused by the gateway's delay (between getting the
 last orchestrator info message and sending the segment) or by the delay in
 polling chain blocks (the expiration time is measured in L1 blocks). For more
 details please check
 [TicketParams expiration time](https://github.com/livepeer/go-livepeer/issues/1343).
-There are no actionable steps for an operator, broadcaster will retry a request
+There are no actionable steps for an operator, gateway will retry a request
 with the updated ticket parameters.
 
 ## Error creating Ethereum account manager
@@ -93,7 +93,7 @@ transcoded in Livepeer.
 **What does being ‘publicly accessible’ mean? Can I run a transcoder from
 home?**
 
-Orchestrators should be reachable by broadcasters via the public IP and port
+Orchestrators should be reachable by gateways via the public IP and port
 that is set during registration. The only port that is required to be public is
 the one that was set during registration (default 8935). Be aware that there are
 many risks to running a public server. Only set up an orchestrator if you are
@@ -132,7 +132,7 @@ Some orchestrators in the past have used
 
 **What is the service URI? Does this need to be an IP?**
 
-The service registry acts as a discovery mechanism to allow broadcasters to look
+The service registry acts as a discovery mechanism to allow gateways to look
 up the addresses of orchestrators on the network. Orchestrators register their
 service URI by storing it on the blockchain. During registration you are only
 asked for your IP:port, but the URI stored on the blockchain in the form of .

--- a/references/go-livepeer/cli-reference.mdx
+++ b/references/go-livepeer/cli-reference.mdx
@@ -31,8 +31,7 @@ also contain instructions for using flags to enable certain functionality in
 - httpAddr: Address to bind for HTTP commands. No default
 
 - serviceAddr: Orchestrator only. Overrides the on-chain serviceURI that
-  broadcasters can use to contact this node; may be an IP or hostname. No
-  default
+  gateways can use to contact this node; may be an IP or hostname. No default
 
 - orchAddr: Orchestrator to connect to as a standalone transcoder. No default.
 
@@ -54,7 +53,8 @@ also contain instructions for using flags to enable certain functionality in
 
 - transcoder: Set to true to be an transcoder. Default `false`
 
-- broadcaster: Set to true to be an broadcaster. Default `false`
+- gateway: Set to true to be an gateway (formerly known as *Broadcaster*). Default
+  `false`
 
 - orchSecret: Shared secret with the orchestrator as a standalone transcoder or
   path to file
@@ -68,8 +68,8 @@ also contain instructions for using flags to enable certain functionality in
   mode only). Default `0.3`
 
 - maxSessions: Maximum number of concurrent transcoding sessions for
-  Orchestrator, maximum number or RTMP streams for Broadcaster, or maximum
-  capacity for transcoder. Default `10`
+  Orchestrator, maximum number or RTMP streams for Gateway, or maximum capacity
+  for transcoder. Default `10`
 
 - currentManifest: Expose the currently active ManifestID as
   \"/stream/current.m3u8\". Default `false`
@@ -127,15 +127,15 @@ also contain instructions for using flags to enable certain functionality in
   than 0. Error if not set.
 
 - maxPricePerUnit: The maximum transcoding price (in wei) per 'pixelsPerUnit' a
-  broadcaster is willing to accept. If not set explicitly, broadcaster is
-  willing to accept ANY price. Default `0`
+  gateway is willing to accept. If not set explicitly, gateway is willing to
+  accept ANY price. Default `0`
 
 - pixelsPerUnit: Amount of pixels per unit. Set to '> 1' to have smaller price
   granularity than 1 wei / pixel. Default `1`
 
-- pricePerBroadcaster: json list of price per broadcaster or path to json config
-  file. Example:
-  `{"broadcasters":[{"ethaddress":"address1","priceperunit":1000,"pixelsperunit":1},{"ethaddress":"address2","priceperunit":1200,"pixelsperunit":1}]}`
+- pricePerGateway: json list of price per gateway or path to json config file.
+  Example:
+  `{"gateways":[{"ethaddress":"address1","priceperunit":1000,"pixelsperunit":1},{"ethaddress":"address2","priceperunit":1200,"pixelsperunit":1}]}`
 
 - autoAdjustPrice: Enable/disable automatic price adjustments based on the
   overhead for redeeming tickets. Default `true`
@@ -166,8 +166,7 @@ also contain instructions for using flags to enable certain functionality in
 - metadataPublishTimeout: Max time (ms) to wait in background for publishing
   operation metadata events. Default `1000 (1s)`
 
-- maxFaceValue: Set the maximum face value of a ticket (in wei).  No default
-
+- maxFaceValue: Set the maximum face value of a ticket (in wei). No default
 
 ### Storage
 

--- a/references/go-livepeer/prometheus-metrics.mdx
+++ b/references/go-livepeer/prometheus-metrics.mdx
@@ -12,58 +12,58 @@ documents all metrics that you can scrape via the `/metrics` endpoint when the
 
 | Name                                                     | Description                                                                                                      | Node Type                                       |
 | -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
-| `livepeer_versions`                                      | Versions used by Livepeer node.                                                                                  | Broadcaster, Orchestrator, Transcoder, Redeemer |
-| `livepeer_segment_source_appeared_total`                 | SegmentSourceAppeared                                                                                            | Broadcaster                                     |
-| `livepeer_segment_source_emerged_total`                  | SegmentEmerged                                                                                                   | Broadcaster                                     |
-| `livepeer_segment_source_emerged_unprocessed_total`      | Raw number of segments emerged from segmenter.                                                                   | Broadcaster, Orchestrator                       |
-| `livepeer_segment_source_uploaded_total`                 | SegmentUploaded                                                                                                  | Broadcaster, Orchestrator, Transcoder           |
-| `livepeer_segment_source_upload_failed_total`            | SegmentUploadedFailed                                                                                            | Broadcaster                                     |
-| `livepeer_segment_transcoded_downloaded_total`           | SegmentDownloaded                                                                                                | Broadcaster, Orchestrator                       |
-| `livepeer_segment_transcoded_total`                      | SegmentTranscoded                                                                                                | Broadcaster, Orchestrator                       |
-| `livepeer_segment_transcoded_unprocessed_total`          | Raw number of segments successfully transcoded.                                                                  | Broadcaster                                     |
-| `livepeer_segment_transcode_failed_total`                | SegmentTranscodeFailed                                                                                           | Broadcaster                                     |
-| `livepeer_segment_transcoded_all_appeared_total`         | SegmentTranscodedAllAppeared                                                                                     | Broadcaster                                     |
-| `livepeer_stream_created_total`                          | StreamCreated                                                                                                    | Broadcaster                                     |
-| `livepeer_stream_started_total`                          | StreamStarted                                                                                                    | Broadcaster                                     |
-| `livepeer_stream_ended_total`                            | StreamEnded                                                                                                      | Broadcaster                                     |
-| `livepeer_max_sessions_total`                            | Max Sessions                                                                                                     | Broadcaster, Orchestrator, Transcoder, Redeemer |
-| `livepeer_current_sessions_total`                        | Number of streams currently transcoding                                                                          | Broadcaster, Orchestrator                       |
-| `livepeer_discovery_errors_total`                        | Number of discover errors                                                                                        | Broadcaster                                     |
-| `livepeer_transcode_retried`                             | Number of times segment transcode was retried                                                                    | Broadcaster                                     |
-| `livepeer_transcoders_number`                            | Number of transcoders currently connected to orchestrator                                                        | Broadcaster, Orchestrator, Transcoder, Redeemer |
-| `livepeer_transcoders_capacity`                          | Total advertised capacity of transcoders currently connected to orchestrator                                     | Broadcaster, Orchestrator, Transcoder, Redeemer |
-| `livepeer_transcoders_load`                              | Total load of transcoders currently connected to orchestrator                                                    | Broadcaster, Orchestrator, Transcoder, Redeemer |
-| `livepeer_success_rate`                                  | Number of transcoded segments divided on number of source segments                                               | Broadcaster, Orchestrator, Transcoder, Redeemer |
-| `livepeer_success_rate_per_stream`                       | Number of transcoded segments divided on number of source segments, per stream                                   | Broadcaster                                     |
-| `livepeer_transcode_time_seconds`                        | TranscodeTime, seconds                                                                                           | Broadcaster, Orchestrator                       |
-| `livepeer_transcode_overall_latency_seconds`             | Transcoding latency, from source segment emerged from segmenter till all transcoded segment apeeared in manifest | Broadcaster                                     |
-| `livepeer_upload_time_seconds`                           | UploadTime, seconds                                                                                              | Broadcaster, Orchestrator, Transcoder           |
-| `livepeer_download_time_seconds`                         | Download time                                                                                                    | Broadcaster, Orchestrator                       |
-| `livepeer_auth_webhook_time_milliseconds`                | Authentication webhook execution time, milliseconds                                                              | Broadcaster                                     |
-| `livepeer_source_segment_duration_seconds`               | Source segment's duration                                                                                        | Broadcaster, Orchestrator                       |
-| `livepeer_http_client_timeout_1`                         | Number of times HTTP connection was dropped before transcoding complete                                          | Broadcaster                                     |
-| `livepeer_http_client_timeout_2`                         | Number of times HTTP connection was dropped before transcoded segments was sent back to client                   | Broadcaster                                     |
-| `livepeer_http_client_segment_transcoded_realtime_ratio` | Ratio of source segment duration / transcode time as measured on HTTP client                                     | Broadcaster                                     |
-| `livepeer_http_client_segment_transcoded_realtime_3x`    | Number of segment transcoded 3x faster than realtime                                                             | Broadcaster                                     |
-| `livepeer_http_client_segment_transcoded_realtime_2x`    | Number of segment transcoded 2x faster than realtime                                                             | Broadcaster                                     |
-| `livepeer_http_client_segment_transcoded_realtime_1x`    | Number of segment transcoded 1x faster than realtime                                                             | Broadcaster                                     |
-| `livepeer_http_client_segment_transcoded_realtime_half`  | Number of segment transcoded no more than two times slower than realtime                                         | Broadcaster                                     |
-| `livepeer_http_client_segment_transcoded_realtime_slow`  | Number of segment transcoded more than two times slower than realtime                                            | Broadcaster                                     |
-| `livepeer_transcode_score`                               | Ratio of source segment duration vs. transcode time                                                              | Broadcaster, Orchestrator                       |
-| `livepeer_recording_save_latency`                        | How long it takes to save segment to the OS                                                                      | Broadcaster                                     |
-| `livepeer_recording_save_errors`                         | Number of errors during save to the recording OS                                                                 | Broadcaster                                     |
-| `livepeer_recording_saved_segments`                      | Number of segments saved to the recording OS                                                                     | Broadcaster                                     |
-| `livepeer_orchestrator_swaps`                            | Number of orchestrator swaps mid-stream                                                                          | Broadcaster                                     |
+| `livepeer_versions`                                      | Versions used by Livepeer node.                                                                                  | Gateway, Orchestrator, Transcoder, Redeemer |
+| `livepeer_segment_source_appeared_total`                 | SegmentSourceAppeared                                                                                            | Gateway                                     |
+| `livepeer_segment_source_emerged_total`                  | SegmentEmerged                                                                                                   | Gateway                                     |
+| `livepeer_segment_source_emerged_unprocessed_total`      | Raw number of segments emerged from segmenter.                                                                   | Gateway, Orchestrator                       |
+| `livepeer_segment_source_uploaded_total`                 | SegmentUploaded                                                                                                  | Gateway, Orchestrator, Transcoder           |
+| `livepeer_segment_source_upload_failed_total`            | SegmentUploadedFailed                                                                                            | Gateway                                     |
+| `livepeer_segment_transcoded_downloaded_total`           | SegmentDownloaded                                                                                                | Gateway, Orchestrator                       |
+| `livepeer_segment_transcoded_total`                      | SegmentTranscoded                                                                                                | Gateway, Orchestrator                       |
+| `livepeer_segment_transcoded_unprocessed_total`          | Raw number of segments successfully transcoded.                                                                  | Gateway                                     |
+| `livepeer_segment_transcode_failed_total`                | SegmentTranscodeFailed                                                                                           | Gateway                                     |
+| `livepeer_segment_transcoded_all_appeared_total`         | SegmentTranscodedAllAppeared                                                                                     | Gateway                                     |
+| `livepeer_stream_created_total`                          | StreamCreated                                                                                                    | Gateway                                     |
+| `livepeer_stream_started_total`                          | StreamStarted                                                                                                    | Gateway                                     |
+| `livepeer_stream_ended_total`                            | StreamEnded                                                                                                      | Gateway                                     |
+| `livepeer_max_sessions_total`                            | Max Sessions                                                                                                     | Gateway, Orchestrator, Transcoder, Redeemer |
+| `livepeer_current_sessions_total`                        | Number of streams currently transcoding                                                                          | Gateway, Orchestrator                       |
+| `livepeer_discovery_errors_total`                        | Number of discover errors                                                                                        | Gateway                                     |
+| `livepeer_transcode_retried`                             | Number of times segment transcode was retried                                                                    | Gateway                                     |
+| `livepeer_transcoders_number`                            | Number of transcoders currently connected to orchestrator                                                        | Gateway, Orchestrator, Transcoder, Redeemer |
+| `livepeer_transcoders_capacity`                          | Total advertised capacity of transcoders currently connected to orchestrator                                     | Gateway, Orchestrator, Transcoder, Redeemer |
+| `livepeer_transcoders_load`                              | Total load of transcoders currently connected to orchestrator                                                    | Gateway, Orchestrator, Transcoder, Redeemer |
+| `livepeer_success_rate`                                  | Number of transcoded segments divided on number of source segments                                               | Gateway, Orchestrator, Transcoder, Redeemer |
+| `livepeer_success_rate_per_stream`                       | Number of transcoded segments divided on number of source segments, per stream                                   | Gateway                                     |
+| `livepeer_transcode_time_seconds`                        | TranscodeTime, seconds                                                                                           | Gateway, Orchestrator                       |
+| `livepeer_transcode_overall_latency_seconds`             | Transcoding latency, from source segment emerged from segmenter till all transcoded segment apeeared in manifest | Gateway                                     |
+| `livepeer_upload_time_seconds`                           | UploadTime, seconds                                                                                              | Gateway, Orchestrator, Transcoder           |
+| `livepeer_download_time_seconds`                         | Download time                                                                                                    | Gateway, Orchestrator                       |
+| `livepeer_auth_webhook_time_milliseconds`                | Authentication webhook execution time, milliseconds                                                              | Gateway                                     |
+| `livepeer_source_segment_duration_seconds`               | Source segment's duration                                                                                        | Gateway, Orchestrator                       |
+| `livepeer_http_client_timeout_1`                         | Number of times HTTP connection was dropped before transcoding complete                                          | Gateway                                     |
+| `livepeer_http_client_timeout_2`                         | Number of times HTTP connection was dropped before transcoded segments was sent back to client                   | Gateway                                     |
+| `livepeer_http_client_segment_transcoded_realtime_ratio` | Ratio of source segment duration / transcode time as measured on HTTP client                                     | Gateway                                     |
+| `livepeer_http_client_segment_transcoded_realtime_3x`    | Number of segment transcoded 3x faster than realtime                                                             | Gateway                                     |
+| `livepeer_http_client_segment_transcoded_realtime_2x`    | Number of segment transcoded 2x faster than realtime                                                             | Gateway                                     |
+| `livepeer_http_client_segment_transcoded_realtime_1x`    | Number of segment transcoded 1x faster than realtime                                                             | Gateway                                     |
+| `livepeer_http_client_segment_transcoded_realtime_half`  | Number of segment transcoded no more than two times slower than realtime                                         | Gateway                                     |
+| `livepeer_http_client_segment_transcoded_realtime_slow`  | Number of segment transcoded more than two times slower than realtime                                            | Gateway                                     |
+| `livepeer_transcode_score`                               | Ratio of source segment duration vs. transcode time                                                              | Gateway, Orchestrator                       |
+| `livepeer_recording_save_latency`                        | How long it takes to save segment to the OS                                                                      | Gateway                                     |
+| `livepeer_recording_save_errors`                         | Number of errors during save to the recording OS                                                                 | Gateway                                     |
+| `livepeer_recording_saved_segments`                      | Number of segments saved to the recording OS                                                                     | Gateway                                     |
+| `livepeer_orchestrator_swaps`                            | Number of orchestrator swaps mid-stream                                                                          | Gateway                                     |
 
 ### Sending payments
 
 | Name                             | Description                                        | Node Type   |
 | -------------------------------- | -------------------------------------------------- | ----------- |
-| `livepeer_ticket_value_sent`     | Ticket value sent                                  | Broadcaster |
-| `livepeer_tickets_sent`          | Tickets sent                                       | Broadcaster |
-| `livepeer_payment_create_errors` | Errors when creating payments                      | Broadcaster |
-| `livepeer_broadcaster_deposit`   | Current remaining deposit for the broadcaster node | Broadcaster |
-| `livepeer_broadcaster_reserve`   | Current remaining reserve for the broadcaster node | Broadcaster |
+| `livepeer_ticket_value_sent`     | Ticket value sent                                  | Gateway |
+| `livepeer_tickets_sent`          | Tickets sent                                       | Gateway |
+| `livepeer_payment_create_errors` | Errors when creating payments                      | Gateway |
+| `livepeer_gateway_deposit`   | Current remaining deposit for the gateway node | Gateway |
+| `livepeer_gateway_reserve`   | Current remaining reserve for the gateway node | Gateway |
 
 ### Receiving payments
 
@@ -75,22 +75,22 @@ documents all metrics that you can scrape via the `/metrics` endpoint when the
 | `livepeer_winning_tickets_recv`     | Winning tickets received                           | Orchestrator                        |
 | `livepeer_value_redeemed`           | Winning ticket value redeemed                      | Orchestrator, Redeemer              |
 | `livepeer_ticket_redemption_errors` | Errors when redeeming tickets                      | Orchestrator, Redeemer              |
-| `livepeer_suggested_gas_price`      | Suggested gas price for winning ticket redemption  | Broadcaster, Orchestrator, Redeemer |
-| `livepeer_min_gas_price`            | Minimum gas price to use for gas price suggestions | Broadcaster, Orchestrator, Redeemer |
-| `livepeer_max_gas_price`            | Maximum gas price to use for gas price suggestions | Broadcaster, Orchestrator, Redeemer |
+| `livepeer_suggested_gas_price`      | Suggested gas price for winning ticket redemption  | Gateway, Orchestrator, Redeemer |
+| `livepeer_min_gas_price`            | Minimum gas price to use for gas price suggestions | Gateway, Orchestrator, Redeemer |
+| `livepeer_max_gas_price`            | Maximum gas price to use for gas price suggestions | Gateway, Orchestrator, Redeemer |
 | `livepeer_transcoding_price`        | Transcoding price per pixel                        | Orchestrator                        |
 
 ### Pixel accounting
 
 | Name                            | Description              | Node Type                 |
 | ------------------------------- | ------------------------ | ------------------------- |
-| `livepeer_mil_pixels_processed` | Million pixels processed | Broadcaster, Orchestrator |
+| `livepeer_mil_pixels_processed` | Million pixels processed | Gateway, Orchestrator |
 
 ### Fast verification
 
 | Name                                                        | Description                                                                                                             | Node Type   |
 | ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ----------- |
-| `livepeer_fast_verification_done`                           | Number of fast verifications done                                                                                       | Broadcaster |
-| `livepeer_fast_verification_failed`                         | Number of fast verifications failed                                                                                     | Broadcaster |
-| `livepeer_fast_verification_enabled_current_sessions_total` | Number of currently transcoded streams that have fast verification enabled                                              | Broadcaster |
-| `livepeer_fast_verification_using_current_sessions_total`   | Number of currently transcoded streams that have fast verification enabled and that are using an untrusted orchestrator | Broadcaster |
+| `livepeer_fast_verification_done`                           | Number of fast verifications done                                                                                       | Gateway |
+| `livepeer_fast_verification_failed`                         | Number of fast verifications failed                                                                                     | Gateway |
+| `livepeer_fast_verification_enabled_current_sessions_total` | Number of currently transcoded streams that have fast verification enabled                                              | Gateway |
+| `livepeer_fast_verification_using_current_sessions_total`   | Number of currently transcoded streams that have fast verification enabled and that are using an untrusted orchestrator | Gateway |

--- a/references/knowledge-base/playback.mdx
+++ b/references/knowledge-base/playback.mdx
@@ -2,7 +2,7 @@
   Diagnose: This is due to the low latency playback feature using WebRTC. If
   there are bframes in the stream, the default behavior is to fallback to HLS
   playback, which means a slight increase in latency. Workaround: In the
-  settings of the broadcaster, turn off the use of frames. If using OBS, select
+  settings of the gateway, turn off the use of frames. If using OBS, select
   Livepeer as the service for the video settings.
   [https://docs.livepeer.org/guides/developing/stream-via-obs#input-your-stream-settings](https://docs.livepeer.org/guides/developing/stream-via-obs#input-your-stream-settings)
 </Card>

--- a/sdks/react/broadcast/Camera.mdx
+++ b/sdks/react/broadcast/Camera.mdx
@@ -2,7 +2,7 @@
 title: "Camera"
 description:
   "The `VideoEnabledTrigger` and `VideoEnabledIndicator` components provide
-  broadcasters with interactive controls and visual cues to manage the video
+  gateways with interactive controls and visual cues to manage the video
   enabled state during a broadcast."
 icon: camcorder
 ---

--- a/sdks/react/broadcast/Enabled.mdx
+++ b/sdks/react/broadcast/Enabled.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Enable"
 description:
-  'The `EnabledTrigger` and `EnabledIndicator` components provide broadcasters
+  'The `EnabledTrigger` and `EnabledIndicator` components provide gateways
   with interactive controls and visual cues to manage the "enabled" state of the
   broadcast.'
 icon: clapperboard

--- a/sdks/react/broadcast/Screenshare.mdx
+++ b/sdks/react/broadcast/Screenshare.mdx
@@ -2,7 +2,7 @@
 title: "Screenshare"
 description:
   "The `ScreenshareTrigger` and `ScreenshareIndicator` components provide
-  broadcasters with controls for managing the screenshare state."
+  gateways with controls for managing the screenshare state."
 icon: screencast
 ---
 

--- a/sdks/react/broadcast/Source.mdx
+++ b/sdks/react/broadcast/Source.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Source"
 description:
-  "The `SourceSelect` component provides broadcasters with a dropdown interface
+  "The `SourceSelect` component provides gateways with a dropdown interface
   to choose between different media source devices like cameras and microphones."
 icon: sliders
 ---


### PR DESCRIPTION
This pull request replaces all instances of 'Broadcaster' with 'Gateway' in
accordance with a decision made by the core team. For more details, refer to
the discussion at https://discord.com/channels/423160867534929930/1051963444598943784/1210356864643109004.

@dob there are two places where I did not yet rename the broadcaster term:

1. In the [monitor-stream-health](https://github.com/livepeer/docs/blob/1eb219bc8b79f7f3e2925cfb1e8d4fdc7f86d170/developers/guides/monitor-stream-health.mdx#L597) page since this is a response returned by the studio API.
2. In the [contract-addresses](https://github.com/livepeer/docs/blob/1eb219bc8b79f7f3e2925cfb1e8d4fdc7f86d170/references/contract-addresses.mdx#L174) page since these test contracts had that name at the given time.

> [!IMPORTANT]
> This pull request is dependent on the following upstream pull requests:
> - https://github.com/livepeer/go-livepeer/pull/3053
> - https://github.com/livepeer/go-livepeer/pull/3055
> - https://github.com/livepeer/go-livepeer/pull/3056