### PR TITLE
docs: clean up inline styles in documentation

### DIFF
--- a/developers/guides/get-engagement-analytics-via-api.mdx
+++ b/developers/guides/get-engagement-analytics-via-api.mdx
@@ -159,7 +159,7 @@ export default function VideoPlayer() {
       controls
       ref={ref}
       src={source}
-      style={{ width: "100%", maxWidth: "500px" }}
+      className="w-full max-w-[500px]"
     />
   );
 }

--- a/sdks/react/broadcast/Audio.mdx
+++ b/sdks/react/broadcast/Audio.mdx
@@ -13,10 +13,7 @@ icon: microphone-stand
   frameBorder="0"
   allowFullScreen
   allow="autoplay; encrypted-media; fullscreen; picture-in-picture; display-capture; camera; microphone"
-  style={{
-    borderRadius: 10,
-    backgroundColor: "black",
-  }}
+  className="rounded-[10px] bg-black"
 />
 
 <Info>

--- a/sdks/react/broadcast/Camera.mdx
+++ b/sdks/react/broadcast/Camera.mdx
@@ -14,10 +14,7 @@ icon: camcorder
   frameBorder="0"
   allowFullScreen
   allow="autoplay; encrypted-media; fullscreen; picture-in-picture; display-capture; camera; microphone"
-  style={{
-    borderRadius: 10,
-    backgroundColor: "black",
-  }}
+  className="rounded-[10px] bg-black"
 />
 
 <Info>

--- a/sdks/react/broadcast/Container.mdx
+++ b/sdks/react/broadcast/Container.mdx
@@ -13,10 +13,7 @@ icon: tv
   frameBorder="0"
   allowFullScreen
   allow="autoplay; encrypted-media; fullscreen; picture-in-picture; display-capture; camera; microphone"
-  style={{
-    borderRadius: 10,
-    backgroundColor: "black",
-  }}
+ className="rounded-[10px] bg-black"
 />
 
 <Info>

--- a/sdks/react/broadcast/Controls.mdx
+++ b/sdks/react/broadcast/Controls.mdx
@@ -13,10 +13,7 @@ icon: gamepad
   frameBorder="0"
   allowFullScreen
   allow="autoplay; encrypted-media; fullscreen; picture-in-picture; display-capture; camera; microphone"
-  style={{
-    borderRadius: 10,
-    backgroundColor: "black",
-  }}
+  className="rounded-[10px] bg-black"
 />
 
 <Info>

--- a/sdks/react/broadcast/Enabled.mdx
+++ b/sdks/react/broadcast/Enabled.mdx
@@ -14,10 +14,7 @@ icon: clapperboard
   frameBorder="0"
   allowFullScreen
   allow="autoplay; encrypted-media; fullscreen; picture-in-picture; display-capture; camera; microphone"
-  style={{
-    borderRadius: 10,
-    backgroundColor: "black",
-  }}
+  className="rounded-[10px] bg-black"
 />
 
 <Info>

--- a/sdks/react/broadcast/Error.mdx
+++ b/sdks/react/broadcast/Error.mdx
@@ -13,10 +13,7 @@ icon: triangle-exclamation
   frameBorder="0"
   allowFullScreen
   allow="autoplay; encrypted-media; fullscreen; picture-in-picture; display-capture; camera; microphone"
-  style={{
-    borderRadius: 10,
-    backgroundColor: "black",
-  }}
+  className="rounded-[10px] bg-black"
 />
 
 <Info>

--- a/sdks/react/broadcast/Fullscreen.mdx
+++ b/sdks/react/broadcast/Fullscreen.mdx
@@ -13,10 +13,7 @@ icon: expand
   frameBorder="0"
   allowFullScreen
   allow="autoplay; encrypted-media; fullscreen; picture-in-picture; display-capture; camera; microphone"
-  style={{
-    borderRadius: 10,
-    backgroundColor: "black",
-  }}
+className="rounded-[10px] bg-black"
 />
 
 ## Features

--- a/sdks/react/broadcast/Loading.mdx
+++ b/sdks/react/broadcast/Loading.mdx
@@ -13,10 +13,7 @@ icon: spinner
   frameBorder="0"
   allowFullScreen
   allow="autoplay; encrypted-media; fullscreen; picture-in-picture; display-capture; camera; microphone"
-  style={{
-    borderRadius: 10,
-    backgroundColor: "black",
-  }}
+ className="rounded-[10px] bg-black"
 />
 
 <Info>

--- a/sdks/react/broadcast/PictureInPicture.mdx
+++ b/sdks/react/broadcast/PictureInPicture.mdx
@@ -12,10 +12,7 @@ icon: clone
   frameBorder="0"
   allowFullScreen
   allow="autoplay; encrypted-media; fullscreen; picture-in-picture; display-capture; camera; microphone"
