### PR TITLE
docs(gateway): add production reserve recommendation

### DIFF
--- a/gateways/guides/fund-gateway.mdx
+++ b/gateways/guides/fund-gateway.mdx
@@ -34,6 +34,10 @@ Gateway address.
 
 # Deposit Gateway Funds via Livepeer CLI
 
+<Warning>
+  **For production environments**, we recommend a **Reserve** of at least 0.36 ETH to prevent service interruptions during gas spikes. The higher reserve amount helps maintain service continuity during periods of high gas prices on the network. There is [an issue open](https://github.com/livepeer/go-livepeer/issues/3744) to reduce this requirement in the future.
+</Warning>
+
 We now need to divide the Gateway funds into a **Deposit** and **Reserve**
 
 In this guide we are using a total of 0.1 ETH. This is minimum recommended and


### PR DESCRIPTION
This pull request adds an admonition to the gateway documentation recommending a minimum reserve of 0.36 ETH to help prevent outages in production environments.
