### PR TITLE
Clarify/simplify dependencies for Ubuntu

### DIFF
--- a/orchestrators/guides/install-go-livepeer.mdx
+++ b/orchestrators/guides/install-go-livepeer.mdx
@@ -156,16 +156,10 @@ docker pull livepeer/go-livepeer:master
 
 Building `livepeer` requires some system dependencies.
 
-#### Linux (Ubuntu: 16.04 or 18.04)
+#### Linux (Ubuntu Server 20.04 or newer)
 
 ```bash
-apt-get update && apt-get -y install build-essential pkg-config autoconf git curl yasm
-```
-
-#### Linux (Ubuntu: 20.04 or newer)
-
-```bash
-apt-get -y install protobuf-compiler-grpc golang-goprotobuf-dev yasm pkg-config
+apt-get -y install build-essential pkg-config nasm libx264-dev
 ```
 
 #### Linux GPU support


### PR DESCRIPTION
Simplified the dependencies.

20.04 and 22.04 both only need build-essential and pkg-config. 24.04 needs the additional nasm and x264, but I figured it made sense to simplify overall.

All were tested on clean installs of ubuntu server.