### PR TITLE
docs(ai): fix broken create wallet link

### DIFF
--- a/ai/orchestrators/onchain.mdx
+++ b/ai/orchestrators/onchain.mdx
@@ -32,7 +32,7 @@ your AI Orchestrator node to redeem tickets:
       <Step title="Wallet Creation">
         <Info>For security, it's advised to use a separate account from your **Mainnet Transcoding Network Orchestrator**.</Info>
 
-        Create a new Ethereum wallet for your **AI Orchestrator**. Follow the [Create a Wallet](/self-hosting/deploying#creating-a-wallet) guide in the [Catalyst](/self-hosting/deploying) documentation for detailed instructions.
+        Create a new Ethereum wallet for your **AI Orchestrator**. Follow the [Wallet Creation](/orchestrators/guides/get-started#automatic-eth-account-creation) guide in the [Orchestrator](/orchestrators/guides/get-started) documentation for detailed instructions.
       </Step>
       <Step title="Wallet Funding">
         Transfer sufficient ETH to the new wallet to cover the gas costs for redeeming AI tickets on-chain.


### PR DESCRIPTION
This pull request points the wallet creation link in the orchestrator on-chain docs to the regular orchestrator docs now that the catalyst page has been removed.