-  style={{
-    borderRadius: 10,
-    backgroundColor: "black",
-  }}
+  className="rounded-[10px] bg-black"
 />
 
 ## Features

--- a/sdks/react/broadcast/Portal.mdx
+++ b/sdks/react/broadcast/Portal.mdx
@@ -13,10 +13,7 @@ icon: person-to-portal
   frameBorder="0"
   allowFullScreen
   allow="autoplay; encrypted-media; fullscreen; picture-in-picture; display-capture; camera; microphone"
-  style={{
-    borderRadius: 10,
-    backgroundColor: "black",
-  }}
+ className="rounded-[10px] bg-black"
 />
 
 <Info>

--- a/sdks/react/broadcast/Root.mdx
+++ b/sdks/react/broadcast/Root.mdx
@@ -12,10 +12,7 @@ icon: flag-checkered
   frameBorder="0"
   allowFullScreen
   allow="autoplay; encrypted-media; fullscreen; picture-in-picture; display-capture; camera; microphone"
-  style={{
-    borderRadius: 10,
-    backgroundColor: "black",
-  }}
+ className="rounded-[10px] bg-black"
 />
 
 <Info>

--- a/sdks/react/broadcast/Screenshare.mdx
+++ b/sdks/react/broadcast/Screenshare.mdx
@@ -13,10 +13,7 @@ icon: screencast
   frameBorder="0"
   allowFullScreen
   allow="autoplay; encrypted-media; fullscreen; picture-in-picture; display-capture; camera; microphone"
-  style={{
-    borderRadius: 10,
-    backgroundColor: "black",
-  }}
+  className="rounded-[10px] bg-black"
 />
 
 ## Features

--- a/sdks/react/broadcast/Source.mdx
+++ b/sdks/react/broadcast/Source.mdx
@@ -13,10 +13,7 @@ icon: sliders
   frameBorder="0"
   allowFullScreen
   allow="autoplay; encrypted-media; fullscreen; picture-in-picture; display-capture; camera; microphone"
-  style={{
-    borderRadius: 10,
-    backgroundColor: "black",
-  }}
+ className="rounded-[10px] bg-black"
 />
 
 <Info>

--- a/sdks/react/broadcast/Status.mdx
+++ b/sdks/react/broadcast/Status.mdx
@@ -13,10 +13,7 @@ icon: wave-pulse
   frameBorder="0"
   allowFullScreen
   allow="autoplay; encrypted-media; fullscreen; picture-in-picture; display-capture; camera; microphone"
-  style={{
-    borderRadius: 10,
-    backgroundColor: "black",
-  }}
+  className="rounded-[10px] bg-black"
 />
 
 ## Features

--- a/sdks/react/broadcast/Video.mdx
+++ b/sdks/react/broadcast/Video.mdx
@@ -12,10 +12,8 @@ icon: video
   frameBorder="0"
   allowFullScreen
   allow="autoplay; encrypted-media; fullscreen; picture-in-picture; display-capture; camera; microphone"
-  style={{
-    borderRadius: 10,
-    backgroundColor: "black",
-  }}
+ className="rounded-[10px] bg-black"
+
 />
 
 <Warning>

--- a/sdks/react/broadcast/useBroadcastContext.mdx
+++ b/sdks/react/broadcast/useBroadcastContext.mdx
@@ -13,10 +13,8 @@ icon: database
   frameBorder="0"
   allowFullScreen
   allow="autoplay; encrypted-media; fullscreen; picture-in-picture; display-capture; camera; microphone"
-  style={{
-    borderRadius: 10,
-    backgroundColor: "black",
-  }}
+ className="rounded-[10px] bg-black"
+
 />
 
 <Info>

--- a/sdks/react/getting-started.mdx
+++ b/sdks/react/getting-started.mdx
@@ -32,10 +32,7 @@ streaming button.
       frameBorder="0"
       allowFullScreen
       allow="autoplay; encrypted-media; fullscreen; picture-in-picture; display-capture; camera; microphone"
-      style={{
-        borderRadius: 10,
-        backgroundColor: "black",
-      }}
+      className="rounded-[10px] bg-black"
     />
   </Tab>
   <Tab title="Broadcast.tsx">
@@ -46,10 +43,7 @@ streaming button.
       frameBorder="0"
       allowFullScreen
       allow="autoplay; encrypted-media; fullscreen; picture-in-picture; display-capture; camera; microphone"
-      style={{
-        borderRadius: 10,
-        backgroundColor: "black",
-      }}
+      className="rounded-[10px] bg-black"
     />
   </Tab>
 </Tabs>

