### PR TITLE
ci(ai): enable AI SDK code example generation

### DIFF
--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -14,6 +14,10 @@ sources:
     livepeer-ai-api:
         inputs:
             - location: https://raw.githubusercontent.com/livepeer/ai-worker/main/runner/gateway.openapi.yaml
+        overlays:
+            - location: https://raw.githubusercontent.com/livepeer/livepeer-ai-js/main/codeSamples.yaml
+            - location: https://raw.githubusercontent.com/livepeer/livepeer-ai-go/main/codeSamples.yaml
+            - location: https://raw.githubusercontent.com/livepeer/livepeer-ai-python/main/codeSamples.yaml
         registry:
             location: registry.speakeasyapi.dev/livepeer-8mq/livepeer-ai/livepeer-ai-oas
         output: ai/api-reference/gateway.openapi.yaml


### PR DESCRIPTION
This commit adds the CI logic to generate the AI OpenAPI spec that also contains the code examples of the new AI SDKs to the API reference sidebar.