### PR TITLE
fix: update broken link to livepeer-python SDK examples

### DIFF
--- a/sdks/python.mdx
+++ b/sdks/python.mdx
@@ -63,7 +63,7 @@ if res.stream is not None:
   <Step title="Try it yourself">
       <Card
     title="Python Example"
-    href="https://github.com/livepeer/livepeer-python/tree/main/example"
+    href="https://github.com/livepeer/livepeer-python?tab=readme-ov-file#sdk-example-usage"
     icon="arrow-up-right-from-square"
   >
       See an example on GitHub.


### PR DESCRIPTION
Fixes a broken link in the docs for livepeer-python