### PR TITLE
docs(ai): add aiRunnerImage flag to docs

### DIFF
--- a/ai/orchestrators/start-orchestrator.mdx
+++ b/ai/orchestrators/start-orchestrator.mdx
@@ -85,7 +85,8 @@ Please follow the steps below to start your AI Subnet Orchestrator node:
                 - `-aiWorker`: This flag enables the AI Worker functionality.
                 - `-aiModels`: This flag sets the path to the JSON file that contains the AI models.
                 - `-aiModelsDir`: This flag indicates the directory where the AI models are stored on the host machine.
-
+                - `-aiRunnerImage`: This optional flag specifies which version of the ai-runner image is used. Example: `livepeer/ai-runner:0.0.2`
+                
                 Moreover, the `--network host` flag facilitates communication between the AI Orchestrator and the AI Runner container.
 
                 <Warning>Please note that since we use [docker-out-of-docker](https://tdongsi.github.io/blog/2017/04/23/docker-out-of-docker/), the `aiModelsDir` path should be defined as being on the host machine.</Warning>
@@ -172,6 +173,8 @@ Please follow the steps below to start your AI Subnet Orchestrator node:
                 - `-aiWorker`: This flag enables the AI Worker functionality.
                 - `-aiModels`: This flag sets the path to the JSON file that contains the AI models.
                 - `-aiModelsDir`: This flag indicates the directory where the AI models are stored.
+                - `-aiRunnerImage`: This optional flag specifies which version of the ai-runner image is used. Example: `livepeer/ai-runner:0.0.2`
+
             </Step>
             <Step title="Confirm Successful Startup of the AI Orchestrator">
                 If your AI Subnet Orchestrator node is functioning correctly, you should see the following output:


### PR DESCRIPTION
This pull request documents how to use the `-aiRunnerImage` flag for pinning a specific ai-runner version to the configuration