### PR TITLE
docs(ai): update I2I default model to pix2pix

### DIFF
--- a/ai/api-reference/ai-openapi-schema.yml
+++ b/ai/api-reference/ai-openapi-schema.yml
@@ -150,6 +150,10 @@ components:
           type: number
           title: Guidance Scale
           default: 7.5
+        image_guidance_scale:
+          type: number
+          title: Image Guidance Scale
+          default: 1.5
         negative_prompt:
           type: string
           title: Negative Prompt
@@ -204,6 +208,10 @@ components:
         seed:
           type: integer
           title: Seed
+        safety_check:
+          type: boolean
+          title: Safety Check
+          default: true
       type: object
       required:
       - image

--- a/ai/pipelines/image-to-image.mdx
+++ b/ai/pipelines/image-to-image.mdx
@@ -31,8 +31,9 @@ graph LR
 
 The current warm model requested for the `image-to-image` pipeline is:
 
-- [ByteDance/SDXL-Lightning](https://huggingface.co/ByteDance/SDXL-Lightning): A
-  high-performance diffusion model developed by ByteDance.
+- [timbrooks/instruct-pix2pix](https://huggingface.co/timbrooks/instruct-pix2pix):
+  A powerful diffusion model that edits images to a high-quality standard based
+  on human-written instructions
 
 <Tip>
   For faster responses with different
@@ -54,6 +55,9 @@ pipeline:
 
 {/* prettier-ignore */}
 <Accordion title="Tested and Verified Diffusion Models">
+- [timbrooks/instruct-pix2pix](https://huggingface.co/timbrooks/instruct-pix2pix):
+  A powerful diffusion model that edits images to a high-quality standard based
+  on human-written instructions.
 - [sd-turbo](https://huggingface.co/stabilityai/sd-turbo): A robust diffusion
   model by Stability AI, designed for efficient and high-quality image
   generation.
@@ -69,8 +73,6 @@ pipeline:
   A streamlined version of RealVisXL_V4.0, designed for faster inference while
   still aiming for photorealism.
 </Accordion>
-
-
 
 ## Basic Usage Instructions
 


### PR DESCRIPTION
This pull request updates the I2I recommended model to https://huggingface.co/timbrooks/instruct-pix2pix since it gives better
results. It also updates the AI API reference.
