### PR TITLE
docs: replace temporary Discord invite URL with permanent URL

### DIFF
--- a/ai/contributors/coming-soon.mdx
+++ b/ai/contributors/coming-soon.mdx
@@ -9,7 +9,7 @@ All our software is open-source, and anyone can permissionlessly add their AI
 compute job to the Livepeer network. We have a strong developer community with a
 [core developer group](https://github.com/livepeer/project-management) and tens
 of open-source developers. The best way to get in touch with this community and
-start developing is by joining our [Discord](https://discord.gg/7w2R6v).
+start developing is by joining our [Discord](https://discord.gg/livepeer).
 
 We also offer multiple opportunities for developers to get rewarded for their
 contributions, such as our
@@ -22,6 +22,6 @@ Let's build something amazing together! 🚀
 
 <Note>
   Contribution guidelines are coming soon. In the meantime, join the `ai-video`
-  channel on the [Livepeer Discord](https://discord.gg/7w2R6v) for any questions
+  channel on the [Livepeer Discord](https://discord.gg/livepeer) for any questions
   or assistance. Let's build something amazing together! 🚀
 </Note>

--- a/ai/contributors/developers.mdx
+++ b/ai/contributors/developers.mdx
@@ -10,7 +10,7 @@ steps to get started:
    https://livepeer.org/developers and read through the general documentation to
    get familiar with the Livepeer ecosystem.
 2. **Join the Livepeer Discord**: Join the Livepeer Discord at
-   https://discord.gg/7w2R6v and introduce yourself in the `ai-video` channel.
+   https://discord.gg/livepeer and introduce yourself in the `ai-video` channel.
    Share your background and what you are interested in building.
 3. **Get familiar with the AI Subnet**: Read through the
    [AI Subnet documentation](/ai/introduction) to understand the architecture

--- a/ai/contributors/get-started.mdx
+++ b/ai/contributors/get-started.mdx
@@ -21,5 +21,5 @@ ecosystem together ❤️. Here are a few ways to get started:
   [Contributing to the AI Subnet](/ai/contributors/coming-soon) to learn more.
 
 For any questions or help needed, reach out in the `ai-video` channel of the
-[Livepeer Discord](https://discord.gg/7w2R6v). Support is available to help get
+[Livepeer Discord](https://discord.gg/livepeer). Support is available to help get
 started and along the way. Let's build together! 🚀

--- a/orchestrators/guides/set-pricing.mdx
+++ b/orchestrators/guides/set-pricing.mdx
@@ -14,7 +14,7 @@ To charge for transcoding orchestrators set a price per pixel denominated in Wei
 (1 ETH = 1e18 Wei), advertised to gateways off-chain.
 
 To get support for setting a price that will allow you to receive work on the
-network, contact us on our [Discord](https://discord.gg/uaPhtyrWsF) channel.
+network, contact us on our [Discord](https://discord.gg/livepeer) channel.
 
 ## Configure Automatic Price Adjustments
 


### PR DESCRIPTION
This pull request updates the Discord invite URL from a temporary (expiring) link to a fixed (permanent) one to ensure long-term accessibility.
