### PR TITLE
docs(ai): remove SAM2 image warning and update docs

### DIFF
--- a/ai/orchestrators/benchmarking.mdx
+++ b/ai/orchestrators/benchmarking.mdx
@@ -26,8 +26,8 @@ Orchestrator node.
     ```
 
   </Step>
-  <Step title="Pull Pipeline-Specific Images">
-    Next, pull any pipeline-specific images if needed. Check the [pipelines](/ai/pipelines/overview) documentation for more information. For example, to pull the image for the [segment-anything-2](/ai/pipelines/segment-anything-2) pipeline:
+  <Step title="Pull Pipeline-Specific Images (optional)">
+    Next, pull any pipeline-specific images if needed. Check the [pipelines](/ai/pipelines/overview) documentation for more information. For example, to pull the image for the [segment-anything-2](/ai/pipelines/segment-anything-2#pipeline-specific-image) pipeline:
 
     ```bash
     docker pull livepeer/ai-runner:segment-anything-2

--- a/ai/orchestrators/models-config.mdx
+++ b/ai/orchestrators/models-config.mdx
@@ -6,16 +6,6 @@ Before deploying your AI Orchestrator node on the Livepeer AI network, you must 
 
 ## Configuration File Format
 
-<Warning>
-  The `livepeer/ai-runner:segment-anything-2` container required to serve the [segment-anything-2](ai/pipelines/segment-anything-2) pipeline has not yet been released to our Docker registry. To serve this model as an orchestrator, please use the following command to download the source code and build the Docker container locally:
-
-```bash
-docker pull livepeer/ai-runner:latest
-docker tag livepeer/ai-runner:latest livepeer/ai-runner:base
-docker build https://github.com/livepeer/ai-worker.git#main:runner/docker -t livepeer/ai-runner:segment-anything-2 -f Dockerfile.segment_anything_2
-```
-</Warning>
-
 Orchestrators specify supported AI models in an `aiModels.json` file, typically
 located in the `~/.lpData` directory. Below is an example configuration showing
 currently **recommended** models and their respective prices.

--- a/ai/orchestrators/start-orchestrator.mdx
+++ b/ai/orchestrators/start-orchestrator.mdx
@@ -43,6 +43,14 @@ Please follow the steps below to start your Livepeer AI Orchestrator node:
                 docker pull livepeer/ai-runner:latest
                 ```
             </Step>
+            <Step title="Pull Pipeline-Specific Images (optional)">
+                Next, pull any pipeline-specific images if needed. Check the [pipelines](/ai/pipelines/overview) documentation for more information. For example, to pull the image for the [segment-anything-2](/ai/pipelines/segment-anything-2#pipeline-specific-image) pipeline:
+
+                ```bash
+                docker pull livepeer/ai-runner:segment-anything-2
+                ```
+
+            </Step>
             <Step title="Verify the AI Models are Available">
                 The Livepeer AI network leverages pre-trained AI models for inference tasks. Before launching the AI Orchestrator node, verify that the weights of these models are accessible on your machine. For more information, visit the [Download AI Models](/ai/orchestrators/models-download) page.
             </Step>
@@ -134,6 +142,13 @@ Please follow the steps below to start your Livepeer AI Orchestrator node:
 
                 ```bash
                 docker pull livepeer/ai-runner:latest