--- a/sdks/react/player/Clip.mdx
+++ b/sdks/react/player/Clip.mdx
@@ -13,10 +13,8 @@ icon: scissors
   frameBorder="0"
   allowFullScreen
   allow="autoplay; encrypted-media; fullscreen; picture-in-picture; display-capture; camera; microphone"
-  style={{
-    borderRadius: 10,
-    backgroundColor: "black",
-  }}
+  className="rounded-[10px] bg-black"
+
 />
 
 <Info>

--- a/sdks/react/player/Container.mdx
+++ b/sdks/react/player/Container.mdx
@@ -13,10 +13,8 @@ icon: tv
   frameBorder="0"
   allowFullScreen
   allow="autoplay; encrypted-media; fullscreen; picture-in-picture; display-capture; camera; microphone"
-  style={{
-    borderRadius: 10,
-    backgroundColor: "black",
-  }}
+  className="rounded-[10px] bg-black"
+
 />
 
 <Info>

--- a/sdks/react/player/Controls.mdx
+++ b/sdks/react/player/Controls.mdx
@@ -13,10 +13,8 @@ icon: gamepad
   frameBorder="0"
   allowFullScreen
   allow="autoplay; encrypted-media; fullscreen; picture-in-picture; display-capture; camera; microphone"
-  style={{
-    borderRadius: 10,
-    backgroundColor: "black",
-  }}
+  className="rounded-[10px] bg-black"
+
 />
 
 <Info>

--- a/sdks/react/player/Error.mdx
+++ b/sdks/react/player/Error.mdx
@@ -13,10 +13,8 @@ icon: triangle-exclamation
   frameBorder="0"
   allowFullScreen
   allow="autoplay; encrypted-media; fullscreen; picture-in-picture; display-capture; camera; microphone"
-  style={{
-    borderRadius: 10,
-    backgroundColor: "black",
-  }}
+ className="rounded-[10px] bg-black"
+
 />
 
 <Info>

--- a/sdks/react/player/Fullscreen.mdx
+++ b/sdks/react/player/Fullscreen.mdx
@@ -13,10 +13,8 @@ icon: expand
   frameBorder="0"
   allowFullScreen
   allow="autoplay; encrypted-media; fullscreen; picture-in-picture; display-capture; camera; microphone"
-  style={{
-    borderRadius: 10,
-    backgroundColor: "black",
-  }}
+  className="rounded-[10px] bg-black"
+
 />
 
 ## Features

--- a/sdks/react/player/Live.mdx
+++ b/sdks/react/player/Live.mdx
@@ -13,10 +13,8 @@ icon: headset
   frameBorder="0"
   allowFullScreen
   allow="autoplay; encrypted-media; fullscreen; picture-in-picture; display-capture; camera; microphone"
-  style={{
-    borderRadius: 10,
-    backgroundColor: "black",
-  }}
+ className="rounded-[10px] bg-black"
+
 />
 
 <Info>

--- a/sdks/react/player/Loading.mdx
+++ b/sdks/react/player/Loading.mdx
@@ -13,10 +13,8 @@ icon: spinner
   frameBorder="0"
   allowFullScreen
   allow="autoplay; encrypted-media; fullscreen; picture-in-picture; display-capture; camera; microphone"
-  style={{
-    borderRadius: 10,
-    backgroundColor: "black",
-  }}
+ className="rounded-[10px] bg-black"
+
 />
 
 <Info>

--- a/sdks/react/player/PictureInPicture.mdx
+++ b/sdks/react/player/PictureInPicture.mdx
@@ -12,10 +12,8 @@ icon: clone
   frameBorder="0"
   allowFullScreen
   allow="autoplay; encrypted-media; fullscreen; picture-in-picture; display-capture; camera; microphone"
-  style={{
-    borderRadius: 10,
-    backgroundColor: "black",
-  }}
+ className="rounded-[10px] bg-black"
+
 />
 
 ## Features

--- a/sdks/react/player/Play.mdx
+++ b/sdks/react/player/Play.mdx
@@ -13,10 +13,8 @@ icon: play
   frameBorder="0"
   allowFullScreen
   allow="autoplay; encrypted-media; fullscreen; picture-in-picture; display-capture; camera; microphone"
-  style={{
-    borderRadius: 10,
-    backgroundColor: "black",
-  }}
+ className="rounded-[10px] bg-black"
+
 />
 
 <Info>

--- a/sdks/react/player/Portal.mdx
+++ b/sdks/react/player/Portal.mdx
@@ -13,10 +13,8 @@ icon: person-to-portal
   frameBorder="0"
   allowFullScreen
   allow="autoplay; encrypted-media; fullscreen; picture-in-picture; display-capture; camera; microphone"
