### PR TITLE
docs(ai): fix T2I lora example model

### DIFF
--- a/ai/pipelines/text-to-image.mdx
+++ b/ai/pipelines/text-to-image.mdx
@@ -134,7 +134,7 @@ To apply LoRa filters to an image, include the `loras` field in your request:
 curl -X POST "https://<GATEWAY_IP>/text-to-image" \
     -H "Content-Type: application/json" \
     -d '{
-        "model_id":"ByteDance/SDXL-Lightning",
+        "model_id":"stabilityai/stable-diffusion-xl-base-1.0",
         "prompt":"A cool cat on the beach",
         "width": 1024,
         "height": 1024,


### PR DESCRIPTION
This commit ensures people use the `stabilityai/stable-diffusion-xl-base-1.0` model
as the based for the Lora requests on the T2I pipeline.
