### PR TITLE
docs(ai): add SD3 and license comments

### DIFF
--- a/ai/pipelines/image-to-image.mdx
+++ b/ai/pipelines/image-to-image.mdx
@@ -33,7 +33,7 @@ The current warm model requested for the `image-to-image` pipeline is:
 
 - [timbrooks/instruct-pix2pix](https://huggingface.co/timbrooks/instruct-pix2pix):
   A powerful diffusion model that edits images to a high-quality standard based
-  on human-written instructions
+  on human-written instructions.
 
 <Tip>
   For faster responses with different
@@ -58,12 +58,6 @@ pipeline:
 - [timbrooks/instruct-pix2pix](https://huggingface.co/timbrooks/instruct-pix2pix):
   A powerful diffusion model that edits images to a high-quality standard based
   on human-written instructions.
-- [sd-turbo](https://huggingface.co/stabilityai/sd-turbo): A robust diffusion
-  model by Stability AI, designed for efficient and high-quality image
-  generation.
-- [sdxl-turbo](https://huggingface.co/stabilityai/sdxl-turbo): An
-  extended version of the sd-turbo model, offering enhanced performance for
-  larger and more complex tasks.
 - [ByteDance/SDXL-Lightning](https://huggingface.co/ByteDance/SDXL-Lightning):A
   lightning-fast diffusion model by ByteDance, optimized for high-speed
   image-to-image transformations.
@@ -72,6 +66,12 @@ pipeline:
 - [SG161222/RealVisXL_V4.0_Lightning](https://huggingface.co/SG161222/RealVisXL_V4.0_Lightning):
   A streamlined version of RealVisXL_V4.0, designed for faster inference while
   still aiming for photorealism.
+- [stabilityai/sd-turbo](https://huggingface.co/stabilityai/sd-turbo): A robust diffusion
+  model by Stability AI, designed for efficient and high-quality image
+  generation ([limited-commercial use license](https://stability.ai/license)).
+- [stabilityai/sdxl-turbo](https://huggingface.co/stabilityai/sdxl-turbo): An
+  extended version of the sd-turbo model, offering enhanced performance for
+  larger and more complex tasks ([limited-commercial use license](https://stability.ai/license)).
 </Accordion>
 
 ## Basic Usage Instructions

--- a/ai/pipelines/image-to-video.mdx
+++ b/ai/pipelines/image-to-video.mdx
@@ -36,7 +36,7 @@ The current warm model requested for the `image-to-video` pipeline is:
 
 - [stabilityai/stable-video-diffusion-img2vid-xt-1-1](https://huggingface.co/stabilityai/stable-video-diffusion-img2vid-xt-1-1):
   An updated version of the stable-video-diffusion-img2vid-xt model with
-  enhanced performance.
+  enhanced performance ([limited-commercial use license](https://stability.ai/license)).
 
 <Tip>
   For faster responses with different
@@ -59,10 +59,10 @@ pipeline:
 {/* prettier-ignore */}
 <Accordion title="Tested and Verified Diffusion Models">
 - [stable-video-diffusion-img2vid-xt](https://huggingface.co/stabilityai/stable-video-diffusion-img2vid-xt):
-  A model by Stability AI designed for stable video diffusion from images.
+  A model by Stability AI designed for stable video diffusion from images ([limited-commercial use license](https://stability.ai/license)).
 - [stabilityai/stable-video-diffusion-img2vid-xt-1-1](https://huggingface.co/stabilityai/stable-video-diffusion-img2vid-xt-1-1):
   An updated version of the stable-video-diffusion-img2vid-xt model with
-  enhanced performance.
+  enhanced performance ([limited-commercial use license](https://stability.ai/license)).
 </Accordion>
 
 ## Basic Usage Instructions

--- a/ai/pipelines/text-to-image.mdx
+++ b/ai/pipelines/text-to-image.mdx
@@ -60,15 +60,11 @@ pipeline:
 
 {/* prettier-ignore */}
 <Accordion title="Tested and Verified Diffusion Models">
-- [sd-turbo](https://huggingface.co/stabilityai/sd-turbo): A high-performance
-  diffusion model by Stability AI.
-- [sdxl-turbo](https://huggingface.co/stabilityai/sdxl-turbo): An extended
-  version of sd-turbo with enhanced capabilities.
-- [stable-diffusion-v1-5](https://huggingface.co/runwayml/stable-diffusion-v1-5):
-  A stable diffusion model by Runway ML.
-- [stable-diffusion-xl-base-1.0](https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0):
+- [stabilityai/stable-diffusion-xl-base-1.0](https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0):
   A base model for stable diffusion by Stability AI.
-- [openjourney-v4](https://huggingface.co/prompthero/openjourney-v4): A model by
+- [runwayml/stable-diffusion-v1-5](https://huggingface.co/runwayml/stable-diffusion-v1-5):
+  A stable diffusion model by Runway ML.
+- [prompthero/openjourney-v4](https://huggingface.co/prompthero/openjourney-v4): A model by
   Prompthero for open-ended journey generation.
 - [ByteDance/SDXL-Lightning](https://huggingface.co/ByteDance/SDXL-Lightning): A
   lightning-fast diffusion model by ByteDance.
@@ -77,6 +73,11 @@ pipeline:
 - [SG161222/RealVisXL_V4.0_Lightning](https://huggingface.co/SG161222/RealVisXL_V4.0_Lightning):
   A streamlined version of RealVisXL_V4.0, designed for faster inference while
   still aiming for photorealism.
+- [stabilityai/sd-turbo](https://huggingface.co/stabilityai/sd-turbo): A high-performance
+  diffusion model by Stability AI ([limited-commercial use license](https://stability.ai/license)).
+- [stabilityai/sdxl-turbo](https://huggingface.co/stabilityai/sdxl-turbo): An extended
+  version of sd-turbo with enhanced capabilities ([limited-commercial use license](https://stability.ai/license)).
+- [stabilityai/stable-diffusion-3-medium-diffusers](https://huggingface.co/stabilityai/stable-diffusion-3-medium-diffusers/): A Multimodal Diffusion Transformer (MMDiT) model with superior image quality, advanced typography, and enhanced prompt comprehension ([limited-commercial use license](https://stability.ai/license)).
 </Accordion>
 
 ## Basic Usage Instructions


### PR DESCRIPTION
This pull request adds the SD3 model as a supported model to the docs and includes a license comment to all models that have a limited commercial license.
