### PR TITLE
docs(ai): fix binary release stable path

### DIFF
--- a/ai/gateways/start-gateway.mdx
+++ b/ai/gateways/start-gateway.mdx
@@ -70,13 +70,13 @@ Please follow the steps below to start your AI Subnet Gateway node:
                 Download the latest AI subnet binary for your system:
 
                 ```bash
-                wget https://build.livepeer.live/go-livepeer/ai-video/latest/livepeer-<OS>-<ARCH>.tar.gz
+                wget https://build.livepeer.live/go-livepeer/ai-video/stable/livepeer-<OS>-<ARCH>.tar.gz
                 ```
 
                 Replace `<OS>` and `<ARCH>` with your system's operating system and architecture. For example, for a Linux system with an AMD64 architecture, the command would be:
 
                 ```bash
-                wget https://build.livepeer.live/go-livepeer/ai-video/latest/livepeer-linux-amd64.tar.gz
+                wget https://build.livepeer.live/go-livepeer/ai-video/stable/livepeer-linux-amd64.tar.gz
                 ```
 
                 See the [go-livepeer installation guide](/orchestrators/guides/install-go-livepeer#install-using-a-binary-release) for more information on the available binaries.

--- a/ai/orchestrators/start-orchestrator.mdx
+++ b/ai/orchestrators/start-orchestrator.mdx
@@ -113,13 +113,13 @@ Please follow the steps below to start your AI Subnet Orchestrator node:
                 Download the latest AI subnet binary for your system:
 
                 ```bash
-                wget https://build.livepeer.live/go-livepeer/ai-video/latest/livepeer-<OS>-gpu-<ARCH>.tar.gz
+                wget https://build.livepeer.live/go-livepeer/ai-video/stable/livepeer-<OS>-gpu-<ARCH>.tar.gz
                 ```
 
                 Replace `<OS>` and `<ARCH>` with your system's operating system and architecture. For example, for a Linux system with an AMD64 architecture, the command would be:
 
                 ```bash
-                wget https://build.livepeer.live/go-livepeer/ai-video/latest/livepeer-linux-gpu-amd64.tar.gz
+                wget https://build.livepeer.live/go-livepeer/ai-video/stable/livepeer-linux-gpu-amd64.tar.gz
                 ```
 
                 See the [go-livepeer installation guide](/orchestrators/guides/install-go-livepeer#install-using-a-binary-release) for more information on the available binaries.


### PR DESCRIPTION
This pull request ensures the binary stable release download url is correct in the orchestrator and Gateway setup documentation.
