### PR TITLE
docs(ai): improve temp SAM docker steps

### DIFF
--- a/ai/orchestrators/models-config.mdx
+++ b/ai/orchestrators/models-config.mdx
@@ -15,6 +15,8 @@ for their download. For details on supported pipelines and models, consult
   The `livepeer/ai-runner:segment-anything-2` container required to serve the [segment-anything-2](ai/pipelines/segment-anything-2) pipeline has not yet been released to our Docker registry. To serve this model as an orchestrator, please use the following command to download the source code and build the Docker container locally:
 
   ```bash
+  docker pull livepeer/ai-runner:latest
+  docker tag livepeer/ai-runner:latest livepeer/ai-runner:base
   docker build https://github.com/livepeer/ai-worker.git#main:runner/docker -t livepeer/ai-runner:segment-anything-2 -f Dockerfile.segment_anything_2
   ```
 </Warning>


### PR DESCRIPTION
This pull request adds all the steps needed to serve the SAM2 container. This can be removed when the container has been deployed to dockerhub.
