### PR TITLE
docs(community): add governance draft page and portal entry

### DIFF
--- a/docs-index.json
+++ b/docs-index.json
@@ -1,6 +1,6 @@
 {
   "version": "docs-index.v1",
-  "generated": "2026-03-02T14:59:06.286Z",
+  "generated": "2026-03-02T15:33:44.362Z",
   "pages": [
     {
       "url": "https://docs.livepeer.org/v2/home/mission-control",
@@ -7588,7 +7588,7 @@
       "apiEndpoints": [],
       "difficulty": "beginner",
       "wordCount": 318,
-      "lastVerified": "2026-03-03T01:56:49+11:00",
+      "lastVerified": "2026-03-03T02:00:21+11:00",
       "headings": [
         {
           "level": 1,
@@ -7698,7 +7698,7 @@
       "apiEndpoints": [],
       "difficulty": "intermediate",
       "wordCount": 306,
-      "lastVerified": "2026-03-03T01:56:49+11:00",
+      "lastVerified": "2026-03-03T02:00:21+11:00",
       "headings": [
         {
           "level": 2,
@@ -7735,7 +7735,7 @@
       "apiEndpoints": [],
       "difficulty": "intermediate",
       "wordCount": 27,
-      "lastVerified": "2026-03-02T17:44:01+11:00",
+      "lastVerified": "2026-03-03T02:00:21+11:00",
       "headings": [],
       "codeLanguages": []
     },
@@ -7785,7 +7785,7 @@
       "apiEndpoints": [],
       "difficulty": "intermediate",
       "wordCount": 620,
-      "lastVerified": "2026-03-03T01:56:49+11:00",
+      "lastVerified": "2026-03-03T02:00:21+11:00",
       "headings": [
         {
           "level": 3,
@@ -7818,7 +7818,7 @@
       "apiEndpoints": [],
       "difficulty": "intermediate",
       "wordCount": 177,
-      "lastVerified": "2026-03-03T01:56:49+11:00",
+      "lastVerified": "2026-03-03T02:00:21+11:00",
       "headings": [
         {
           "level": 2,
@@ -7899,7 +7899,7 @@
       "apiEndpoints": [],
       "difficulty": "intermediate",
       "wordCount": 500,
-      "lastVerified": "2026-03-03T01:56:49+11:00",
+      "lastVerified": "2026-03-03T02:00:21+11:00",
       "headings": [
         {
           "level": 2,
@@ -7944,7 +7944,7 @@
       "apiEndpoints": [],
       "difficulty": "intermediate",
       "wordCount": 1790,
-      "lastVerified": "2026-03-03T01:56:49+11:00",
+      "lastVerified": "2026-03-03T02:00:21+11:00",
       "headings": [
         {
           "level": 2,
@@ -8002,7 +8002,7 @@
       "apiEndpoints": [],
       "difficulty": "intermediate",
       "wordCount": 864,
-      "lastVerified": "2026-03-03T01:56:49+11:00",
+      "lastVerified": "2026-03-03T02:00:21+11:00",
       "headings": [
         {
           "level": 1,
@@ -8034,7 +8034,7 @@
       "apiEndpoints": [],
       "difficulty": "beginner",
       "wordCount": 214,
-      "lastVerified": "2026-03-03T01:56:49+11:00",
+      "lastVerified": "2026-03-03T02:00:21+11:00",
       "headings": [
         {
           "level": 2,
@@ -8130,7 +8130,7 @@
       "apiEndpoints": [],
       "difficulty": "intermediate",
       "wordCount": 297,
-      "lastVerified": "2026-03-03T01:56:49+11:00",
+      "lastVerified": "2026-03-03T02:00:21+11:00",
       "headings": [
         {
           "level": 1,
@@ -8165,7 +8165,7 @@
       "apiEndpoints": [],
       "difficulty": "intermediate",
       "wordCount": 220,
-      "lastVerified": "2026-03-03T01:56:49+11:00",
+      "lastVerified": "2026-03-03T02:00:21+11:00",
       "headings": [
         {
           "level": 2,
@@ -8242,7 +8242,7 @@
       "apiEndpoints": [],
       "difficulty": "beginner",
       "wordCount": 180,
-      "lastVerified": "2026-03-03T01:56:49+11:00",
+      "lastVerified": "2026-03-03T02:00:21+11:00",
       "headings": [
         {
           "level": 2,
@@ -8380,7 +8380,7 @@
       "apiEndpoints": [],
       "difficulty": "intermediate",
       "wordCount": 500,
-      "lastVerified": "2026-03-03T01:56:49+11:00",
+      "lastVerified": "2026-03-03T02:00:21+11:00",
       "headings": [
         {
           "level": 2,
@@ -8426,7 +8426,7 @@
       "apiEndpoints": [],
       "difficulty": "intermediate",
       "wordCount": 460,
-      "lastVerified": "2026-03-03T01:56:49+11:00",
+      "lastVerified": "2026-03-03T02:00:21+11:00",
       "headings": [
         {
           "level": 2,
@@ -8487,7 +8487,7 @@
       "apiEndpoints": [],
       "difficulty": "intermediate",
       "wordCount": 589,
-      "lastVerified": "2026-03-03T01:56:49+11:00",
+      "lastVerified": "2026-03-03T02:00:21+11:00",
       "headings": [
         {
           "level": 2,
@@ -8597,7 +8597,7 @@
       "apiEndpoints": [],
       "difficulty": "intermediate",
       "wordCount": 119,
-      "lastVerified": "2026-03-03T01:56:49+11:00",
+      "lastVerified": "2026-03-03T02:00:21+11:00",
       "headings": [
         {
           "level": 1,
@@ -8698,7 +8698,7 @@
       "apiEndpoints": [],
       "difficulty": "intermediate",
       "wordCount": 172,
-      "lastVerified": "2026-03-03T01:56:49+11:00",
+      "lastVerified": "2026-03-03T02:00:21+11:00",
       "headings": [
         {
           "level": 1,
@@ -8827,7 +8827,7 @@
       "apiEndpoints": [],
       "difficulty": "intermediate",
       "wordCount": 61,
-      "lastVerified": "2026-03-03T01:56:49+11:00",
+      "lastVerified": "2026-03-03T02:00:21+11:00",
       "headings": [
         {
           "level": 2,
@@ -9087,7 +9087,7 @@
       "apiEndpoints": [],
       "difficulty": "advanced",
       "wordCount": 758,
-      "lastVerified": "2026-03-03T01:56:49+11:00",
+      "lastVerified": "2026-03-03T02:00:21+11:00",
       "headings": [
         {
           "level": 2,
@@ -9884,7 +9884,7 @@
       "apiEndpoints": [],
       "difficulty": "advanced",
       "wordCount": 53,
-      "lastVerified": "2026-03-03T01:56:49+11:00",
+      "lastVerified": "2026-03-03T02:00:21+11:00",
       "headings": [
         {
           "level": 2,
@@ -10333,7 +10333,7 @@
       "apiEndpoints": [],
       "difficulty": "intermediate",
       "wordCount": 26,
-      "lastVerified": "2026-03-02T17:44:01+11:00",
+      "lastVerified": "2026-03-03T02:00:21+11:00",
       "headings": [],
       "codeLanguages": []
     },
@@ -12311,8 +12311,8 @@
       "entities": [],
       "apiEndpoints": [],
       "difficulty": "intermediate",
-      "wordCount": 209,
-      "lastVerified": "2026-02-21T22:22:37+11:00",
+      "wordCount": 220,
+      "lastVerified": "2026-03-03T02:33:44+11:00",
       "headings": [],
       "codeLanguages": []
     },
@@ -12819,7 +12819,7 @@
       "apiEndpoints": [],
       "difficulty": "intermediate",
       "wordCount": 416,
-      "lastVerified": "2026-03-02T06:44:46.015Z",
+      "lastVerified": "2026-03-02T15:09:46.735Z",
       "headings": [
         {
           "level": 2,
@@ -15824,7 +15824,7 @@
       "apiEndpoints": [],
       "difficulty": "intermediate",
       "wordCount": 337,
-      "lastVerified": "2026-03-02T06:44:46.020Z",
+      "lastVerified": "2026-03-02T15:09:46.735Z",
       "headings": [
         {
           "level": 1,
@@ -15870,7 +15870,7 @@
       "apiEndpoints": [],
       "difficulty": "intermediate",
       "wordCount": 408,
-      "lastVerified": "2026-03-02T14:55:34.971Z",
+      "lastVerified": "2026-03-02T15:09:46.739Z",
       "headings": [
         {
           "level": 1,
@@ -15928,7 +15928,7 @@
       "apiEndpoints": [],
       "difficulty": "intermediate",
       "wordCount": 2093,
-      "lastVerified": "2026-03-02T14:55:34.971Z",
+      "lastVerified": "2026-03-02T15:09:46.738Z",
       "headings": [
         {
           "level": 2,
@@ -16030,7 +16030,7 @@
       "apiEndpoints": [],
       "difficulty": "intermediate",
       "wordCount": 41,
-      "lastVerified": "2026-03-02T14:55:35.133Z",
+      "lastVerified": "2026-03-02T15:31:03.677Z",
       "headings": [],
       "codeLanguages": []
     },
@@ -16052,7 +16052,7 @@
       "apiEndpoints": [],
       "difficulty": "intermediate",
       "wordCount": 916,
-      "lastVerified": "2026-03-02T06:44:46.023Z",
+      "lastVerified": "2026-03-02T15:09:46.737Z",
       "headings": [
         {
           "level": 2,
@@ -16105,7 +16105,7 @@
       "apiEndpoints": [],
       "difficulty": "intermediate",
       "wordCount": 2008,
-      "lastVerified": "2026-03-02T14:55:34.970Z",
+      "lastVerified": "2026-03-02T15:09:46.737Z",
       "headings": [
         {
           "level": 2,
@@ -16149,7 +16149,7 @@
       "apiEndpoints": [],
       "difficulty": "intermediate",
       "wordCount": 719,
-      "lastVerified": "2026-03-02T06:44:46.024Z",
+      "lastVerified": "2026-03-02T15:09:46.737Z",
       "headings": [],
       "codeLanguages": []
     },
@@ -16171,7 +16171,7 @@
       "apiEndpoints": [],
       "difficulty": "intermediate",
       "wordCount": 351,
-      "lastVerified": "2026-03-02T06:44:46.024Z",
+      "lastVerified": "2026-03-02T15:09:46.737Z",
       "headings": [],
       "codeLanguages": []
     },
@@ -16194,7 +16194,7 @@
       "apiEndpoints": [],
       "difficulty": "intermediate",
       "wordCount": 323,
-      "lastVerified": "2026-03-02T06:44:46.022Z",
+      "lastVerified": "2026-03-02T15:09:46.736Z",
       "headings": [
         {
           "level": 2,
@@ -16252,7 +16252,7 @@
       "apiEndpoints": [],
       "difficulty": "advanced",
       "wordCount": 209,
-      "lastVerified": "2026-03-02T06:44:46.021Z",
+      "lastVerified": "2026-03-02T15:09:46.735Z",
       "headings": [
         {
           "level": 2,
@@ -16312,7 +16312,7 @@
       "apiEndpoints": [],
       "difficulty": "intermediate",
       "wordCount": 331,
-      "lastVerified": "2026-03-02T06:44:46.021Z",
+      "lastVerified": "2026-03-02T15:09:46.736Z",
       "headings": [
         {
           "level": 2,
@@ -16376,7 +16376,7 @@
       "apiEndpoints": [],
       "difficulty": "intermediate",
       "wordCount": 238,
-      "lastVerified": "2026-03-02T06:44:46.022Z",
+      "lastVerified": "2026-03-02T15:09:46.736Z",
       "headings": [
         {
           "level": 2,
@@ -16441,7 +16441,7 @@
       "apiEndpoints": [],
       "difficulty": "intermediate",
       "wordCount": 1537,
-      "lastVerified": "2026-03-02T14:55:34.969Z",
+      "lastVerified": "2026-03-02T15:09:46.736Z",
       "headings": [
         {
           "level": 1,
@@ -16551,7 +16551,7 @@
       "apiEndpoints": [],
       "difficulty": "intermediate",
       "wordCount": 167,
-      "lastVerified": "2026-03-02T06:44:46.022Z",
+      "lastVerified": "2026-03-02T15:09:46.736Z",
       "headings": [
         {
           "level": 2,
@@ -16593,7 +16593,7 @@
       "apiEndpoints": [],
       "difficulty": "intermediate",
       "wordCount": 138,
-      "lastVerified": "2026-03-02T14:55:34.968Z",
+      "lastVerified": "2026-03-02T15:09:46.735Z",
       "headings": [
         {
           "level": 2,
@@ -16635,7 +16635,7 @@
       "apiEndpoints": [],
       "difficulty": "intermediate",
       "wordCount": 387,
-      "lastVerified": "2026-03-02T06:44:46.030Z",
+      "lastVerified": "2026-03-02T15:09:46.739Z",
       "headings": [
         {
           "level": 2,
@@ -29334,7 +29334,7 @@
       "apiEndpoints": [],
       "difficulty": "intermediate",
       "wordCount": 868,
-      "lastVerified": "2026-03-03T01:56:49+11:00",
+      "lastVerified": "2026-03-03T02:00:21+11:00",
       "headings": [
         {
           "level": 1,
@@ -31177,7 +31177,7 @@
       "apiEndpoints": [],
       "difficulty": "advanced",
       "wordCount": 55,
-      "lastVerified": "2026-03-03T01:56:49+11:00",
+      "lastVerified": "2026-03-03T02:00:21+11:00",
       "headings": [
         {
           "level": 2,
@@ -44330,7 +44330,7 @@
       "apiEndpoints": [],
       "difficulty": "intermediate",
       "wordCount": 872,
-      "lastVerified": "2026-03-03T01:56:49+11:00",
+      "lastVerified": "2026-03-03T02:00:21+11:00",
       "headings": [
         {
           "level": 1,
@@ -46173,7 +46173,7 @@
       "apiEndpoints": [],
       "difficulty": "advanced",
       "wordCount": 57,
-      "lastVerified": "2026-03-03T01:56:49+11:00",
+      "lastVerified": "2026-03-03T02:00:21+11:00",
       "headings": [
         {
           "level": 2,
@@ -59181,7 +59181,7 @@
       "apiEndpoints": [],
       "difficulty": "intermediate",
       "wordCount": 839,
-      "lastVerified": "2026-03-03T01:56:49+11:00",
+      "lastVerified": "2026-03-03T02:00:21+11:00",
       "headings": [
         {
           "level": 1,
@@ -60957,7 +60957,7 @@
       "apiEndpoints": [],
       "difficulty": "advanced",
       "wordCount": 27,
-      "lastVerified": "2026-03-03T01:56:49+11:00",
+      "lastVerified": "2026-03-03T02:00:21+11:00",
       "headings": [
         {
           "level": 2,

--- a/v2/community/community-portal.mdx
+++ b/v2/community/community-portal.mdx
@@ -61,7 +61,7 @@ import { YouTubeVideo } from '/snippets/components/display/video.jsx'
   <PortalCardsHeader title="Community Portal">
     <BlinkingIcon icon="circle-play" size={20}  />
   </PortalCardsHeader>
-  {/* ## <Icon icon="signs-post" size={32} color={"#2b9a66"}/> Community Portal: Choose Your Mission */}
+  {/* ## <Icon icon="signs-post" size={32} color={"var(--accent)"} /> Community Portal: Choose Your Mission */}
 
   <Columns cols={2}>
     <Card
@@ -79,6 +79,14 @@ import { YouTubeVideo } from '/snippets/components/display/video.jsx'
       arrow
     >
       The Livepeer Forum is a great place to ask questions, share ideas, and connect with other members of the Livepeer community.
+    </Card>
+    <Card
+      title="Governance & Foundation"
+      icon="building-columns"
+      href="/v2/community/livepeer-community/governance-and-foundation"
+      arrow
+    >
+      How governance works, the SPE process, Workstreams, and the Livepeer Foundation.
     </Card>
     <Card
       title="Follow Livepeer on X"

--- a/v2/community/index.mdx
+++ b/v2/community/index.mdx
@@ -37,6 +37,7 @@ Run command: node tools/scripts/generate-pages-index.js --write
 
 ## Livepeer Community
 - [Community Guidelines](livepeer-community/community-guidelines.mdx)
+- [⚠️ Governance & the Livepeer Foundation](livepeer-community/governance-and-foundation.mdx)
 - [Livepeer Hot Topics & Updates](livepeer-community/livepeer-latest-topics.mdx)
 - [Livepeer Foundation Roadmap](livepeer-community/roadmap.mdx)
 - [Trending Topics](livepeer-community/trending-topics.mdx)

--- a/v2/community/livepeer-community/governance-and-foundation.mdx
+++ b/v2/community/livepeer-community/governance-and-foundation.mdx
@@ -1,0 +1,245 @@
+---
+title: "Governance & the Livepeer Foundation"
+description: "How Livepeer is governed, who the Livepeer Foundation is, how the treasury works, and how to participate in decisions that shape the network."
+sidebarTitle: "Governance & Foundation"
+pageType: "guide"
+audience: ["gateway", "orchestrator", "delegator", "developer", "everyone"]
+status: "provisional"
+lastVerified: "2026-03-02"
+sourceOfTruth: "forum.livepeer.org/c/governance/17"
+---
+
+# Governance & the Livepeer Foundation
+
+<Warning>
+  Draft page: factual claims on this page are pending formal source verification.
+  For the latest governance updates, use the
+  [Livepeer Forum Governance category](https://forum.livepeer.org/c/governance/17)
+  as the canonical live source.
+</Warning>
+
+Livepeer is governed by its community. Token holders — orchestrators, delegators, and gateway operators — collectively decide how the network evolves through on-chain proposals and treasury funding. The **Livepeer Foundation** coordinates this process and stewards the ecosystem's long-term direction.
+
+<Note>
+  This page covers governance participation and the Foundation's role. For LPT staking mechanics, delegation, and voting weight, see the [LPT Token](/v2/lpt) section.
+</Note>
+
+---
+
+## The Livepeer Foundation
+
+The Livepeer Foundation (LF) is a Cayman Islands non-profit, announced in April 2025 and formally established in June 2025. Its mission is to steward the long-term vision, ecosystem growth, and core development of the Livepeer network.
+
+The Foundation is not a replacement for Livepeer Inc — it is a complementary structure designed to coordinate the ecosystem's expanding set of contributors, SPEs, and community initiatives.
+
+| Entity | Primary role |
+|---|---|
+| **Livepeer Inc** | Original protocol creator; continues core R&D and the go-livepeer codebase |
+| **Livepeer Foundation** | Ecosystem coordination, strategic roadmap, contributor onboarding, capital deployment |
+| **Community Treasury** | Governed by all LPT stakers on-chain; funds SPEs and ecosystem work |
+| **GovWorks** | Meta-governance SPE; supports proposal authors and oversees treasury process |
+
+The Foundation holds delegated LPT stake to participate in governance, but is one participant among many — it does not control the protocol or the treasury.
+
+**Foundation phasing:**
+
+- **2025 — Foundation Phase:** Core operations, Advisory Boards, real-time video AI adoption
+- **2026–2027 — Scaling Phase:** Lead project marketing, diversify gateway infrastructure, scale demand
+- **2028+ — Decentralisation Phase:** Full brand stewardship and strategic governance transitions to the broader community
+
+---
+
+## Advisory Boards
+
+In June 2025, the Foundation launched four Advisory Boards to provide structured, community-informed strategic input. Each board drew on 45+ community survey responses and is composed of contributors from Livepeer Inc, the Foundation, orchestrators, gateway operators, and delegators.
+
+<CardGroup cols={2}>
+  <Card title="Network" icon="network-wired">
+    Protocol architecture, performance, infrastructure priorities, and technical roadmap.
+  </Card>
+  <Card title="Governance" icon="building-columns">
+    Treasury operations, proposal processes, decentralisation mechanisms, and GovWorks oversight.
+  </Card>
+  <Card title="Growth" icon="arrow-trend-up">
+    Developer and gateway onboarding, ecosystem expansion, demand generation.
+  </Card>
+  <Card title="Markets" icon="chart-line">
+    Token economics, liquidity, exchange access, and market positioning.
+  </Card>
+</CardGroup>
+
+Advisory Boards completed their strategy-setting phase in Q3 2025, producing two key outputs:
+
+1. **Phase 1 Strategic Pillars** (published 10 July 2025)
+2. **Phase 2 Tactical Recommendations** (published 30 July 2025)
+
+These recommendations fed directly into the Workstreams execution framework.
+
+---
+
+## Workstreams
+
+In August 2025, the Livepeer Foundation introduced **Workstreams** — nine focused execution areas that translate Advisory Board strategy into concrete, contributor-facing work. Each workstream has a phased roadmap (Now / Next / Beyond).
+
+<Tabs>
+  <Tab title="Brand & Communication">
+    **Ambition:** A leading, globally-recognised brand for video and AI infrastructure.
+
+    Covers ecosystem messaging, content strategy, developer storytelling, and Livepeer's presence at events and in media. Relevant for community contributors, content creators, and technical writers.
+  </Tab>
+  <Tab title="Livepeer Builders">
+    **Ambition:** A community of high-value builders generating demand through new applications.
+
+    Covers developer grants, hackathons, integration support, and onboarding new gateway operators and application developers into the ecosystem.
+  </Tab>
+  <Tab title="Core Contributor Coordination">
+    **Ambition:** A coordinated project roadmap attracting high-performing talent.
+
+    Covers coordination between Livepeer Inc, Foundation teams, and independent SPEs. Entry point for contributors seeking to participate in funded ecosystem work.
+  </Tab>
+  <Tab title="Ecosystem Data & Tooling">
+    **Ambition:** The network's intelligence layer within a best-in-class Explorer.
+
+    Covers the Livepeer Explorer, network dashboards (Growth, Governance, AI Compute Visualiser), Dune analytics, and monitoring tools for operators.
+  </Tab>
+  <Tab title="LPT Participation">
+    **Ambition:** Awareness around the economic opportunities of participating in Livepeer.
+
+    Covers delegator education, staking interfaces, fiat on-ramps (LISAR SPE), and Live Pioneers community initiatives across 8+ languages.
+  </Tab>
+  <Tab title="Core R&D">
+    **Ambition:** A secure, adaptable core protocol with a unified developer experience.
+
+    Covers go-livepeer development, API unification, protocol upgrades, and the LIP process.
+  </Tab>
+  <Tab title="Real-Time Video AI">
+    **Ambition:** The leading real-time video AI platform and community.
+
+    Covers ComfyStream, AI-runner pipelines, BYOC containers, and onboarding AI application developers.
+  </Tab>
+  <Tab title="Compute Marketplace">
+    **Ambition:** A high-performance, dynamic compute marketplace.
+
+    Covers GPU orchestrator onboarding, AI subnet performance, pricing visibility, and infrastructure tooling for node operators.
+  </Tab>
+  <Tab title="Active Capital Management">
+    **Ambition:** An actively-managed treasury to fund new opportunities.
+
+    Covers treasury diversification, SPE portfolio management, and capital deployment strategy. Coordinated by the Transformation SPE (approved September 2025).
+  </Tab>
+</Tabs>
+
+<Card title="Read the full Workstreams post" icon="arrow-right" href="https://forum.livepeer.org/t/introducing-workstreams-a-new-era-of-execution-for-the-livepeer-project/3030">
+  The Foundation's August 2025 post outlines each workstream with its Now / Next / Beyond roadmap and how to get involved.
+</Card>
+
+---
+
+## Special Purpose Entities (SPEs)
+
+SPEs are the primary mechanism for funded community work. Any community member can propose an SPE — a working group with a specific mandate, funded by an on-chain treasury vote.
+
+**Notable SPEs active in 2025:**
+
+| SPE | Approved | Funding | Mandate |
+|---|---|---|---|
+| GovWorks | Feb 2025 | — | Meta-governance and treasury coordination |
+| AI Video SPE Stage 4 | Jun 2025 | 56,560 LPT | ComfyStream, BYOC containers, AI infrastructure |
+| LiveInfra | Jul 2025 | 7,152 LPT | Community Arbitrum Node, 99.9% uptime |
+| GWID | May 2025 | 6,600 LPT | Gateway wizard and simplified gateway operation |
+| LISAR | Sep 2025 | 4,450 LPT | Fiat-to-delegation gateway (USD, EUR, GBP, NGN) |
+| Transformation | Sep 2025 | 44,500 LPT | Capital, Builders, and Development coordination |
+
+### How to propose an SPE
+
+The process is defined and maintained by GovWorks. The full guide is at [forum.livepeer.org/t/livepeer-governance-process/2767](https://forum.livepeer.org/t/livepeer-governance-process/2767).
+
+<Steps>
+  <Step title="Develop your idea">
+    Check existing SPEs and the [SPE Dashboard](https://www.notion.so/SPE-Dashboard-cd7e27da8dd54820b1aaea5b0b33541b) to confirm your proposal fills a genuine gap. Consider whether applying to an existing SPE's grants programme (e.g., Transformation SPE) is a better fit than a standalone treasury proposal.
+  </Step>
+  <Step title="Get early feedback">
+    Post a Pre-Proposal in the [Treasury category](https://forum.livepeer.org/c/treasury/18) using the [SPE Proposal Template](https://docs.google.com/document/d/11I8ds1-tA1PaYU5rxJ58eodR-JfsjuyOm2pXXE-O6ow/edit). Leave at least 7 days for community discussion. Attend a Treasury Talk or Water Cooler call in Discord to get direct feedback.
+  </Step>
+  <Step title="Build community support">
+    Tag `@Orchestrator` in the Discord `#governance` channel to notify active validators. Surface the proposal on social media. Quorum requires 33% of all active stake — visibility is critical.
+  </Step>
+  <Step title="Submit on-chain">
+    Submit your final proposal at [explorer.livepeer.org/treasury](https://explorer.livepeer.org/treasury). You need at least **100 LPT staked** to submit. GovWorks can connect you with a staker if needed — contact them via the [GovWorks Notion Hub](https://www.notion.so/GovWorks-SPE-caa4a5442ddb4014b1f0e85aba4dce47).
+  </Step>
+  <Step title="Voting period">
+    After a ~21-hour delay, a 10-round voting window opens (approximately 9 days). Any orchestrator or staked delegator can vote For, Against, or Abstain via the Explorer.
+  </Step>
+  <Step title="Result and implementation">
+    The proposal passes with **33% quorum** and **more than 50% For** votes. Funds are released to the specified wallet address. A multi-sig is strongly recommended for team proposals. Publish a transparent execution roadmap and regular update posts on the Forum.
+  </Step>
+</Steps>
+
+---
+
+## GovWorks
+
+GovWorks is the meta-governance SPE for Livepeer, chaired by [StableLab](https://www.stablelab.xyz) since November 2024. It provides mentorship for new SPE authors, standardises proposal formats, maintains the Governance Hub, and publishes regular governance digests.
+
+GovWorks' first term (February–July 2025) delivered: standardised proposal formats, quarterly funding cycles, a Governance Wiki and Hub, governance digest publications, and direct SPE onboarding support for new working groups.
+
+<CardGroup cols={2}>
+  <Card title="GovWorks Notion Hub" icon="book-open" href="https://www.notion.so/GovWorks-SPE-caa4a5442ddb4014b1f0e85aba4dce47">
+    SPE templates, mentorship, and governance documentation maintained by StableLab.
+  </Card>
+  <Card title="SPE Dashboard" icon="table-list" href="https://www.notion.so/SPE-Dashboard-cd7e27da8dd54820b1aaea5b0b33541b">
+    Active SPEs, open bounties, execution status, and budget tracking.
+  </Card>
+  <Card title="Governance Forum" icon="comments" href="https://forum.livepeer.org/c/governance/17">
+    LIPs, meta-governance discussion, GovWorks updates, and parameter change proposals.
+  </Card>
+  <Card title="GovWorks Updates" icon="newspaper" href="https://forum.livepeer.org/t/govworks-community-updates/2673">
+    Regular governance digests and operational reports from StableLab.
+  </Card>
+</CardGroup>
+
+---
+
+## Voting mechanics
+
+All governance votes — both treasury proposals and protocol parameter changes — use the same on-chain system anchored in Arbitrum.
+
+| Parameter | Value |
+|---|---|
+| Minimum stake to submit a proposal | 100 LPT (staked) |
+| Voting delay after submission | ~21 hours |
+| Voting period | 10 rounds (~9 days) |
+| Quorum threshold | 33% of all active stake must vote |
+| Passing threshold | More than 50% of votes must be For |
+| Vote options | For, Against, Abstain |
+
+Orchestrators vote with the weight of their own stake plus delegated stake. Delegators can override their orchestrator's vote and vote directly — this is called "vote detachment" and is supported in the Livepeer Explorer.
+
+<Warning>
+  The LPT emissions model is subject to active governance discussion as of early 2026. A pre-proposal to adjust inflation parameters was published in January 2026. Monitor the [Governance Forum](https://forum.livepeer.org/c/governance/17) for the current status before making delegation or staking decisions based on inflation assumptions.
+</Warning>
+
+---
+
+## Technical governance: LIPs
+
+Protocol-level changes use Livepeer Improvement Proposals (LIPs). The current on-chain treasury and governance framework is defined by LIP-89 through LIP-92 (the Treasury Bundle), ratified in October 2023. These LIPs established the treasury, the 33% quorum rule, and the funding release mechanism.
+
+<Card title="Livepeer LIPs on GitHub" icon="github" href="https://github.com/livepeer/LIPs">
+  All LIPs, their current status, and the governance process for protocol changes.
+</Card>
+
+---
+
+## Gateway operators and governance
+
+Gateway operators have a direct stake in governance outcomes — protocol fee structures, AI subnet pricing, and network parameters directly affect operational economics.
+
+**How governance is relevant to gateway operators:**
+
+- **SPE proposals** can fund tooling that simplifies your operation (e.g., GWID SPE, May 2025)
+- **Parameter change LIPs** affect pricing, reward structures, and network behaviour
+- **Workstream contributions** — particularly the *Compute Marketplace* and *Livepeer Builders* workstreams — are open to gateway operators
+- **Discord `#governance`** — tag `@Orchestrator` to ensure your feedback is heard before a vote closes
+
+If you want to propose improvements to gateway infrastructure or economics, GovWorks offers direct mentorship via the [GovWorks Notion Hub](https://www.notion.so/GovWorks-SPE-caa4a5442ddb4014b1f0e85aba4dce47).

--- a/v2/index.mdx
+++ b/v2/index.mdx
@@ -584,6 +584,7 @@ Run command: node tools/scripts/generate-pages-index.js --write
 
 ### Livepeer Community
 - [Community Guidelines](community/livepeer-community/community-guidelines.mdx)
+- [⚠️ Governance & the Livepeer Foundation](community/livepeer-community/governance-and-foundation.mdx)
 - [Livepeer Hot Topics & Updates](community/livepeer-community/livepeer-latest-topics.mdx)
 - [Livepeer Foundation Roadmap](community/livepeer-community/roadmap.mdx)
 - [Trending Topics](community/livepeer-community/trending-topics.mdx)


### PR DESCRIPTION
## Summary
- add `v2/community/livepeer-community/governance-and-foundation.mdx` as a draft governance page
- add governance card link in `v2/community/community-portal.mdx`
- include generated index/docs artifacts required by hooks:
  - `docs-index.json`
  - `v2/community/index.mdx`
  - `v2/index.mdx`

## Draft Policy Applied
- page status is set to `provisional`
- added top-of-page warning that claims are pending formal verification
- canonical live source points to the Forum governance category

## Validation
- targeted unit checks (mdx, quality, links-imports, style-guide stagedOnly) passed for target community files
- strict link audit on affected files: Missing refs = 0
- docs-navigation strict baseline remains 17 (no increase)

## Follow-up Tasks
- #769 verify governance claims and promote status after verification
- #770 clean style-guide debt in `community-portal.mdx`
- #771 add locale parity for governance page (`es/fr/cn`)
