### PR TITLE
docs(ai): add LLM api-reference

### DIFF
--- a/ai/api-reference/llm.mdx
+++ b/ai/api-reference/llm.mdx
@@ -1,0 +1,13 @@
+---
+openapi: post /llm
+---
+
+<Info>
+  The default Gateway used in this guide is the public
+  [Livepeer.cloud](https://www.livepeer.cloud/) Gateway. It is free to use but
+  not intended for production-ready applications. For production-ready
+  applications, consider using the [Livepeer Studio](https://livepeer.studio/)
+  Gateway, which requires an API token. Alternatively, you can set up your own
+  Gateway node or partner with one via the `ai-video` channel on
+  [Discord](https://discord.gg/livepeer).
+</Info>


### PR DESCRIPTION
This pull request adds the LLM api-reference page to the AI docs. The pipeline page will be added by the LLM SPE in a subsequent pull request.