### PR TITLE
docs(ai): fix gateway max prices config

### DIFF
--- a/ai/gateways/onchain.mdx
+++ b/ai/gateways/onchain.mdx
@@ -72,7 +72,7 @@ following configurations:
 
 ```json
 {
-  "capabilities-prices": [
+  "capabilities_prices": [
     {
       "pipeline": "image-to-image",
       "model_id": "ByteDance/SDXL-Lightning",
@@ -97,7 +97,7 @@ following configurations:
     },
     {
       "pipeline": "audio-to-text",
-      "price_per_unit": 12882811,
+      "price_per_unit": 12882811
     }
   ]
 }


### PR DESCRIPTION
This pull request fixes a typo in the Gateway max prices configuration file that is shown on the onchain AI gateway page.
