### PR TITLE
(t2s) - fix incorrect req param for t2s

### DIFF
--- a/ai/pipelines/text-to-speech.mdx
+++ b/ai/pipelines/text-to-speech.mdx
@@ -21,7 +21,7 @@ curl -X POST "http://<GATEWAY_IP>/text-to-speech" \
     -H "Content-Type: application/json" \
     -d '{
         "model_id": "parler-tts/parler-tts-large-v1",
-        "text_input": "A cool cat on the beach",
+        "text": "A cool cat on the beach",
         "description": "Jon his voice is monotone yet slightly fast in delivery, with a very close recording that almost has no background noise."
     }'
 ```
@@ -29,7 +29,7 @@ curl -X POST "http://<GATEWAY_IP>/text-to-speech" \
 ### Request Parameters
 
 - `model_id`: The ID of the text-to-speech model to use. Currently, this should be set to `"parler-tts/parler-tts-large-v1"`.
-- `text_input`: The text you want to convert to speech.
+- `text`: The text you want to convert to speech.
 - `description`: A description of the desired voice characteristics. This can include details about the speaker's voice, speaking style, and audio quality.
 
 ### Voice Customization


### PR DESCRIPTION
Fixes the field name which is `text` instead of `text-input`