### PR TITLE
docs(ia): add Realistic Vision V6 T2I model support

### DIFF
--- a/ai/pipelines/text-to-image.mdx
+++ b/ai/pipelines/text-to-image.mdx
@@ -60,6 +60,7 @@ pipeline:
 
 {/* prettier-ignore */}
 <Accordion title="Tested and Verified Diffusion Models">
+- [SG161222/Realistic_Vision_V6.0_B1_noVAE](https://huggingface.co/SG161222/Realistic_Vision_V6.0_B1_noVAE): Latest (experimental) release of the Realistic Vision model specialized in creating photorealistic portraits.
 - [stabilityai/stable-diffusion-xl-base-1.0](https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0):
   A base model for stable diffusion by Stability AI.
 - [runwayml/stable-diffusion-v1-5](https://huggingface.co/runwayml/stable-diffusion-v1-5):


### PR DESCRIPTION
This pull request ensures that users are aware that the https://huggingface.co/SG161222/Realistic_Vision_V6.0_B1_noVAE
model is supported on the subnet.
