### PR TITLE
Revert "fix: add llm to mint.json for ai sdk api reference"

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -601,7 +601,6 @@
             "ai/api-reference/text-to-image",
             "ai/api-reference/image-to-image",
             "ai/api-reference/image-to-video",
-            "ai/api-reference/llm",
             "ai/api-reference/segment-anything-2",
             "ai/api-reference/upscale"
           ]


### PR DESCRIPTION
Reverts livepeer/docs#663 because the speakeasy setup has to be changed to handle the new LLM body type. 