### PR TITLE
docs(ai): fix incorrect AIServiceRegistry reference

### DIFF
--- a/ai/orchestrators/onchain.mdx
+++ b/ai/orchestrators/onchain.mdx
@@ -97,7 +97,7 @@ contract on the [Arbitrum Mainnet](https://arbitrum.io).
         ```
       </Step>
       <Step title="Verify your Service URI">
-        Verify your Service URI by invoking the `getServiceURI` function on the [AIServiceRegistry](https://arbiscan.io/address/0x5d31637eb0f442376053d5dea2347f663c4019dc) contract:
+        Verify your Service URI by invoking the `getServiceURI` function on the [AIServiceRegistry](https://arbiscan.io/address/0x04C0b249740175999E5BF5c9ac1dA92431EF34C5) contract:
 
         ```bash
         cast call --rpc-url <ARBITRUM_RPC_URI> 0x04C0b249740175999E5BF5c9ac1dA92431EF34C5 "getServiceURI(address)" <PUBLIC_WALLET_KEY> | xxd -r -p


### PR DESCRIPTION
This pull request fixes a incorrect AIServiceRegistry reference which pointed to an earlier deployed contract.
