### PR TITLE
docs(ai): add AIServiceRegistry contract

### DIFF
--- a/references/contract-addresses.mdx
+++ b/references/contract-addresses.mdx
@@ -46,6 +46,8 @@ All contracts on Arbitrum Mainnet implement the Delta version of the protocol.
   [0xC92d3A360b8f9e083bA64DE15d95Cf8180897431](https://arbiscan.io/address/0xC92d3A360b8f9e083bA64DE15d95Cf8180897431)
 - ServiceRegistry (Target):
   [0x38093CDca43aeCd7bb474983519A246e93A3b0a7](https://arbiscan.io/address/0x38093CDca43aeCd7bb474983519A246e93A3b0a7)
+- AIServiceRegistry (Target):
+  [0x04C0b249740175999E5BF5c9ac1dA92431EF34C5](https://arbiscan.io/address/0x04C0b249740175999E5BF5c9ac1dA92431EF34C5) (detatched from controller)
 - SortedDoublyLL:
   [0xC45f6918F7Bcac7aBc8fe05302b3cDF39776cdeb](https://arbiscan.io/address/0xC45f6918F7Bcac7aBc8fe05302b3cDF39776cdeb)
 - PollCreator:


### PR DESCRIPTION
This pull request adds the `AIServiceRegistry` to the verified contracts list.
