### PR TITLE
Fixed benchmark example command to --gpus '"device=0"'

### DIFF
--- a/ai/orchestrators/benchmarking.mdx
+++ b/ai/orchestrators/benchmarking.mdx
@@ -47,12 +47,12 @@ Orchestrator node.
     Example command:
 
     ```bash
-    docker run --gpus 0 -v ./models:/models livepeer/ai-runner:latest python bench.py --pipeline text-to-image --model_id stabilityai/sd-turbo --runs 3 --batch_size 3
+    docker run --gpus '"device=0"' -v ./models:/models livepeer/ai-runner:latest python bench.py --pipeline text-to-image --model_id stabilityai/sd-turbo --runs 3 --batch_size 3
     ```
 
     In this command, the following parameters are used:
 
-    - `<GPU_IDs>`: Specify which GPU(s) to use. For example, `0` for GPU 0, `0,1` for GPU 0 and GPU 1, or `all` for all GPUs.
+    - `<GPU_IDs>`: Specify which GPU(s) to use. For example, `'"device=0"'` for GPU 0, `'"device=0,1"'` for GPU 0 and GPU 1, or `'"device=all"'` for all GPUs.
     - `<PIPELINE>`: The pipeline to benchmark (e.g., `text-to-image`).
     - `<MODEL_ID>`: The model ID to use for benchmarking (e.g., `stabilityai/sd-turbo`).
     - `<RUNS>`: The number of benchmark runs to perform.


### PR DESCRIPTION
Current implementation will only default to gpu 0 regardless of the input, fixed example to `'"device=0"'` based on docker documentation and tested to confirm it works. https://docs.docker.com/engine/containers/resource_constraints/#expose-gpus-for-use