### PR TITLE
docs(ai): add DEEPCACHE lightning/turbo warning

### DIFF
--- a/ai/orchestrators/models-config.mdx
+++ b/ai/orchestrators/models-config.mdx
@@ -88,7 +88,9 @@ available:
   loss**. Can not be used in conjunction with `DEEPCACHE`.
 </ParamField>
 
-#### General Pipeline Optimization
+#### Text-to-image pipeline Optimization
+
+<Warning>**DO NOT** enable `DEEPCACHE` for Lightning/Turbo models since they're already optimized. Due to [known limitations](https://github.com/horseee/DeepCache/issues/27), it does not provide speed benefits and may significantly lower image quality.</Warning>
 
 <ParamField path="DEEPCACHE" type="boolean">
   The `DEEPCACHE` flag enables the


### PR DESCRIPTION
This pull request ensures that people are aware of the limitations of the [DeepCache](https://github.com/horseee/DeepCache) optimization w.r.t. Lightning/turbo models.
