### PR TITLE
add upscale and audio-to-text overview panels

### DIFF
--- a/ai/pipelines/overview.mdx
+++ b/ai/pipelines/overview.mdx
@@ -49,16 +49,22 @@ phase, Orchestrators need to pre-download a model.
 The subnet currently supports the following generative AI pipelines:
 
 <CardGroup cols={2}>
-  <Card title="Text-to-image" icon="image" href="/ai/pipelines/text-to-image">
+  <Card title="Text-to-Image" icon="image" href="/ai/pipelines/text-to-image">
     The text-to-image pipeline generates high-quality images from text
-    descriptions.
+    descriptions
   </Card>
-  <Card title="image-to-image" icon="image" href="/ai/pipelines/image-to-image">
+  <Card title="Image-to-Image" icon="image" href="/ai/pipelines/image-to-image">
     The image-to-image pipeline enables advanced image manipulations, including
-    style transfer, image enhancement, and more.
+    style transfer, image enhancement, and more
   </Card>
-  <Card title="image-to-video" icon="video" href="/ai/pipelines/image-to-video">
-    The image-to-video pipeline creates animated high-quality videos from
-    images.
+  <Card title="Image-to-Video" icon="video" href="/ai/pipelines/image-to-video">
+    The image-to-video pipeline creates animated high-quality videos from images
+  </Card>
+  <Card title="Upscale" icon="video" href="/ai/pipelines/upscale">
+    The upscale pipeline transforms low-resolution images into high-quality ones without distortion
+    images
+  </Card>
+  <Card title="Audio-to-Text" icon="video" href="/ai/pipelines/audio-to-text">
+    The audio-to-text pipeline uses automatic speech recognition (ASR) to translate audio to text with timestamps
   </Card>
 </CardGroup>


### PR DESCRIPTION
Adds upscale and audio-to-text pipeline descriptions to the overview page. Also standardizes some punctutation