### PR TITLE
docs(gateways): promote docker install path and quickstart guidance

### DIFF
--- a/v2/gateways/run-a-gateway/install/docker-install.mdx
+++ b/v2/gateways/run-a-gateway/install/docker-install.mdx
@@ -1,604 +1,273 @@
 ---
 title: Docker Install
-description: How to install a Livepeer Gateway using Docker
+description: Install and run a Livepeer transcoding gateway using Docker
 sidebarTitle: Docker Install
 icon: docker
-keywords: ["livepeer", "gateways", "run a gateway", "install", "docker install", "docker", "gateway"]
+keywords: ["livepeer", "gateways", "run a gateway", "install", "docker install", "docker", "gateway", "transcoding", "rtmp"]
 og:image: "/snippets/assets/domain/SHARED/LivepeerDocsLogo.svg"
 ---
 
-
-
-
-<Warning> Complete: needs review </Warning>
-
-import { StyledSteps, StyledStep } from '/snippets/components/layout/steps.jsx'
 import { DoubleIconLink } from '/snippets/components/primitives/links.jsx'
+import { StyledSteps, StyledStep } from '/snippets/components/layout/steps.jsx'
 
-<Badge color="green"> Dual AI & Video </Badge>
-<Icon icon="linux" />
-<Icon icon="windows" />
+<Note>
+  The Livepeer Gateway was previously called the Livepeer Broadcaster. Some CLI
+  flags and log output still reference the Broadcaster name.
+</Note>
+
+## Prerequisites
+
+Docker Engine 20.10 or later is required. If Docker is not installed or needs updating, follow the official [Docker Engine installation guide](https://docs.docker.com/engine/install/) for your platform.
+
+Verify your installed version:
+
+```bash
+docker --version
+```
+
+## Pull the Livepeer Docker Image
+
+Fetch the latest <DoubleIconLink label="Livepeer Docker image" href="https://hub.docker.com/r/livepeer/go-livepeer" iconLeft="docker" /> from Docker Hub:
+
+```bash
+docker pull livepeer/go-livepeer:master
+```
+
+## Configure the Gateway
+
+Create a working directory and a `docker-compose.yml` file. Choose the configuration that matches your deployment target:
+
+<Tabs>
+  <Tab title="On-Chain (Production)">
+    On-chain mode connects the gateway to the Livepeer network on Arbitrum. An
+    Ethereum wallet and Arbitrum One RPC endpoint are required before starting.
+    See [On-Chain Setup Requirements](/v2/gateways/run-a-gateway/requirements/on-chain%20setup/on-chain)
+    for prerequisites.
+
+    ```yaml docker-compose.yml
+    services:
+      gateway:
+        image: livepeer/go-livepeer:master
+        container_name: "gateway"
+        restart: unless-stopped
+        ports:
+          - 1935:1935   # RTMP ingest
+          - 8935:8935   # HTTP API / HLS output
+          - 5935:5935   # CLI
+        volumes:
+          - ./data/gateway:/root/.lpData
+        command:
+          - "-gateway"
+          - "-network=arbitrum-one-mainnet"
+          - "-ethUrl=<YOUR_ARB_RPC_URL>"
+          - "-ethKeystorePath=/root/.lpData/keystore"
+          - "-ethPassword=/root/.lpData/eth-secret.txt"
+          - "-rtmpAddr=0.0.0.0:1935"
+          - "-httpAddr=0.0.0.0:8935"
+          - "-cliAddr=0.0.0.0:5935"
+          - "-httpIngest=true"
+          - "-blockPollingInterval=10"
+          - "-transcodingOptions=P240p30fps16x9,P360p30fps16x9"
+          - "-monitor"
+          - "-v=6"
+    ```
+
+    Replace `<YOUR_ARB_RPC_URL>` with your Arbitrum One RPC endpoint (e.g.
+    from Alchemy or Infura).
+
+    After creating this file, complete the [Create Livepeer Gateway ETH Account](#create-livepeer-gateway-eth-account)
+    step below before starting the gateway.
+  </Tab>
+  <Tab title="Development (Off-Chain)">
+    Off-chain mode runs without blockchain connectivity and is intended for
+    local development. You must supply the address of a running orchestrator
+    node via `-orchAddr`.
+
+    <Warning>
+      You need access to a running orchestrator node. For local testing, run
+      your own orchestrator or point to a known development node.
+    </Warning>
+
+    ```yaml docker-compose.yml
+    services:
+      gateway:
+        image: livepeer/go-livepeer:master
+        container_name: "gateway"
+        restart: unless-stopped
+        ports:
+          - 1935:1935   # RTMP ingest
+          - 8935:8935   # HTTP API / HLS output
+          - 5935:5935   # CLI
+        volumes:
+          - ./data/gateway:/root/.lpData
+        command:
+          - "-gateway"
+          - "-network=offchain"
+          - "-orchAddr=<YOUR_ORCHESTRATOR_ADDRESS>"
+          - "-rtmpAddr=0.0.0.0:1935"
+          - "-httpAddr=0.0.0.0:8935"
+          - "-cliAddr=0.0.0.0:5935"
+          - "-httpIngest=true"
+          - "-transcodingOptions=P240p30fps16x9,P360p30fps16x9"
+          - "-v=6"
+    ```
+
+    Replace `<YOUR_ORCHESTRATOR_ADDRESS>` with the service address of your
+    orchestrator (e.g. `https://my-orch:8935`).
+  </Tab>
+</Tabs>
+
+## Create Livepeer Gateway ETH Account
+
+<Note>
+  This section applies to the **On-Chain** configuration only. Skip this step
+  if using development (off-chain) mode.
+</Note>
+
+Before the gateway can sign transactions on-chain, it needs an Ethereum account.
+Run the gateway interactively once to generate one:
 
 <StyledSteps>
-  {/* <StyledStep title="Pre-Installation Information">
-    #### Directories & Folders
-    Livepeer will require files to be placed on the host and within the docker
-    container.
-
-    <Tabs>
-      <Tab title="Host Directory">
-      **Host Directory**
-
-      By default, docker will store all volumes in the directory at
-
-        ```bash
-        /var/lib/docker/volumes
-        ```
-
-        This installation will create a volume called: `gateway-lpData`
-        located at
-
-        ```bash
-        /var/lib/docker/volumes/gateway-lpData/_data
-        ```
-
-        **Container Directory**
-
-        Within the docker container, the volume `gateway-lpData` will be mounted at
-
-        ```bash
-        /root/.lpData
-        ```
-      </Tab>
-      <Tab title="On-Chain Wallet Directory">
-      For On-Chain Gateways, you will need to create a directory for your wallet
-
-        ```bash
-        # Create keystore directory
-        mkdir -p gateway-lpData/keystore
-
-        # Copy your Ethereum keystore files to gateway-lpData/keystore/
-        # Create password file with your Ethereum password
-        echo "your_password" > gateway-lpData/password.txt
-        ```
-      </Tab>
-      <Tab title="AI Model Directory">
-      For AI gateways, you will need to create a directory for AI models & pipelines
-
-        ```bash
-          # AI keystore directory
-          mkdir -p ai-gateway-lpData/keystore
-          # AI Model directory
-          mkdir -p models
-        ```
-      </Tab>
-    </Tabs>
-
-  </StyledStep> */}
-  <StyledStep title="Install Docker">
-      <Tip> If docker is already installed at or above version 20.10.x, you can **skip this step**.</Tip>
-
-      You can check your version by running
-      ```bash
-      docker --version
-      ```
-
-      <Tabs>
-        <Tab title ="Update Docker">
-            If you have an older version of Docker installed - you will need to update the Docker Engine and CLI.
-
-            Follow the instructions for your OS and Docker type in the [Docker Docs](https://docs.docker.com/) to install the latest version of Docker or follow the terminal command guide below:
-            <Expandable title=">_ Update Docker">
-            **Linux**
-            1. Update package lists
-            ```bash
-            sudo apt-get update
-            ```
-            2. Install the latest version of Docker
-            ```bash
-            sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
-            ```
-            3. Verify the installation
-            ```bash
-            docker --version
-            ```
-
-            **Docker Desktop (Windows & MacOS)**
-            1. Use the GUI
-
-              Open Application and go to `Settings > Software Updates` menu
-
-            2. Use the CLI
-            ```bash
-            docker desktop update
-            ```
-            </Expandable>
-        </Tab>
-          <Tab title ="Install Docker">
-            If docker is not installed, follow the instructions for your OS in the [Docker installation guide](https://app.docker.com/) to install Docker Engine & CLI or follow the (non-canonical) quick guide below:
-            <Expandable title=">_ Install Docker">
-            **Linux**
-            1. Update package lists & install dependencies
-            ```bash
-            sudo apt-get update
-            sudo apt-get install ca-certificates curl apt-transport-https lsb-release
-            ```
-            2. Add Docker's official GPG key
-            ```bash
-              sudo mkdir -m 0755 -p /etc/apt/keyrings
-              sudo curl -fsSL download.docker.com -o /etc/apt/keyrings/docker.asc
-              sudo chmod a+r /etc/apt/keyrings/docker.asc
-            ```
-            3. Setup the Repo
-            (Replace ubuntu with debian if you are using Debian).
-            ```bash
-              echo \
-              "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] download.docker.com \
-              $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-            ```
-            2. Install Docker Packages
-            ```bash
-              sudo apt-get update
-              sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
-            ```
-            3. Verify the installation
-            ```bash
-              docker --version
-            ```
-            ```bash
-              sudo docker run hello-world
-            ```
-
-            **Windows & MacOS**
-            1. Download Docker Desktop for [Mac](https://docs.docker.com/desktop/install/mac-install/)
-            or [Windows](https://docs.docker.com/desktop/install/windows-install/)
-            2. Follow the instructions in the installer
-            </Expandable>
-        </Tab>
-      </Tabs>
-
-  </StyledStep>
-  {/* <StyledStep title="Pull Livepeer Docker Image ">
-    Livepeer hosts a public docker image for the Livepeer Gateway. 
-    
-    <Icon icon="diamond" iconType="solid" size={10} /> You can pull the image from [Livepeer Docker Hub](https://hub.docker.com/r/livepeer/go-livepeer) (Recommended) 
-    
-    **_OR_**
-    
-    <Icon icon="diamond" iconType="solid" size={10} /> You can create a docker volume for the Gateway data instead.
-
-    <Tabs>
-      <Tab title="Pull Livepeer Docker Image">
-        Fetch the latest <DoubleIconLink label="Livepeer Docker image" href="https://hub.docker.com/r/livepeer/go-livepeer" iconLeft="docker" /> with the following command
-        ```bash
-        docker pull livepeer/go-livepeer:master
-        ```
-      </Tab>
-      <Tab title="Create a Docker Volume">
-      Create a Docker volume for the Gateway data
-      ```bash
-      docker volume create gateway-lpData
-      ```
-      Verify the volume was created
-      ```bash
-      docker volume ls
-      ```
-
-      Create Docker Compose file from the root user's home directory `_/root/_`
-      ```bash
-      nano docker-compose.yml
-      ```
-
-      Copy, paste & save the following volume for your Gateway mode
-      <Tabs>
-      <Tab title="On-Chain Volume">
-        In onchain mode, the gateway requires an ETH wallet to pay for services.
-        See the [Fund Gateway Guide](/v2/gateways/run-a-gateway/requirements/on-chain%20setup/fund-gateway) for more information.]
-
-        Ensure you have a directory for your wallet:
-        ```bash
-          # Create keystore directory
-          mkdir -p gateway-lpData/keystore
-
-          # Copy your Ethereum keystore files to gateway-lpData/keystore/
-          # Create password file with your Ethereum password
-          echo "your_password" > gateway-lpData/password.txt
-        ```
-
-        <Badge color="blue"> Video Only </Badge> `docker-compose.yml`
-        <Expandable title="video docker-compose.yml">
-
-        ```bash
-          version: '3.9'
-
-          services:
-            gateway:
-              image: livepeer/go-livepeer:master
-              container_name: "gateway"
-              hostname: "gateway"
-              ports:
-                - 1935:1935
-                - 8935:8935
-                - 5935:5935  # CLI port
-              volumes:
-                - gateway-lpData:/root/.lpData
-              command: '-ethUrl=<YOUR ARB RPC URL>
-                        -ethKeystorePath=/root/.lpData/keystore
-                        -ethAcctAddr=<YOUR_ETH_ADDRESS>
-                        -ethPassword=/root/.lpData/password.txt
-                        -network=arbitrum-one-mainnet
-                        -cliAddr=0.0.0.0:5935
-                        -gateway
-                        -monitor=true
-                        -v=6
-                        -blockPollingInterval=20
-                        -maxPricePerUnit=300
-                        -pixelsPerUnit=1
-                        -rtmpAddr=0.0.0.0:1935
-                        -httpAddr=0.0.0.0:8935
-                        -orchAddr=<ORCHESTRATOR_ADDRESSES>
-                        -transcodingOptions=P240p30fps16x9,P360p30fps16x9'
-
-          volumes:
-            gateway-lpData:
-              external: true
-
-          ```
-          </Expandable>
-
-        <Badge color="purple"> AI Only </Badge> `docker-compose.yml`
-        <Expandable title="ai docker-compose.yml">
-
-        Ensure you have a directory for AI models & keystore
-
-        ```bash
-          # Create directories
-          mkdir -p ai-gateway-lpData/keystore
-          mkdir -p models
-        ```
-
-        Then copy, paste & save this `docker-compose.yml`
-
-      ```bash
-        version: '3.9'
-
-        services:
-          ai-gateway:
-            image: livepeer/go-livepeer:master
-            container_name: "ai-gateway"
-            hostname: "ai-gateway"
-            ports:
-              - 8935:8935
-              - 5935:5935
-            volumes:
-              - ai-gateway-lpData:/root/.lpData
-              - ./aiModels.json:/root/.lpData/aiModels.json
-              - ./models:/root/.lpData/models
-            command: '-ethUrl=<YOUR ARB RPC URL>
-                      -ethKeystorePath=/root/.lpData/keystore
-                      -ethAcctAddr=<YOUR_ETH_ADDRESS>
-                      -ethPassword=/root/.lpData/password.txt
-                      -network=arbitrum-one-mainnet
-                      -cliAddr=0.0.0.0:5935
-                      -gateway
-                      -httpIngest
-                      -aiServiceRegistry
-                      -monitor=true
-                      -v=6
-                      -blockPollingInterval=20
-                      -maxPricePerCapability={"capabilities_prices": [{"pipeline": "text-to-image", "model_id": "stabilityai/sd-turbo", "price_per_unit": 1000}]}
-                      -httpAddr=0.0.0.0:8935
-                      -orchAddr=<ORCHESTRATOR_ADDRESSES>
-                      -aiModels=/root/.lpData/aiModels.json
-                      -aiModelsDir=/root/.lpData/models
-                      -livePaymentInterval=5s'
-        volumes:
-          ai-gateway-lpData:
-            external: true
-        ```
-
-        </Expandable>
-
-        <Badge color="green"> Dual AI & Video </Badge> `docker-compose.yml`
-        <Expandable title="dual docker-compose.yml">
-
-        Ensure you have a directory for AI models & keystore
-
-        ```bash
-          # Create directories
-          mkdir -p ai-gateway-lpData/keystore
-          mkdir -p models
-        ```
-
-        Then copy, paste & save this `docker-compose.yml`
-
-        ```bash
-        version: '3.9'
-
-        services:
-          gateway:
-            image: livepeer/go-livepeer:master
-            container_name: "gateway"
-            hostname: "gateway"
-            ports:
-              - 1935:1935
-              - 8935:8935
-              - 5935:5935
-            volumes:
-              - gateway-lpData:/root/.lpData
-              - ./aiModels.json:/root/.lpData/aiModels.json
-              - ./models:/root/.lpData/models
-            command: '-ethUrl=<YOUR ARB RPC URL>
-                      -ethKeystorePath=/root/.lpData/keystore
-                      -ethAcctAddr=<YOUR_ETH_ADDRESS>
-                      -ethPassword=/root/.lpData/password.txt
-                      -network=arbitrum-one-mainnet
-                      -cliAddr=0.0.0.0:5935
-                      -gateway
-                      -httpIngest
-                      -monitor=true
-                      -v=6
-                      -blockPollingInterval=20
-                      -maxPricePerUnit=300
-                      -maxPricePerCapability={"capabilities_prices": [{"pipeline": "text-to-image", "model_id": "stabilityai/sd-turbo", "price_per_unit": 1000}]}
-                      -pixelsPerUnit=1
-                      -rtmpAddr=0.0.0.0:1935
-                      -httpAddr=0.0.0.0:8935
-                      -orchAddr=<ORCHESTRATOR_ADDRESSES>
-                      -transcodingOptions=P240p30fps16x9,P360p30fps16x9
-                      -aiModels=/root/.lpData/aiModels.json
-                      -aiModelsDir=/root/.lpData/models
-                      -aiServiceRegistry'
-
-        volumes:
-          gateway-lpData:
-            external: true
-    ```
-      </Expandable>
-
-        </Tab>
-        <Tab title="Off-Chain Volume">
-
-        <Warning> You will need to run your own Orchestrator node for local development and have the `orchAddr=<ORCHESTRATOR_ADDRESSES>` point to it </Warning>
-
-        In offchain mode, the gateway operates without blockchain integration, eliminating the need for ETH wallet configuration.
-        The ETH-related configuration fields default to empty strings.
-
-        `-network offchain` enables local & private operation without blockchain connectivity
-
-        <Badge color="blue"> Video Only </Badge> `docker-compose.yml`
-        <Expandable title="video docker-compose.yml">
-
-        ```bash
-            version: '3.9'
-
-            services:
-              gateway:
-                image: livepeer/go-livepeer:master
-                container_name: "gateway"
-                hostname: "gateway"
-                ports:
-                  - 1935:1935
-                  - 8935:8935
-                  - 5935:5935  # CLI port
-                volumes:
-                  - gateway-lpData:/root/.lpData
-                command: '-network offchain
-                          -cliAddr=0.0.0.0:5935
-                          -gateway
-                          -monitor=true
-                          -v=6
-                          -maxPricePerUnit=300
-                          -pixelsPerUnit=1
-                          -rtmpAddr=0.0.0.0:1935
-                          -httpAddr=0.0.0.0:8935
-                          -orchAddr=<ORCHESTRATOR_ADDRESSES>
-                          -transcodingOptions=P240p30fps16x9,P360p30fps16x9'
-
-            volumes:
-              gateway-lpData:
-                external: true
-
-          ```
-
-          #### Notes
-          - Video Processing: RTMP ingest on `port 1935`, transcoding to multiple bitrates
-          - HTTP port 8935 for HLS output / API access
-          - `-transcodingOptions` configures video transcoding profiles (default: P240p30fps16x9,P360p30fps16x9)
-
-          </Expandable>
-
-        <Badge color="purple"> AI Only </Badge> `docker-compose.yml`
-        <Expandable title="ai docker-compose.yml">
-
-        First, create a directory for AI models & pipelines
-
-        ```bash
-          # Create directories
-          mkdir -p ai-gateway-lpData/keystore
-          mkdir -p models
-        ```
-
-        Then copy, paste & save this `docker-compose.yml`
-
-      ```bash
-          version: '3.9'
-
-          services:
-            ai-gateway:
-              image: livepeer/go-livepeer:master
-              container_name: "ai-gateway"
-              hostname: "ai-gateway"
-              ports:
-                - 8935:8935
-                - 5935:5935
-              volumes:
-                - ai-gateway-lpData:/root/.lpData
-                - ./aiModels.json:/root/.lpData/aiModels.json
-                - ./models:/root/.lpData/models
-              command: '-network offchain
-                        -cliAddr=0.0.0.0:5935
-                        -gateway
-                        -httpIngest
-                        -aiServiceRegistry
-                        -monitor=true
-                        -v=6
-                        -maxPricePerCapability={"capabilities_prices": [{"pipeline": "text-to-image", "model_id": "stabilityai/sd-turbo", "price_per_unit": 1000}]}
-                        -httpAddr=0.0.0.0:8935
-                        -orchAddr=<ORCHESTRATOR_ADDRESSES>
-                        -aiModels=/root/.lpData/aiModels.json
-                        -aiModelsDir=/root/.lpData/models
-                        -livePaymentInterval=5s'
-
-          volumes:
-            ai-gateway-lpData:
-              external: true
-
-        ```
-
-        #### Notes
-        - `-aiServiceRegistry` enables AI service registry functionality
-        - `-httpIngest` required for AI HTTP endpoints livepeer.go:124
-        - `-aiModels` and `-aiModelsDir` configure AI model support
-        - AI Processing: HTTP endpoints for AI models on `port 8935`
-
-        </Expandable>
-
-        <Badge color="green"> Dual AI & Video </Badge> `docker-compose.yml`
-        <Expandable title="dual docker-compose.yml">
-
-        Ensure you have a directory for AI models & keystore
-
-        ```bash
-          # Create directories
-          mkdir -p ai-gateway-lpData/keystore
-          mkdir -p models
-        ```
-
-        Then copy, paste & save this `docker-compose.yml`
-
-      ```bash
-          services:
-            dual-gateway:
-              image: livepeer/go-livepeer:master
-              container_name: "dual-gateway"
-              hostname: "dual-gateway"
-              ports:
-                - 1935:1935  # RTMP for video ingest
-                - 8935:8935  # HTTP API for both video and AI
-                - 5935:5935  # CLI port
-              volumes:
-                - dual-gateway-lpData:/root/.lpData
-                - ./aiModels.json:/root/.lpData/aiModels.json
-                - ./models:/root/.lpData/models
-              command: '-network offchain
-                        -cliAddr=0.0.0.0:5935
-                        -gateway
-                        -httpIngest
-                        -aiServiceRegistry
-                        -monitor=true
-                        -v=6
-                        -maxPricePerUnit=300
-                        -maxPricePerCapability={"capabilities_prices": [{"pipeline": "text-to-image", "model_id": "stabilityai/sd-turbo", "price_per_unit": 1000}]}
-                        -rtmpAddr=0.0.0.0:1935
-                        -httpAddr=0.0.0.0:8935
-                        -orchAddr=<ORCHESTRATOR_ADDRESSES>
-                        -transcodingOptions=P240p30fps16x9,P360p30fps16x9
-                        -aiModels=/root/.lpData/aiModels.json
-                        -aiModelsDir=/root/.lpData/models
-                        -livePaymentInterval=5s'
-
-          volumes:
-            dual-gateway-lpData:
-              external: true
-
-        ```
-
-        #### Notes
-        **Video-specific**
-        - Video Processing: RTMP ingest on `port 1935`, transcoding to multiple bitrates
-        - HTTP port 8935 for HLS output
-        - `-transcodingOptions` configures video transcoding profiles (default: P240p30fps16x9,P360p30fps16x9)
-
-        **AI-specific**
-        - AI Processing: HTTP endpoints for AI models on `port 8935`
-        - `-aiServiceRegistry` enables AI service registry functionality
-        - `-httpIngest` required for AI HTTP endpoints livepeer.go:124
-        - -`aiModels` and `-aiModelsDir` configure AI model support
-        </Expandable>
-      </Tab>
-      </Tabs>
-
-      </Tab>
-    </Tabs>
-
-  </StyledStep> */}
-  <StyledStep title="Pull Livepeer Docker image">
-      Fetch the latest <DoubleIconLink label="Livepeer Docker image" href="https://hub.docker.com/r/livepeer/go-livepeer" iconLeft="docker" /> with the following command     
-  
-        ```bash
-        docker pull livepeer/go-livepeer:master
-        ```
-  </StyledStep>
-  <StyledStep title="Start Docker Volume">
-    Start the Base Docker volume
-    ```bash 
-      docker-compose up -d
+  <StyledStep title="Generate the ETH account">
+    Create the data directory, then start the container interactively:
+
+    ```bash
+    mkdir -p ./data/gateway
+    docker compose run -it gateway
     ```
 
-    - **On-chain** files: `~/.lpData/arbitrum-one-mainnet`
-    - **Off-chain** files: `~/.lpData/offchain`
-    - **AI** files: `~/.ai-gateway-lpData`
-    <Expandable title="Volume Structure Differences">
-      <div style={{ overflowX: 'auto' }}>
-        <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '14px' }}>
-          <thead>
-            <tr style={{ borderBottom: '2px solid #2b9a66' }}>
-              <th style={{ padding: '12px 8px', textAlign: 'left', color: '#2b9a66' }}>Configuration</th>
-              <th style={{ padding: '12px 8px', textAlign: 'left', color: '#2b9a66' }}>Directory Structure</th>
-              <th style={{ padding: '12px 8px', textAlign: 'left', color: '#2b9a66' }}>Additional Requirements</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr style={{ borderBottom: '1px solid #333' }}>
-              <td style={{ padding: '10px 8px' }}>Video Off-Chain</td>
-              <td style={{ padding: '10px 8px' }}><code>/root/.lpData/offchain/</code></td>
-              <td style={{ padding: '10px 8px' }}>Basic setup only</td>
-            </tr>
-            <tr style={{ borderBottom: '1px solid #333' }}>
-              <td style={{ padding: '10px 8px' }}>AI Off-Chain</td>
-              <td style={{ padding: '10px 8px' }}><code>/root/.lpData/offchain/</code> + models dir</td>
-              <td style={{ padding: '10px 8px' }}>AI models directory</td>
-            </tr>
-            <tr style={{ borderBottom: '1px solid #333' }}>
-              <td style={{ padding: '10px 8px' }}>Dual Off-Chain</td>
-              <td style={{ padding: '10px 8px' }}><code>/root/.lpData/offchain/</code> + models dir</td>
-              <td style={{ padding: '10px 8px' }}>Both video and AI files</td>
-            </tr>
-            <tr style={{ borderBottom: '1px solid #333' }}>
-              <td style={{ padding: '10px 8px' }}>Video On-Chain</td>
-              <td style={{ padding: '10px 8px' }}><code>/root/.lpData/arbitrum-one-mainnet/</code> + keystore</td>
-              <td style={{ padding: '10px 8px' }}>ETH keystore files</td>
-            </tr>
-            <tr style={{ borderBottom: '1px solid #333' }}>
-              <td style={{ padding: '10px 8px' }}>AI On-Chain</td>
-              <td style={{ padding: '10px 8px' }}><code>/root/.lpData/arbitrum-one-mainnet/</code> + keystore + models</td>
-              <td style={{ padding: '10px 8px' }}>ETH + AI files</td>
-            </tr>
-            <tr>
-              <td style={{ padding: '10px 8px' }}>Dual On-Chain</td>
-              <td style={{ padding: '10px 8px' }}><code>/root/.lpData/arbitrum-one-mainnet/</code> + keystore + models</td>
-              <td style={{ padding: '10px 8px' }}>All components</td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    </Expandable>
+    When prompted, enter a strong password to protect your Ethereum private key.
 
-    <Tip>Volume names can be customised as desired to avoid conflicts between different setups or Gateway instances (e.g., `ai-gateway-lpData`, `dual-gateway-lpData`)</Tip>
+    <Warning>
+      Never share or lose your keystore file or password. Both are required to
+      recover your ETH account.
+    </Warning>
 
+    After the log output confirms the Ethereum account has been unlocked, press
+    `Ctrl+C` to exit.
+  </StyledStep>
+  <StyledStep title="Create the password file">
+    Write your password to the file that the gateway reads on startup:
+
+    ```bash
+    echo "your_password" > ./data/gateway/eth-secret.txt
+    ```
+
+    <Tip>
+      This must match the password you entered in the previous step.
+    </Tip>
+  </StyledStep>
+  <StyledStep title="Back up the keystore">
+    Your keystore file is stored at `./data/gateway/keystore/`. Back it up
+    securely before going to production. Losing this file means losing access
+    to any ETH held in the account.
   </StyledStep>
 </StyledSteps>
+
+## Start the Gateway
+
+Start the gateway container in the background:
+
+```bash
+docker compose up -d
+```
+
+Verify the gateway is running:
+
+```bash
+docker logs gateway
+```
+
+The gateway is ready when logs show it binding to the configured ports and
+connecting to orchestrators on the network.
+
+<Note>
+  **On-chain mode only:** The gateway must be funded with ETH before
+  orchestrators will accept transcoding jobs. If streams produce no output,
+  check that your gateway account has sufficient ETH. See
+  [Fund your gateway](/v2/gateways/run-a-gateway/requirements/on-chain%20setup/fund-gateway).
+</Note>
+
+## Stream Live Video
+
+The gateway accepts RTMP ingest on port `1935`. Transcoded HLS output is
+available on port `8935` at `/stream/<manifest-id>.m3u8`.
+
+<Tabs>
+  <Tab title="FFmpeg">
+    Push a file or live source to the gateway using FFmpeg:
+
+    ```bash
+    ffmpeg -re -i input.mp4 -c:v libx264 -c:a aac -f flv rtmp://localhost:1935/live/stream
+    ```
+
+    Replace `input.mp4` with a local file or a live source URL. The path
+    segment after `/live/` (`stream` in the example above) becomes the manifest
+    ID used to retrieve the HLS output.
+
+    The transcoded HLS output will be available at:
+
+    ```
+    http://localhost:8935/stream/stream.m3u8
+    ```
+  </Tab>
+  <Tab title="OBS Studio">
+    [OBS Studio](https://obsproject.com/) is a common choice for RTMP
+    broadcasting.
+
+    1. Open OBS and go to **Settings > Stream**
+    2. Set **Service** to **Custom...**
+    3. Set **Server** to `rtmp://localhost:1935/live`
+    4. Set **Stream Key** to `stream` (or any identifier you choose)
+    5. Go to **Settings > Output** and set **Output Mode** to **Advanced**
+    6. Set **Keyframe Interval** to `2` seconds
+    7. Click **OK** and press **Start Streaming**
+
+    The transcoded HLS output will be available at:
+
+    ```
+    http://localhost:8935/stream/stream.m3u8
+    ```
+  </Tab>
+</Tabs>
+
+<Tip>
+  If running on a cloud server, ensure ports `1935` (RTMP ingest) and `8935`
+  (HLS output) are open in your firewall or security group rules.
+</Tip>
+
+## Stream Authentication
+
+By default, the gateway accepts any incoming RTMP stream. To restrict access,
+use the `-authWebhookUrl` flag to point the gateway at an authentication
+endpoint you control.
+
+When an incoming stream arrives, the gateway sends a `POST` request to the
+webhook URL with the stream URL as a JSON payload:
+
+```json
+{
+  "url": "rtmp://localhost:1935/live/stream"
+}
+```
+
+Your server responds with HTTP `200` to allow the stream, or any other status
+code to reject it.
+
+Add the flag to your `docker-compose.yml` command block:
+
+```yaml
+- "-authWebhookUrl=https://your-auth-server.com/auth"
+```
+
+The stream key in the RTMP path (e.g. `stream` in `rtmp://localhost/live/stream`)
+is included in the webhook payload URL. Your webhook implementation can use this
+value to authenticate incoming callers — for example, by checking it against a
+list of valid stream keys.
+
+For full webhook response options including custom `manifestID`, `streamKey`
+override, and per-stream transcoding profiles, see the
+[RTMP Webhook Authentication reference](https://github.com/livepeer/go-livepeer/blob/master/doc/rtmpwebhookauth.md).
 
 <Card
   title="Next Step: Configure the Gateway"
@@ -607,143 +276,5 @@ import { DoubleIconLink } from '/snippets/components/primitives/links.jsx'
   horizontal
   arrow
 >
-  Jump to the configuration guide to see configuration options for the Gateway
+  View all available configuration options for the gateway
 </Card>
-
-<br />
-
-<Danger>
-  {' '}
-  I think the volumes section belongs in configuration not installation{' '}
-</Danger>
-
-<Expandable title="Really only 2 options for install (Docker Hub or Source)">
-    Pull from Docker Hub (recommended) or build from source
-
-    You can also build locally instead of pulling from Docker Hub:
-
-    **Clone and build**
-    git clone https://github.com/livepeer/go-livepeer.git
-    cd go-livepeer
-    make livepeer
-    The Makefile shows the build process Makefile:110-112 and includes all dependencies including FFmpeg and CUDA support.
-    For development, the source build gives you more flexibility to modify and test changes.
-
-</Expandable>
-
-<Expandable title="Notes on install vs Config">
-Installation vs Configuration
-Installation refers to obtaining the software:
-
-Pulling the Docker image: docker pull livepeer/go-livepeer:master
-Or building from source: make livepeer
-Configuration refers to setting up runtime parameters:
-
-Creating docker-compose.yml with command-line flags livepeer.go:112-197
-Specifying network settings, transcoding options, AI models, etc.
-More Accurate Installation Steps
-Install: Pull Docker image or build from source
-Configure: Create docker-compose.yml with your specific flags and settings
-Deploy: Run docker-compose up -d
-The docker-compose file is where you define all the configuration flags like -gateway, -network, -transcodingOptions, -aiModels, etc. starter.go:80-178 . This makes it fundamentally a configuration step that customizes how the installed software runs.
-
-Notes
-This distinction matters because:
-
-You can install the same software multiple ways (Docker, source build, binary)
-Each installation method requires different configuration approaches
-The configuration contains your business logic and operational parameters
-Installation is a one-time setup, configuration evolves with your needs
-The Livepeer repository provides examples in the box/ directory that demonstrate different configuration patterns box.md:1-119 .
-
-</Expandable>
-
-<Expandable title="Create ETH Wallet-> goes in config">
-
-    # Create Livepeer Gateway ETH account
-
-    In this step we need to start the Gateway in order to create an Ethereum
-    account.
-
-    ```
-    docker compose run -it gateway
-    ```
-
-    When prompted for the ETH password, enter a strong password to secure your
-    Ethereum account. This password is used to decrypt and access the ETH private
-    key. <Warning>Make sure to never share or lose access to either the password or
-    the keystore file.</Warning>
-
-    <Tip>Keep this password handy, we will use it in the following steps.</Tip>
-
-    After you see the message that the Ethereum account has been unlocked, CTRL+C to
-    exit the Livepeer docker instance.
-
-    Using the previously created ETH password, create the eth-secret file
-
-    ```
-    nano -p /var/lib/docker/volumes/gateway-lpData/_data/eth-secret.txt
-    ```
-
-    # Modify Docker compose file to include eth-secret.txt
-
-    ```
-    nano docker-compose.yml
-    ```
-
-    Add the following line below the `-ethKeystorePath` and save
-
-    ```
-    -ethPassword=/root/.lpData/eth-secret.txt
-    ```
-
-    Here is the full modified version of the docker-compose.yml file
-
-    ```
-    version: '3.9'
-
-    services:
-      gateway:
-        image: livepeer/go-livepeer:<RELEASE_VERSION>
-        container_name: "gateway"
-        hostname: "gateway"
-        ports:
-          - 1935:1935
-          - 8935:8935
-        volumes:
-          - gateway-lpData:/root/.lpData
-        command: '-ethUrl=<YOUR ARB APC>
-                  -ethKeystorePath=/root/.lpData
-                  -ethPassword=/root/.lpData/eth-secret.txt
-                  -network=arbitrum-one-mainnet
-                  -cliAddr=gateway:5935
-                  -broadcaster=true
-                  -monitor=true
-                  -v=99
-                  -blockPollingInterval=20
-                  -maxPricePerUnit=300
-                  -pixelsPerUnit=1
-                  -rtmpAddr=0.0.0.0:1935
-                  -httpAddr=0.0.0.0:8935
-                  '
-    volumes:
-      gateway-lpData:
-        external: true
-    ```
-
-    Start Livepeer in the background
-
-    ```
-    docker compose up -d
-    ```
-
-    Launch the livepeer_cli
-
-    ```
-    docker exec -it gateway /bin/bash
-    livepeer_cli -host gateway -http 5935
-    ```
-
-</Expandable>
-
-<Danger> Broken Link </Danger>

--- a/v2/gateways/run-a-gateway/quickstart/quickstart-a-gateway.mdx
+++ b/v2/gateways/run-a-gateway/quickstart/quickstart-a-gateway.mdx
@@ -90,6 +90,10 @@ This page will get you up & running with a Livepeer Gateway Node for <Badge colo
 
   This guide will install and configure a Gateway to run video & AI workloads.
 
+  <Tip>
+    Docker is the recommended install method for most users.
+  </Tip>
+
   _**Choose your Gateway Mode:**_
   <Tabs>
       <DockerOffChainTab />
@@ -232,7 +236,7 @@ This page will get you up & running with a Livepeer Gateway Node for <Badge colo
   </Card>
   <Card
     title="Orchestrator Guide"
-    href="/v2/pages/05_orchestrators/orchestrators-portal"
+    href="/v2/orchestrators/orchestrators-portal"
     arrow
     horizontal
   >

--- a/v2/gateways/run-a-gateway/quickstart/views/linux/linuxOffChainTab.mdx
+++ b/v2/gateways/run-a-gateway/quickstart/views/linux/linuxOffChainTab.mdx
@@ -5,7 +5,7 @@ title: 'Linu/MacOS Off-Chain Gateway Quickstart TAB VIEW'
 {/* Imports only used in this file should be here */}
 {/* STRIKE THAT - THEY MUST BE IMPORTED IN THE ROOT PAGE - BLOODY MINTLIFY */}
 import { latestVersion, latestVersionUrl } from '/snippets/automations/globals/globals.mdx';
-import { LINUX_CODE } from '/snippets/data/gateways/linux/code.jsx';
+import { LINUX_CODE } from '../../data/linux/code.jsx';
 
 <Tab title="Off-Chain Gateway" icon="floppy-disk">
     <GatewayOffChainWarning />


### PR DESCRIPTION
## Summary\n- replace gateway Docker install page content with the prepared version\n- align ETH account section with StyledSteps\n- add on-chain funding note before streaming and firewall tip in streaming section\n- add explicit Docker recommendation in gateway quickstart\n- fix quickstart orchestrator guide route and linux tab import path\n\n## Validation\n- npm --prefix tests run test:mdx\n- npm --prefix tests run test:links\n- npm --prefix tests run test:docs-nav\n- node tests/integration/v2-link-audit.js --files v2/gateways/run-a-gateway/install/docker-install.mdx,v2/gateways/run-a-gateway/install/install-overview.mdx,v2/gateways/run-a-gateway/quickstart/quickstart-a-gateway.mdx --strict --no-write-links --report /tmp/livepeer-gateway-dedicated-link-audit.md --report-json /tmp/livepeer-gateway-dedicated-link-audit.json\n\n## Runtime Note\nRuntime ETH-account flow (`docker compose run -it gateway`) was not executed in this change; docs were updated based on checklist alignment.