### PR TITLE
docs(ai): add AIServiceRegistry CLI flag

### DIFF
--- a/ai/gateways/onchain.mdx
+++ b/ai/gateways/onchain.mdx
@@ -35,6 +35,7 @@ for more information. Here’s a summary of the key steps:
   <Step title="Launch the AI Gateway">
     Now launch your AI Gateway node. The process is similar to the **docker** or **binary** setup in the [previous section](/ai/gateways/start-gateway), but requires additional flags to enable on-chain functionality. Example:
 
+    - `-AIServiceRegistry`: Ensures that the Gateway is connected to the Livepeer AI network.
     - `-network=arbitrum-one-mainnet`: Connects the AI Gateway to the Arbitrum Mainnet network.
     - `-ethUrl=https://arb1.arbitrum.io/rpc`: Sets the Arbitrum Mainnet RPC URL. Replace it with your own if necessary.
     - `-ethKeystorePath=/root/.lpData/arbitrum-one-mainnet/keystore`: Sets the path to the Ethereum keystore file for the AI Gateway.

--- a/ai/gateways/start-gateway.mdx
+++ b/ai/gateways/start-gateway.mdx
@@ -102,7 +102,7 @@ Follow the steps below to start your Livepeer AI Gateway node:
         </Steps>
 
         <Note>
