### PR TITLE
add lora docs for t2i and i2i

### DIFF
--- a/ai/api-reference/gateway.openapi.yaml
+++ b/ai/api-reference/gateway.openapi.yaml
@@ -701,6 +701,13 @@ components:
           title: Model Id
           description: Hugging Face model ID used for image generation.
           default: ''
+        loras:
+          type: string
+          title: Loras
+          description: 'A LoRA (Low-Rank Adaptation) model and its corresponding weight
+            for image generation. Example: { "latent-consistency/lcm-lora-sdxl": 1.0,
+            "nerijs/pixel-art-xl": 1.2}.'
+          default: ''
         strength:
           type: number
           title: Strength
@@ -985,6 +992,13 @@ components:
           type: string
           title: Model Id
           description: Hugging Face model ID used for image generation.
+          default: ''
+        loras:
+          type: string
+          title: Loras
+          description: 'A LoRA (Low-Rank Adaptation) model and its corresponding weight
+            for image generation. Example: { "latent-consistency/lcm-lora-sdxl": 1.0,
+            "nerijs/pixel-art-xl": 1.2}.'
           default: ''
         prompt:
           type: string

--- a/ai/pipelines/image-to-image.mdx
+++ b/ai/pipelines/image-to-image.mdx
@@ -114,6 +114,19 @@ with:
 curl -O "https://<STORAGE_ENDPOINT>/stream/dd5ad78d/7adde483.png"
 ```
 
+## LoRa models
+
+To apply LoRa filters to the image, you can include the `loras` field:
+```bash
+curl -X POST https://<GATEWAY_IP>/image-to-image \
+    -F model_id="ByteDance/SDXL-Lightning" \
+    -F image=@<PATH_TO_IMAGE>/cool-cat.png \
+    -F prompt="a hat" \
+    -F loras={ \"nerijs/pixel-art-xl\" : 1.2 }"
+```
+
+A list of available LoRas can be found in [lora-studio](https://huggingface.co/spaces/enzostvs/lora-studio)
+
 ## Orchestrator Configuration
 
 To configure your Orchestrator to serve the `image-to-image` pipeline, refer to

--- a/ai/pipelines/image-to-image.mdx
+++ b/ai/pipelines/image-to-image.mdx
@@ -114,7 +114,7 @@ with:
 curl -O "https://<STORAGE_ENDPOINT>/stream/dd5ad78d/7adde483.png"
 ```
 
-## LoRa Models
+## Applying LoRa Models
 
 To apply LoRa filters to an image, include the `loras` field in your request:
 

--- a/ai/pipelines/image-to-image.mdx
+++ b/ai/pipelines/image-to-image.mdx
@@ -76,7 +76,7 @@ to the Gateway's `image-to-image` API endpoint:
 
 ```bash
 curl -X POST https://<GATEWAY_IP>/image-to-image \
-    -F model_id="ByteDance/SDXL-Lightning" \
+    -F model_id="timbrooks/instruct-pix2pix" \
     -F image=@<PATH_TO_IMAGE>/cool-cat.png \
     -F prompt="a hat"
 ```
@@ -114,18 +114,19 @@ with:
 curl -O "https://<STORAGE_ENDPOINT>/stream/dd5ad78d/7adde483.png"
 ```
 
-## LoRa models
+## LoRa Models
 
-To apply LoRa filters to the image, you can include the `loras` field:
+To apply LoRa filters to an image, include the `loras` field in your request:
+
 ```bash
 curl -X POST https://<GATEWAY_IP>/image-to-image \
     -F model_id="ByteDance/SDXL-Lightning" \
     -F image=@<PATH_TO_IMAGE>/cool-cat.png \
     -F prompt="a hat" \
-    -F loras={ \"nerijs/pixel-art-xl\" : 1.2 }"
+    -F loras='{ "nerijs/pixel-art-xl": 1.2 }'
 ```
 
-A list of available LoRas can be found in [lora-studio](https://huggingface.co/spaces/enzostvs/lora-studio)
+You can find a list of available LoRa models for various models on [lora-studio](https://huggingface.co/spaces/enzostvs/lora-studio).
 
 ## Orchestrator Configuration
 

--- a/ai/pipelines/text-to-image.mdx
+++ b/ai/pipelines/text-to-image.mdx
@@ -131,7 +131,7 @@ with:
 curl -O "https://<GATEWAY_IP>/stream/d0fc1fc6/8fdf5a94.png"
 ```
 
-## LoRa models
+## Applying LoRa Models
 
 To apply LoRa filters to an image, include the `loras` field in your request:
 

--- a/ai/pipelines/text-to-image.mdx
+++ b/ai/pipelines/text-to-image.mdx
@@ -82,7 +82,7 @@ pipeline:
 </Tip>
 
 To generate an image with the `text-to-image` pipeline, send a `POST` request
-to\*\* \*\*the Gateway's `text-to-image` API endpoint:
+to the Gateway's `text-to-image` API endpoint:
 
 ```bash
 curl -X POST "https://<GATEWAY_IP>/text-to-image" \

--- a/ai/pipelines/text-to-image.mdx
+++ b/ai/pipelines/text-to-image.mdx
@@ -101,11 +101,6 @@ In this command:
 - `model_id` is the diffusion model for image generation.
 - `prompt` is the text description for the image.
 
-<Tip>
-  For examples of effective prompts, visit
-  [PromptHero](https://prompthero.com/).
-</Tip>
-
 For additional optional parameters, refer to the
 [Livepeer AI API Reference](/ai/api-reference/text-to-image).
 

--- a/ai/pipelines/text-to-image.mdx
+++ b/ai/pipelines/text-to-image.mdx
@@ -77,11 +77,12 @@ pipeline:
 <Tip>
   For a detailed understanding of the `text-to-image` endpoint and to experiment
   with the API, see the [Livepeer AI API
-  Reference](/ai/api-reference/text-to-image).
+  Reference](/ai/api-reference/text-to-image). For examples of effective
+  prompts, visit [PromptHero](https://prompthero.com/).
 </Tip>
 
-To generate an image with the `text-to-image` pipeline, send a `POST` request to
-the Gateway's `text-to-image` API endpoint:
+To generate an image with the `text-to-image` pipeline, send a `POST` request
+to\*\* \*\*the Gateway's `text-to-image` API endpoint:
 
 ```bash
 curl -X POST "https://<GATEWAY_IP>/text-to-image" \
@@ -99,6 +100,11 @@ In this command:
 - `<GATEWAY_IP>` should be replaced with your AI Gateway's IP address.
 - `model_id` is the diffusion model for image generation.
 - `prompt` is the text description for the image.
+
+<Tip>
+  For examples of effective prompts, visit
+  [PromptHero](https://prompthero.com/).
+</Tip>
 
 For additional optional parameters, refer to the
 [Livepeer AI API Reference](/ai/api-reference/text-to-image).
@@ -127,7 +133,8 @@ curl -O "https://<GATEWAY_IP>/stream/d0fc1fc6/8fdf5a94.png"
 
 ## LoRa models
 
-To apply LoRa filters to the image, you can include the `loras` field:
+To apply LoRa filters to an image, include the `loras` field in your request:
+
 ```bash
 curl -X POST "https://<GATEWAY_IP>/text-to-image" \
     -H "Content-Type: application/json" \
@@ -136,11 +143,12 @@ curl -X POST "https://<GATEWAY_IP>/text-to-image" \
         "prompt":"A cool cat on the beach",
         "width": 1024,
         "height": 1024,
-        "loras": "{ \"nerijs/pixel-art-xl\" : 1.2 }"
+        "loras": "{ \"latent-consistency/lcm-lora-sdxl\": 1.0, \"nerijs/pixel-art-xl\": 1.2}"
     }'
 ```
 
-A list of available LoRas can be found in [lora-studio](https://huggingface.co/spaces/enzostvs/lora-studio)
+You can find a list of available LoRa models for various models on
+[lora-studio](https://huggingface.co/spaces/enzostvs/lora-studio).
 
 ## Orchestrator Configuration
 

--- a/ai/pipelines/text-to-image.mdx
+++ b/ai/pipelines/text-to-image.mdx
@@ -81,8 +81,8 @@ pipeline:
   prompts, visit [PromptHero](https://prompthero.com/).
 </Tip>
 
-To generate an image with the `text-to-image` pipeline, send a `POST` request
-to the Gateway's `text-to-image` API endpoint:
+To generate an image with the `text-to-image` pipeline, send a `POST` request to
+the Gateway's `text-to-image` API endpoint:
 
 ```bash
 curl -X POST "https://<GATEWAY_IP>/text-to-image" \

--- a/ai/pipelines/text-to-image.mdx
+++ b/ai/pipelines/text-to-image.mdx
@@ -125,6 +125,23 @@ with:
 curl -O "https://<GATEWAY_IP>/stream/d0fc1fc6/8fdf5a94.png"
 ```
 
+## LoRa models
+
+To apply LoRa filters to the image, you can include the `loras` field:
+```bash
+curl -X POST "https://<GATEWAY_IP>/text-to-image" \
+    -H "Content-Type: application/json" \
+    -d '{
+        "model_id":"ByteDance/SDXL-Lightning",
+        "prompt":"A cool cat on the beach",
+        "width": 1024,
+        "height": 1024,
+        "loras": "{ \"nerijs/pixel-art-xl\" : 1.2 }"
+    }'
+```
+
+A list of available LoRas can be found in [lora-studio](https://huggingface.co/spaces/enzostvs/lora-studio)
+
 ## Orchestrator Configuration
 
 To configure your Orchestrator to serve the `text-to-image` pipeline, refer to


### PR DESCRIPTION
This change adds documentation for requesting LoRa filters in text-to-image and image-to-image pipelines for https://github.com/livepeer/ai-worker/pull/119 and https://github.com/livepeer/go-livepeer/pull/3154