### PR TITLE
Update workload consumer URLs in developer journey

### DIFF
--- a/v2/developers/developer-journey.mdx
+++ b/v2/developers/developer-journey.mdx
@@ -125,13 +125,12 @@ As a **Workload Consumer**, you use existing pipeline workloads that are already
 ### Available Pipelines
 
 <Columns cols={2}>
-  <Card title="Daydream (DaS Scope)" icon="wand-sparkles" href="#">
+  <Card title="Daydream (DaS Scope)" icon="wand-sparkles" href="https://daydream.live/?utm_source=google&utm_medium=search&utm_campaign=23258122503&utm_term=&utm_content=&gad_source=1&gad_campaignid=23267486074&gbraid=0AAAABBoxESHVYX7R6KJ9HPMUuCIz6IOcj&gclid=Cj0KCQiA5I_NBhDVARIsAOrqIsasHrmS4nY13_rIDLHbm-LLc-PveIaE3HaD9t-7oQKycBzIE5lqogAaAqY5EALw_wcB" arrow>
     Consume Daydream pipeline workloads on the Livepeer network.
-    <Note>Link coming soon</Note>
   </Card>
-  <Card title="Embody Pipeline" icon="user-robot" href="#">
-    Consume Embody pipeline workloads for real-time avatar and VTuber applications.
-    <Note>Link coming soon</Note>
+  <Card title="Embody Pipeline" icon="user-robot" href="https://github.com/its-DeFine/embody-skill/blob/main/SKILL.md" arrow>
+    Use Embody workloads for real-time avatar and VTuber applications by giving your agent the `SKILL.md` file.
+    The `SKILL.md` contains the full instructions needed to consume and use Embody workloads.
   </Card>
 </Columns>
 


### PR DESCRIPTION
## Summary
- replace Daydream placeholder link in Path 2 (Workload Consumer) with the provided Daydream URL
- replace Embody placeholder link with the embody-skill SKILL.md URL
- add copy explaining that providing agents the SKILL.md is enough because it contains instructions to consume and use Embody workloads

## File changed
- v2/developers/developer-journey.mdx