+                ```
+            </Step>
+            <Step title="Pull Pipeline-Specific Images (optional)">
+                Next, pull any pipeline-specific images if needed. Check the [pipelines](/ai/pipelines/overview) documentation for more information. For example, to pull the image for the [segment-anything-2](/ai/pipelines/segment-anything-2#pipeline-specific-image) pipeline:
+
+                ```bash
+                docker pull livepeer/ai-runner:segment-anything-2
                 ```
             </Step>
             <Step title="Verify the AI Models are Available">

--- a/ai/pipelines/audio-to-text.mdx
+++ b/ai/pipelines/audio-to-text.mdx
@@ -98,8 +98,11 @@ to the Gateway:
 ## Orchestrator Configuration
 
 To configure your Orchestrator to serve the `audio-to-text` pipeline, refer to
-the [Orchestrator Configuration](/ai/orchestrators/get-started) guide. The
-following system requirements are recommended for optimal performance:
+the [Orchestrator Configuration](/ai/orchestrators/get-started) guide.
+
+### System Requirements
+
+The following system requirements are recommended for optimal performance:
 
 - [NVIDIA GPU](https://developer.nvidia.com/cuda-gpus) with **at least 12GB** of
   VRAM.

--- a/ai/pipelines/image-to-image.mdx
+++ b/ai/pipelines/image-to-image.mdx
@@ -117,8 +117,11 @@ curl -O "https://<STORAGE_ENDPOINT>/stream/dd5ad78d/7adde483.png"
 ## Orchestrator Configuration
 
 To configure your Orchestrator to serve the `image-to-image` pipeline, refer to
-the [Orchestrator Configuration](/ai/orchestrators/get-started) guide. The
-following system requirements are recommended for optimal performance:
+the [Orchestrator Configuration](/ai/orchestrators/get-started) guide.
+
+### System Requirements
+
+The following system requirements are recommended for optimal performance:
 
 - [NVIDIA GPU](https://developer.nvidia.com/cuda-gpus) with **at least 20GB** of
   VRAM.

--- a/ai/pipelines/image-to-video.mdx
+++ b/ai/pipelines/image-to-video.mdx
@@ -117,8 +117,11 @@ curl -O "https://<STORAGE_ENDPOINT>/stream/2b835716/01c0e9a6.mp4"
 ## Orchestrator Configuration
 
 To configure your Orchestrator to serve the `image-to-video` pipeline, refer to
-the [Orchestrator Configuration](/ai/orchestrators/get-started) guide. The
-following system requirements are recommended for optimal performance:
+the [Orchestrator Configuration](/ai/orchestrators/get-started) guide.
+
+### System Requirements
+
+The following system requirements are recommended for optimal performance:
 
 - [NVIDIA GPU](https://developer.nvidia.com/cuda-gpus) with **at least 24GB** of
   VRAM.

--- a/ai/pipelines/segment-anything-2.mdx
+++ b/ai/pipelines/segment-anything-2.mdx
@@ -95,11 +95,25 @@ to the Gateway:
 ## Orchestrator Configuration
 
 To configure your Orchestrator to serve the `segment-anything-2` pipeline, refer
-to the [Orchestrator Configuration](/ai/orchestrators/get-started) guide. The
-following system requirements are recommended for optimal performance:
+to the [Orchestrator Configuration](/ai/orchestrators/get-started) guide.
+
+### System Requirements
+
+The following system requirements are recommended for optimal performance:
 
 - [NVIDIA GPU](https://developer.nvidia.com/cuda-gpus) with **at least 6GB** of
   VRAM.
+
+### Pipeline-Specific Image
+
+To serve the `segment-anything-2` pipeline, you must use a pipeline specific AI
+Runner container. Pull the required container from
+[Docker Hub](https://hub.docker.com/layers/livepeer/ai-runner/segment-anything-2/images/sha256-b47b04e31907670db673152c38221373e5d749173ed54f932f8d9f8ad5959a33?context=explore)
+using the following command:
+
+```bash
+docker pull livepeer/ai-runner:segment-anything-2
+```
 
 ## API Reference
 

--- a/ai/pipelines/text-to-image.mdx
+++ b/ai/pipelines/text-to-image.mdx
@@ -128,8 +128,11 @@ curl -O "https://<GATEWAY_IP>/stream/d0fc1fc6/8fdf5a94.png"
 ## Orchestrator Configuration
 
 To configure your Orchestrator to serve the `text-to-image` pipeline, refer to
-the [Orchestrator Configuration](/ai/orchestrators/get-started) guide. The
-following system requirements are recommended for optimal performance:
+the [Orchestrator Configuration](/ai/orchestrators/get-started) guide.
+
+### System Requirements
+
+The following system requirements are recommended for optimal performance:
 
 - [NVIDIA GPU](https://developer.nvidia.com/cuda-gpus) with **at least 24GB** of
   VRAM.

--- a/ai/pipelines/upscale.mdx
+++ b/ai/pipelines/upscale.mdx
@@ -112,8 +112,11 @@ curl -O "https://<GATEWAY_IP>/stream/dd5ad78d/7adde483.png"
 ## Orchestrator Configuration
 
 To configure your Orchestrator to serve the `upscale` pipeline, refer to the
-[Orchestrator Configuration](/ai/orchestrators/get-started) guide. The following
-system requirements are recommended for optimal performance:
+[Orchestrator Configuration](/ai/orchestrators/get-started) guide.
+
+### System Requirements
+
+The following system requirements are recommended for optimal performance:
 
 - [NVIDIA GPU](https://developer.nvidia.com/cuda-gpus) with **at least 24GB** of
   VRAM.


### PR DESCRIPTION
This pull request removes the SAM2 image download warning on the orchestrator model configuration page and ensures that people know that for some pipelines model specific images are needed.