-  style={{
-    borderRadius: 10,
-    backgroundColor: "black",
-  }}
+className="rounded-[10px] bg-black"
+
 />
 
 <Info>

--- a/sdks/react/player/Poster.mdx
+++ b/sdks/react/player/Poster.mdx
@@ -13,10 +13,8 @@ icon: image
   frameBorder="0"
   allowFullScreen
   allow="autoplay; encrypted-media; fullscreen; picture-in-picture; display-capture; camera; microphone"
-  style={{
-    borderRadius: 10,
-    backgroundColor: "black",
-  }}
+  className="rounded-[10px] bg-black"
+
 />
 
 <Info>

--- a/sdks/react/player/RateSelect.mdx
+++ b/sdks/react/player/RateSelect.mdx
@@ -13,10 +13,8 @@ icon: gauge-simple-high
   frameBorder="0"
   allowFullScreen
   allow="autoplay; encrypted-media; fullscreen; picture-in-picture; display-capture; camera; microphone"
-  style={{
-    borderRadius: 10,
-    backgroundColor: "black",
-  }}
+ className="rounded-[10px] bg-black"
+
 />
 
 <Info>

--- a/sdks/react/player/Root.mdx
+++ b/sdks/react/player/Root.mdx
@@ -12,10 +12,8 @@ icon: flag-checkered
   frameBorder="0"
   allowFullScreen
   allow="autoplay; encrypted-media; fullscreen; picture-in-picture; display-capture; camera; microphone"
-  style={{
-    borderRadius: 10,
-    backgroundColor: "black",
-  }}
+ className="rounded-[10px] bg-black"
+
 />
 
 <Info>

--- a/sdks/react/player/Seek.mdx
+++ b/sdks/react/player/Seek.mdx
@@ -13,10 +13,8 @@ icon: forward
   frameBorder="0"
   allowFullScreen
   allow="autoplay; encrypted-media; fullscreen; picture-in-picture; display-capture; camera; microphone"
-  style={{
-    borderRadius: 10,
-    backgroundColor: "black",
-  }}
+  className="rounded-[10px] bg-black"
+
 />
 
 <Info>

--- a/sdks/react/player/Time.mdx
+++ b/sdks/react/player/Time.mdx
@@ -12,10 +12,8 @@ icon: clock
   frameBorder="0"
   allowFullScreen
   allow="autoplay; encrypted-media; fullscreen; picture-in-picture; display-capture; camera; microphone"
-  style={{
-    borderRadius: 10,
-    backgroundColor: "black",
-  }}
+ className="rounded-[10px] bg-black"
+
 />
 
 ## Features

--- a/sdks/react/player/Video.mdx
+++ b/sdks/react/player/Video.mdx
@@ -12,10 +12,8 @@ icon: video
   frameBorder="0"
   allowFullScreen
   allow="autoplay; encrypted-media; fullscreen; picture-in-picture; display-capture; camera; microphone"
-  style={{
-    borderRadius: 10,
-    backgroundColor: "black",
-  }}
+ className="rounded-[10px] bg-black"
+
 />
 
 #### Features

--- a/sdks/react/player/VideoQualitySelect.mdx
+++ b/sdks/react/player/VideoQualitySelect.mdx
@@ -13,10 +13,8 @@ icon: signal
   frameBorder="0"
   allowFullScreen
   allow="autoplay; encrypted-media; fullscreen; picture-in-picture; display-capture; camera; microphone"
-  style={{
-    borderRadius: 10,
-    backgroundColor: "black",
-  }}
+className="rounded-[10px] bg-black"
+
 />
 
 <Info>

--- a/sdks/react/player/Volume.mdx
+++ b/sdks/react/player/Volume.mdx
@@ -13,10 +13,8 @@ icon: volume-high
   frameBorder="0"
   allowFullScreen
   allow="autoplay; encrypted-media; fullscreen; picture-in-picture; display-capture; camera; microphone"
-  style={{
-    borderRadius: 10,
-    backgroundColor: "black",
-  }}
+ className="rounded-[10px] bg-black"
+
 />
 
 <Info>

--- a/sdks/react/player/useMediaContext.mdx
+++ b/sdks/react/player/useMediaContext.mdx
@@ -13,10 +13,8 @@ icon: database
   frameBorder="0"
   allowFullScreen
   allow="autoplay; encrypted-media; fullscreen; picture-in-picture; display-capture; camera; microphone"
-  style={{
-    borderRadius: 10,
-    backgroundColor: "black",
-  }}
+ className="rounded-[10px] bg-black"
+
 />
 
 <Info>


### PR DESCRIPTION
### What changed
- Removed inline styles from multiple MDX documentation pages
- Replaced them with class-based styling to avoid mixed styling approaches

### Why
- Improves consistency and maintainability of docs styling

Closes #744
