### PR TITLE
docs(ai): remove transcode flag from AI docs

### DIFF
--- a/ai/orchestrators/start-orchestrator.mdx
+++ b/ai/orchestrators/start-orchestrator.mdx
@@ -91,7 +91,6 @@ Please follow the steps below to start your **combined AI orchestrator** node.
                     --gpus all \
                     livepeer/go-livepeer:master \
                     -orchestrator \
-                    -transcoder \
                     -serviceAddr 0.0.0.0:8936 \
                     -v 6 \
                     -nvidia "all" \
@@ -186,7 +185,6 @@ Please follow the steps below to start your **combined AI orchestrator** node.
                 ```bash
                 ./livepeer \
                     -orchestrator \
-                    -transcoder \
                     -serviceAddr 0.0.0.0:8936 \
                     -v 6 \
                     -nvidia "all" \


### PR DESCRIPTION
This pull request removes the `transcode` flag from the AI orch setup instructions since it is no longer needed now that https://github.com/livepeer/go-livepeer/pull/3355 is merged.