-            If binaries are unavailable for your system, you can build the [maser branch](https://github.com/livepeer/go-livepeer/tree/master) of [go-livepeer](https://github.com/livepeer/go-livepeer) from source. Refer to the [Livepeer installation guide](/orchestrators/guides/install-go-livepeer#install-using-a-binary-release) or reach out to the Livepeer community on [Discord](https://discord.gg/livepeer) for assistance.
+            If binaries are unavailable for your system, you can build the [master branch](https://github.com/livepeer/go-livepeer/tree/master) of [go-livepeer](https://github.com/livepeer/go-livepeer) from source. Refer to the [Livepeer installation guide](/orchestrators/guides/install-go-livepeer#install-using-a-binary-release) or reach out to the Livepeer community on [Discord](https://discord.gg/livepeer) for assistance.
         </Note>
     </Tab>
 

--- a/ai/gateways/start-gateway.mdx
+++ b/ai/gateways/start-gateway.mdx
@@ -1,11 +1,8 @@
 ### Start your AI Gateway
 
-The Livepeer AI network is currently in **Beta** and is not yet integrated into
-the main [go-livepeer](https://github.com/livepeer/go-livepeer) software. To
-enable AI inference capabilities on your Gateway node, use the `ai-video` branch
-of [go-livepeer](https://github.com/livepeer/go-livepeer/tree/ai-video), which
-includes the necessary software for running the AI Gateway. You can run the
-Livepeer AI software in two ways:
+The Livepeer AI network is currently in **Beta** but is already integrated into
+the main [go-livepeer](https://github.com/livepeer/go-livepeer) software. You
+can run the Livepeer AI software using one of the following methods:
 
 - **Docker** (Recommended): The simplest and preferred method.
 - **Pre-built Binaries**: An alternative if you prefer not to use Docker.
@@ -21,7 +18,7 @@ Follow the steps below to start your Livepeer AI Gateway node:
                 Fetch the latest [Livepeer AI Docker image](https://hub.docker.com/r/livepeer/go-livepeer) with the following command:
 
                 ```bash
-                docker pull livepeer/go-livepeer:ai-video
+                docker pull livepeer/go-livepeer:master
                 ```
             </Step>
             <Step title="Launch an Off-chain AI Gateway">
@@ -33,7 +30,7 @@ Follow the steps below to start your Livepeer AI Gateway node:
                     -v ~/.lpData2/:/root/.lpData2 \
                     -p 8937:8937 \
                     --network host \
-                    livepeer/go-livepeer:ai-video \
+                    livepeer/go-livepeer:master \
                     -datadir ~/.lpData2 \
                     -gateway \
                     -orchAddr <ORCH_LIST> \
@@ -65,7 +62,7 @@ Follow the steps below to start your Livepeer AI Gateway node:
                 Download the latest Livepeer AI binary for your system:
 
                 ```bash
-                wget https://build.livepeer.live/go-livepeer/ai-video/stable/livepeer-<OS>-<ARCH>.tar.gz
+                wget https://build.livepeer.live/go-livepeer/livepeer-<OS>-<ARCH>.tar.gz
                 ```
 
                 Replace `<OS>` and `<ARCH>` with your operating system and architecture (e.g., `linux-amd64` for Linux AMD64). For more details, see the [go-livepeer installation guide](/orchestrators/guides/install-go-livepeer#install-using-a-binary-release).
@@ -105,7 +102,7 @@ Follow the steps below to start your Livepeer AI Gateway node:
         </Steps>
 
         <Note>
-            If binaries are unavailable for your system, you can build the [ai-video branch](https://github.com/livepeer/go-livepeer/tree/ai-video) of [go-livepeer](https://github.com/livepeer/go-livepeer) from source. Refer to the [Livepeer installation guide](/orchestrators/guides/install-go-livepeer#install-using-a-binary-release) or reach out to the Livepeer community on [Discord](https://discord.gg/livepeer) for assistance.
+            If binaries are unavailable for your system, you can build the [maser branch](https://github.com/livepeer/go-livepeer/tree/master) of [go-livepeer](https://github.com/livepeer/go-livepeer) from source. Refer to the [Livepeer installation guide](/orchestrators/guides/install-go-livepeer#install-using-a-binary-release) or reach out to the Livepeer community on [Discord](https://discord.gg/livepeer) for assistance.
         </Note>
     </Tab>
 

--- a/ai/orchestrators/onchain.mdx
+++ b/ai/orchestrators/onchain.mdx
@@ -16,13 +16,12 @@ to the Livepeer AI network and earn fees for processing AI inference jobs.
 
 ## Ensure you can Redeem Tickets
 
-Since the Livepeer AI network is in its **Beta** phase,
-[its software](https://github.com/livepeer/go-livepeer/tree/ai-video) isn't
-integrated with the Mainnet Transcoding Network
-[software stack](https://github.com/livepeer/go-livepeer) yet. This means that
+The Livepeer AI network is currently in **Beta** but is already integrated into
+the main [go-livepeer](https://github.com/livepeer/go-livepeer) software.
+However, it still uses a separate port for the AI Orchestrator. This means that
 your **Mainnet Transcoding Network Orchestrator** is currently unable to
-directly redeem AI-related tickets. However, there are two methods to enable
-your AI Orchestrator node to redeem tickets:
+directly redeem AI-related tickets. There are two methods to enable your AI
+Orchestrator node to redeem tickets:
 
 <Tabs>
   <Tab title="Set Ticket Recipient (recommended)">
@@ -158,7 +157,8 @@ network. The commands to start the AI Orchestrator are similar to those for the
 [off-chain Orchestrator](/ai/orchestrators/start-orchestrator), but with
 additional flags to enable on-chain functionality:
 
-- `-AIServiceRegistry`: Ensures that the Gateway is connected to the Livepeer AI network.
+- `-AIServiceRegistry`: Ensures that the Gateway is connected to the Livepeer AI
+  network.
 - `-network=arbitrum-one-mainnet`: Connects the AI Orchestrator node to the
   Arbitrum Mainnet network.
 - `-ethUrl=https://arb1.arbitrum.io/rpc`: Sets the Arbitrum Mainnet RPC URL. You

--- a/ai/orchestrators/onchain.mdx
+++ b/ai/orchestrators/onchain.mdx
@@ -158,6 +158,7 @@ network. The commands to start the AI Orchestrator are similar to those for the
 [off-chain Orchestrator](/ai/orchestrators/start-orchestrator), but with
 additional flags to enable on-chain functionality:
 
+- `-AIServiceRegistry`: Ensures that the Gateway is connected to the Livepeer AI network.
 - `-network=arbitrum-one-mainnet`: Connects the AI Orchestrator node to the
   Arbitrum Mainnet network.
 - `-ethUrl=https://arb1.arbitrum.io/rpc`: Sets the Arbitrum Mainnet RPC URL. You

--- a/ai/orchestrators/start-orchestrator.mdx
+++ b/ai/orchestrators/start-orchestrator.mdx
@@ -8,18 +8,12 @@ title: Start your AI Orchestrator
   or Gateway node may cause stability issues. Please proceed with caution.
 </Warning>
 
-The Livepeer AI network is not yet integrated into the main
-[go-livepeer](https://github.com/livepeer/go-livepeer) software due to its
-**Beta** status. To equip your Orchestrator node with AI inference capabilities,
-please use the `ai-video` branch of
-[go-livepeer](https://github.com/livepeer/go-livepeer/tree/ai-video). This
-branch contains the necessary software for the AI Orchestrator. Currently, there
-are two methods to run the Livepeer AI network software:
+The Livepeer AI network is currently in **Beta** but is already integrated into
+the main [go-livepeer](https://github.com/livepeer/go-livepeer) software. You
+can run the Livepeer AI software using one of the following methods:
 
-- **Docker**: This is the most straightforward and recommended method to run the
-  AI Orchestrator node.
-- **Pre-built Binaries**: Pre-built binaries are available if you prefer not to
-  use Docker.
+- **Docker** (Recommended): The simplest and preferred method.
+- **Pre-built Binaries**: An alternative if you prefer not to use Docker.
 
 ## Orchestrator Node Architecture
 
@@ -51,7 +45,7 @@ Please follow the steps below to start your **combined AI orchestrator** node.
                 Fetch the latest Livepeer AI Docker image from the [Livepeer Docker Hub](https://hub.docker.com/r/livepeer/go-livepeer) with the following command:
 
                 ```bash
-                docker pull livepeer/go-livepeer:ai-video
+                docker pull livepeer/go-livepeer:master
                 ```
             </Step>
             <Step title="Fetch the Latest AI Runner Docker Image">
@@ -95,7 +89,7 @@ Please follow the steps below to start your **combined AI orchestrator** node.
                     -v /var/run/docker.sock:/var/run/docker.sock \
                     --network host \
                     --gpus all \
-                    livepeer/go-livepeer:ai-video \
+                    livepeer/go-livepeer:master \
                     -orchestrator \
                     -transcoder \
                     -serviceAddr 0.0.0.0:8936 \
@@ -139,13 +133,13 @@ Please follow the steps below to start your **combined AI orchestrator** node.
                 Download the latest Livepeer AI binary for your system:
 
                 ```bash
-                wget https://build.livepeer.live/go-livepeer/ai-video/stable/livepeer-<OS>-gpu-<ARCH>.tar.gz
+                wget https://build.livepeer.live/go-livepeer/livepeer-<OS>-gpu-<ARCH>.tar.gz
                 ```
 
                 Replace `<OS>` and `<ARCH>` with your system's operating system and architecture. For example, for a Linux system with an AMD64 architecture, the command would be:
 
                 ```bash
-                wget https://build.livepeer.live/go-livepeer/ai-video/stable/livepeer-linux-gpu-amd64.tar.gz
+                wget https://build.livepeer.live/go-livepeer/livepeer-linux-gpu-amd64.tar.gz
                 ```
 
                 See the [go-livepeer installation guide](/orchestrators/guides/install-go-livepeer#install-using-a-binary-release) for more information on the available binaries.
@@ -225,7 +219,7 @@ Please follow the steps below to start your **combined AI orchestrator** node.
             </Step>
         </Steps>
         <Note>
-            If no binaries are available for your system, you can build the [ai-video branch](https://github.com/livepeer/go-livepeer/tree/ai-video) of [go-livepeer](https://github.com/livepeer/go-livepeer) from source by following the instructions in the [Livepeer repository](/orchestrators/guides/install-go-livepeer) or by reaching out to the Livepeer community on [Discord](https://discord.gg/livepeer).
+            If no binaries are available for your system, you can build the [master branch](https://github.com/livepeer/go-livepeer/tree/master) of [go-livepeer](https://github.com/livepeer/go-livepeer) from source by following the instructions in the [Livepeer repository](/orchestrators/guides/install-go-livepeer) or by reaching out to the Livepeer community on [Discord](https://discord.gg/livepeer).
         </Note>
     </Tab>
 


### PR DESCRIPTION
This pull request ensures that node operators are aware they have to use the `AIServiceRegistry` flag for processing or requesting AI jobs.