### PR TITLE
Fixed benchmark example command to --gpus '"device=0"'

### DIFF
--- a/ai/orchestrators/benchmarking.mdx
+++ b/ai/orchestrators/benchmarking.mdx
@@ -52,7 +52,7 @@ Orchestrator node.
 
     In this command, the following parameters are used:
 
-    - `<GPU_IDs>`: Specify which GPU(s) to use. For example, `0` for GPU 0, `0,1` for GPU 0 and GPU 1, or `all` for all GPUs.
+    - `<GPU_IDs>`: Specify which GPU(s) to use. For example, `'"device=0"'` for GPU 0, `'"device=0,1"'` for GPU 0 and GPU 1, or `'"device=all"'` for all GPUs.
     - `<PIPELINE>`: The pipeline to benchmark (e.g., `text-to-image`).
     - `<MODEL_ID>`: The model ID to use for benchmarking (e.g., `stabilityai/sd-turbo`).
     - `<RUNS>`: The number of benchmark runs to perform.

--- a/ai/orchestrators/benchmarking.mdx
+++ b/ai/orchestrators/benchmarking.mdx
@@ -47,7 +47,7 @@ Orchestrator node.
     Example command:
 
     ```bash
-    docker run --gpus 0 -v ./models:/models livepeer/ai-runner:latest python bench.py --pipeline text-to-image --model_id stabilityai/sd-turbo --runs 3 --batch_size 3
+    docker run --gpus '"device=0"' -v ./models:/models livepeer/ai-runner:latest python bench.py --pipeline text-to-image --model_id stabilityai/sd-turbo --runs 3 --batch_size 3
     ```
 
     In this command, the following parameters are used:


### PR DESCRIPTION
Current implementation is incorrect and will always default to slot 0, needs '"device=0"' syntax to adjust to 0, 1, 2 etc