### PR TITLE
Download latest released dl_checkpoints.sh

### DIFF
--- a/ai/orchestrators/models-download.mdx
+++ b/ai/orchestrators/models-download.mdx
@@ -36,7 +36,7 @@ through downloading the **recommended** models for Livepeer AI.
         ```bash
         cd ~/.lpData
         latest=$(curl -s https://api.github.com/repos/livepeer/ai-runner/releases/latest | grep '"tag_name":' | cut -d'"' -f4)
-        curl -s https://raw.githubusercontent.com/livepeer/ai-worker/tags/$latest/runner/dl_checkpoints.sh | bash -s -- --beta
+        curl -s https://raw.githubusercontent.com/livepeer/ai-runner/tags/$latest/runner/dl_checkpoints.sh | bash -s -- --beta
         ```
 
         This command downloads the recommended models for Livepeer AI and stores them in your machine's `~/.lpData/models` directory. To obtain a complete set of models, omit the `--beta` flag. This will require additional disk space.

--- a/ai/orchestrators/models-download.mdx
+++ b/ai/orchestrators/models-download.mdx
@@ -35,7 +35,8 @@ through downloading the **recommended** models for Livepeer AI.
 
         ```bash
         cd ~/.lpData
-        curl -s https://raw.githubusercontent.com/livepeer/ai-worker/main/runner/dl_checkpoints.sh | bash -s -- --beta
+        latest=$(curl -s https://api.github.com/repos/livepeer/ai-runner/releases/latest | grep '"tag_name":' | cut -d'"' -f4)
+        curl -s https://raw.githubusercontent.com/livepeer/ai-worker/tags/$latest/runner/dl_checkpoints.sh | bash -s -- --beta
         ```
 
         This command downloads the recommended models for Livepeer AI and stores them in your machine's `~/.lpData/models` directory. To obtain a complete set of models, omit the `--beta` flag. This will require additional disk space.


### PR DESCRIPTION
Pulling from `main` branch pulls beta versions (staging), we are transitioning to deploying to `prod` via releases, so public Os pulling the latest release should match the same code we deploy to `prod`