### PR TITLE
docs(ai): hide broken LLM API reference

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -601,7 +601,6 @@
             "ai/api-reference/text-to-image",
             "ai/api-reference/image-to-image",
             "ai/api-reference/image-to-video",
-            "ai/api-reference/llm",
             "ai/api-reference/segment-anything-2",
             "ai/api-reference/upscale"
           ]


### PR DESCRIPTION
This pull request hides the LLM api reference, since it does require a hot fix to work. We should improve the generation at the speakeasy side so that we don't have to manually change the included OpenAPI spec (see https://linear.app/livepeer-ai/issue/AI-622/fix-llm-input-type-documentation).
