### PR TITLE
docs: add theme

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -317,6 +317,7 @@
     "light": "#2b9a66",
     "dark": "#18794E"
   },
+  "theme": "prism",
   "feedback": {
     "suggestEdit": true,
     "raiseIssue": true,
@@ -329,7 +330,6 @@
   "modeToggle": {
     "default": "dark"
   },
-  "backgroundImage": "/images/background.png",
   "topbarLinks": [
     {
       "name": "Discord",


### PR DESCRIPTION
Mintlify has just [released](https://mintlify.com/blog/launch-week-3-day-1) a new set of "themes". I've chosen the prism theme which is very close to our current layout and design and looks much better.

I've also removed the background gradient image, because the theme already has a beautiful grid background image. 

<img width="1458" alt="image" src="https://github.com/livepeer/docs/assets/56798748/6171cafc-95cc-4134-bfe5-96eca58206b0">
