### PR TITLE
[#782] Workflow Softening Overrides

### DIFF
--- a/.codex/task-contract.yaml
+++ b/.codex/task-contract.yaml
@@ -1,26 +1,34 @@
-task_id: 774
-branch: codex/774-guides-and-tools-i18n
+task_id: 782
 base_branch: docs-v2
+branch: codex/782-workflow-softening-overrides
 scope_in:
-  - docs.json
-  - docs-index.json
-  - docs-guide/indexes/pages-index.mdx
+  - .codex/task-contract.yaml
+  - .github/AGENTS.md
+  - .github/augment-instructions.md
+  - README.md
+  - contribute/CONTRIBUTING/AGENT-INSTRUCTIONS.md
+  - contribute/CONTRIBUTING/GIT-HOOKS.md
+  - ai-tools/ai-rules/HUMAN-OVERRIDE-POLICY.md
+  - ai-tools/ai-rules/AI_GUIDELINES.md
+  - ai-tools/ai-rules/rules/git-safety.md
+  - ai-tools/ai-rules/rules/imported/AI_GUIDELINES.md
+  - ai-tools/ai-skills/templates/31-codex-task-isolation-standard.template.md
+  - tools/scripts/codex-safe-merge-with-stash.js
+  - tools/scripts/codex-commit.js
   - tools/script-index.md
-  - v2/index.mdx
-  - v2/about/index.mdx
-  - v2/developers/index.mdx
-  - v2/cn/index.mdx
-  - v2/es/index.mdx
-  - v2/fr/index.mdx
-  - v2/internal/index.mdx
-  - v2/orchestrators/index.mdx
-  - v2/solutions/index.mdx
-  - v2/es/developers/guides-and-tools/
-  - v2/fr/developers/guides-and-tools/
-  - v2/cn/developers/guides-and-tools/
-  - v2/es/developers/livepeer-real-time-video/
+  - tests/unit/codex-safe-merge-with-stash.test.js
+  - tests/unit/codex-commit.test.js
+  - tests/script-index.md
+scope_out:
+  - v1/
 allowed_generated:
   - .codex/pr-body.generated.md
+  - docs-guide/indexes/scripts-index.mdx
 acceptance_checks:
-  - node tools/scripts/generate-docs-guide-pages-index.js --write
-  - node tests/unit/script-docs.test.js --write --rebuild-indexes
+  - node tests/unit/script-docs.test.js
+  - node tests/unit/codex-safe-merge-with-stash.test.js
+  - node tests/unit/codex-commit.test.js
+  - node tests/run-pr-checks.js --base-ref docs-v2
+risk_flags:
+  - ci-impact
+follow_up_issues: []

--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -4,8 +4,10 @@
 
 - **ALWAYS** check for the existence of local Git hooks in `.git/hooks/` before
   initiating a write command.
-- **NEVER** use `--no-verify` or `-n` flags to bypass safety checks. These are
-  hard project constraints.
+- **DEFAULT:** Do not use `--no-verify` or `-n` to bypass safety checks.
+- **EXCEPTION:** Only when explicitly instructed by a human in-thread, `git commit --no-verify`
+  is allowed with audit metadata per
+  `ai-tools/ai-rules/HUMAN-OVERRIDE-POLICY.md`.
 - **NEVER** perform a `git reset --hard` or `git push --force` without an
   explicit, multi-turn plan confirmed by the user.
 - **NEVER** perform a `git reset --hard` or `git push --force` without a saved

--- a/.github/augment-instructions.md
+++ b/.github/augment-instructions.md
@@ -7,7 +7,8 @@
 - **NEVER** run `git commit` without explicit user permission
 - **NEVER** run `git push` without explicit user permission
 - **NEVER** run `git reset` (soft/hard/mixed) without explicit user permission
-- **NEVER** use `--no-verify` flag to bypass hooks
+- **DEFAULT:** do not use `--no-verify` to bypass hooks
+- **EXCEPTION:** only when explicitly instructed by a human in-thread, `git commit --no-verify` is allowed with audit metadata per `ai-tools/ai-rules/HUMAN-OVERRIDE-POLICY.md`
 - **NEVER** modify git history or remote state
 - **ALWAYS** ask before ANY git operation that could lose work
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ For agent implementation branches, use:
 - branch name: `codex/<issue-id>-<slug>`
 - task contract file: `.codex/task-contract.yaml`
 - required PR sections: `Scope`, `Validation`, `Follow-up Tasks`
+- override policy (human-directed only): `ai-tools/ai-rules/HUMAN-OVERRIDE-POLICY.md`
 
 Enforcement runs on `codex/*` only via:
 
@@ -152,6 +153,11 @@ node tools/scripts/create-codex-pr.js --create
 
 This generates `.codex/pr-body.generated.md` and calls `gh pr create --body-file ...`.
 Codex PR CI also requires the generated marker in the PR body, so manual bodies without the marker fail contract validation.
+
+When a human explicitly requests merge or no-verify commit operations:
+
+- safe merge flow: `node tools/scripts/codex-safe-merge-with-stash.js --target <branch-or-ref>`
+- audited no-verify commit flow: `node tools/scripts/codex-commit.js --message "..." --no-verify --human-override true --override-note "..."`
 
 Contributor deep docs:
 

--- a/ai-tools/ai-rules/AI_GUIDELINES.md
+++ b/ai-tools/ai-rules/AI_GUIDELINES.md
@@ -5,9 +5,8 @@
 This repository uses custom Git hooks for "Human-in-the-Loop" (HitL)
 verification.
 
-- **ENFORCEMENT:** You SHALL NOT attempt to bypass hooks.
-- **FORBIDDEN:** The use of `--no-verify`, `-n`, or any environment variable
-  designed to skip Git hook execution is STRICTLY PROHIBITED.
+- **ENFORCEMENT:** You SHALL NOT attempt to bypass hooks by default.
+- **EXCEPTION:** `git commit --no-verify` is allowed only when explicitly requested by a human in-thread, and only with override audit metadata documented in `ai-tools/ai-rules/HUMAN-OVERRIDE-POLICY.md`.
 - **BEHAVIOR:** When you initiate a `commit`, `push`, or `rebase`, the hook will
   pause and wait for manual input in the user's terminal. You MUST wait for the
   user to confirm.

--- a/ai-tools/ai-rules/HUMAN-OVERRIDE-POLICY.md
+++ b/ai-tools/ai-rules/HUMAN-OVERRIDE-POLICY.md
@@ -1,0 +1,38 @@
+# Human Override Policy for Agent Git Operations
+
+## Default Rule
+
+Agents must use normal repository safety checks by default:
+- run standard commit flow with hooks
+- avoid bypass flags
+- open PRs for review
+
+## Explicit Human Override Exception
+
+A bypass is allowed only when the human explicitly instructs it in-thread.
+
+Current allowed override scope:
+- `git commit --no-verify` only
+
+Not covered by this exception:
+- force pushes
+- bypassing codex scope enforcement
+- destructive history rewrites
+
+## Required Audit Fields
+
+When a no-verify override is used, include audit metadata in commit/PR notes:
+- `override_type: no-verify`
+- `requested_by: human`
+- `request_context: <short quoted instruction>`
+- `reason: <human-provided or user-directed override>`
+
+## Multi-Agent Merge Rule
+
+Default multi-agent behavior is PR-only.
+
+Only when explicitly asked to merge:
+1. stash local changes (`tracked + untracked`)
+2. merge requested target
+3. pop stash
+4. stop and report if merge or stash-pop conflicts occur

--- a/ai-tools/ai-rules/rules/git-safety.md
+++ b/ai-tools/ai-rules/rules/git-safety.md
@@ -1,5 +1,6 @@
 # GIT WRITE PROTOCOL
 - **ENFORCEMENT:** You MUST verify the existence of local Git hooks in `.git/hooks/` before initiating any write command (commit, push, rebase).
-- **FORBIDDEN:** You are STRICTLY FORBIDDEN from using `--no-verify` or `-n`.
+- **DEFAULT:** Do not bypass hooks (`--no-verify` or `-n`) during normal operation.
+- **EXCEPTION:** `git commit --no-verify` is allowed only with explicit human in-thread instruction and required audit metadata per `ai-tools/ai-rules/HUMAN-OVERRIDE-POLICY.md`.
 - **BEHAVIOR:** When a write command is initiated, you MUST announce: "Initiating [action]. Please approve the safety checkpoint in your terminal."
 - **RECOVERY:** If a command fails, suggest restoring from the latest `checkpoint/` branch.

--- a/ai-tools/ai-rules/rules/imported/AI_GUIDELINES.md
+++ b/ai-tools/ai-rules/rules/imported/AI_GUIDELINES.md
@@ -9,9 +9,8 @@ type: "always_apply"
 This repository uses custom Git hooks for "Human-in-the-Loop" (HitL)
 verification.
 
-- **ENFORCEMENT:** You SHALL NOT attempt to bypass hooks.
-- **FORBIDDEN:** The use of `--no-verify`, `-n`, or any environment variable
-  designed to skip Git hook execution is STRICTLY PROHIBITED.
+- **ENFORCEMENT:** You SHALL NOT attempt to bypass hooks by default.
+- **EXCEPTION:** `git commit --no-verify` is allowed only when explicitly requested by a human in-thread, and only with override audit metadata documented in `ai-tools/ai-rules/HUMAN-OVERRIDE-POLICY.md`.
 - **BEHAVIOR:** When you initiate a `commit`, `push`, or `rebase`, the hook will
   pause and wait for manual input in the user's terminal. You MUST wait for the
   user to confirm.

--- a/ai-tools/ai-skills/templates/31-codex-task-isolation-standard.template.md
+++ b/ai-tools/ai-skills/templates/31-codex-task-isolation-standard.template.md
@@ -27,7 +27,7 @@ Goal
 Execute implementation tasks in isolation with an explicit task contract, branch binding, and validation evidence that blocks scope drift.
 
 Constraints
-- Do not bypass hooks (`--no-verify` or `-n`).
+- Do not bypass hooks by default. `git commit --no-verify` is allowed only when explicitly instructed by a human in-thread and must follow `ai-tools/ai-rules/HUMAN-OVERRIDE-POLICY.md`.
 - Use dedicated `codex/<issue-id>-<slug>` branches for agent implementation tasks.
 - Keep `scope_in` minimal and explicit; do not include unrelated paths.
 - Do not force push codex branches unless explicit human approval is provided.

--- a/contribute/CONTRIBUTING/AGENT-INSTRUCTIONS.md
+++ b/contribute/CONTRIBUTING/AGENT-INSTRUCTIONS.md
@@ -151,16 +151,24 @@ import { Component } from "/snippets/components/Component.jsx";
 
 ## Bypassing Hooks
 
-**⚠️ CRITICAL:** Agents MUST NOT bypass hooks without explicit user permission.
+**⚠️ CRITICAL:** Agents MUST NOT bypass hooks by default.
 
-The `.github/augment-instructions.md` explicitly states:
-- **NEVER** use `--no-verify` flag to bypass hooks
-- This is a hard project constraint
+Canonical policy:
+- `ai-tools/ai-rules/HUMAN-OVERRIDE-POLICY.md`
+- Default is normal hook-enforced commits.
+- Exception is limited to `git commit --no-verify` when explicitly requested by a human in-thread.
+- Override usage must include audit metadata (`override_type`, `requested_by`, `request_context`, `reason`).
 
 If you encounter a false positive:
 1. Report it to the user
 2. Ask for guidance
-3. Do NOT bypass the hook
+3. Use normal commit flow unless the user explicitly requests no-verify
+
+If the user explicitly requests no-verify for a commit, use:
+
+```bash
+node tools/scripts/codex-commit.js --message "..." --no-verify --human-override true --override-note "..."
+```
 
 If a human explicitly needs to edit `.allowlist`, they must commit with:
 

--- a/contribute/CONTRIBUTING/GIT-HOOKS.md
+++ b/contribute/CONTRIBUTING/GIT-HOOKS.md
@@ -18,6 +18,27 @@ Git hooks are scripts that run automatically at certain points in the git workfl
 2. **Enforce scoped changes** - blocks pushes with out-of-scope files
 3. **Block force push by default** - allows override only with explicit env flag
 
+## Agent Workflow Defaults (Multi-Agent Safe)
+
+- Default path for agents is PR-only: commit scoped changes and open a PR.
+- Merge operations are explicit-only and run only when a human asks to merge now.
+- Hook bypass is disallowed by default; `git commit --no-verify` is allowed only with explicit human instruction and audited metadata per `ai-tools/ai-rules/HUMAN-OVERRIDE-POLICY.md`.
+
+### Explicit Merge Flow (When Human Requests Merge)
+
+Use the helper script to run stash/merge/pop safely:
+
+```bash
+node tools/scripts/codex-safe-merge-with-stash.js --target <branch-or-ref>
+```
+
+Behavior:
+
+1. Stashes tracked + untracked local changes.
+2. Merges the requested target.
+3. Pops the stash after successful merge.
+4. Stops on merge conflicts or stash-pop conflicts and prints recovery guidance.
+
 ## Pre-commit Hook
 
 ### LPD Hook Commands
@@ -326,9 +347,13 @@ WARNINGS+=("❌ $file: Error message")
 VIOLATIONS=$((VIOLATIONS + 1))
 ```
 
-## Bypassing Hooks (Not Recommended)
+## Hook Overrides (Human-Directed Only)
 
-**⚠️ WARNING:** Only bypass hooks if you have a legitimate reason and understand the consequences.
+Default behavior is no hook bypass. Canonical policy:
+
+- `ai-tools/ai-rules/HUMAN-OVERRIDE-POLICY.md`
+
+`git commit --no-verify` is permitted only when explicitly requested by a human in-thread and must include override audit metadata.
 
 ### Protected `.allowlist` Edits (Human-Only)
 
@@ -354,9 +379,14 @@ git commit -m "Remove obsolete files" --trailer "allow-deletions=true"
 
 This override is scoped to deletions and still runs all other pre-commit checks.
 
+Use the audited helper for human-requested no-verify commits:
+
 ```bash
-# Bypass pre-commit hook
-git commit --no-verify -m "message"
+node tools/scripts/codex-commit.js \
+  --message "..." \
+  --no-verify \
+  --human-override true \
+  --override-note "..."
 ```
 
 **Why this is discouraged:**
@@ -399,7 +429,7 @@ If the hook takes too long:
 
 1. **Check verification scripts** - Some checks (like Mintlify build) can be slow
 2. **Make checks optional** - Comment out slow checks for local development
-3. **Use `--no-verify`** - Only if absolutely necessary (see warning above)
+3. **Do not bypass by default** - Use the audited override flow only when explicitly instructed by a human
 
 ## For CI/CD
 

--- a/docs-guide/indexes/scripts-index.mdx
+++ b/docs-guide/indexes/scripts-index.mdx
@@ -57,6 +57,8 @@ Run command: node tests/unit/script-docs.test.js --write --rebuild-indexes
 | `tests/integration/v2-wcag-audit.selftest.js` | Script-level self-tests for the v2 WCAG audit (local HTTP + Puppeteer axe run, and temp-file fix/stage behavior without Mintlify). | `node tests/integration/v2-wcag-audit.selftest.js` | docs |
 | `tests/run-all.js` | Utility script for tests/run-all.js. | `node tests/run-all.js` | docs |
 | `tests/run-pr-checks.js` | Run changed-file scoped validation checks for pull request CI, including Codex skill sync and codex task-contract enforcement. | `node tests/run-pr-checks.js --base-ref main` | docs |
+| `tests/unit/codex-commit.test.js` | Validate codex commit helper behavior for normal commits and explicit audited no-verify override handling. | `node tests/unit/codex-commit.test.js` | docs |
+| `tests/unit/codex-safe-merge-with-stash.test.js` | Validate safe merge helper behavior for clean merges, dirty-tree stash/restore, and conflict handling. | `node tests/unit/codex-safe-merge-with-stash.test.js` | docs |
 | `tests/unit/codex-skill-sync.test.js` | Validate template-driven Codex skill sync behavior including check drift, safe upsert, subset sync, and openai.yaml generation. | `node tests/unit/codex-skill-sync.test.js` | docs |
 | `tests/unit/create-codex-pr.test.js` | Validate codex PR body generation and dry-run create behavior from task-contract input. | `node tests/unit/create-codex-pr.test.js` | docs |
 | `tests/unit/docs-guide-sot.test.js` | Validate docs-guide source-of-truth coverage, README pointers, and generated index freshness. | `node tests/unit/docs-guide-sot.test.js` | docs |
@@ -94,6 +96,8 @@ Run command: node tests/unit/script-docs.test.js --write --rebuild-indexes
 | `tools/scripts/audit-v2-usefulness.js` | Audit v2 MDX pages (excluding x-* directories) and emit page-level usefulness matrix rows with source-weighted 2026 accuracy verification fields. | `node tools/scripts/audit-v2-usefulness.js --mode full --accuracy-mode tiered` | docs |
 | `tools/scripts/check-component-errors.js` | Utility script for tools/scripts/check-component-errors.js. | `node tools/scripts/check-component-errors.js` | docs |
 | `tools/scripts/cleanup-quarantine-manager.js` | Classify cleanup candidates and optionally quarantine files with a reversible manifest. | `node tools/scripts/cleanup-quarantine-manager.js` | docs |
+| `tools/scripts/codex-commit.js` | Create commits through a guarded interface that supports audited human-requested no-verify overrides. | `node tools/scripts/codex-commit.js --message "chore: update docs"` | docs |
+| `tools/scripts/codex-safe-merge-with-stash.js` | Safely execute an explicit merge request by stashing local changes, merging a target ref, and restoring the stash. | `node tools/scripts/codex-safe-merge-with-stash.js --target docs-v2` | docs |
 | `tools/scripts/component-layout-governance.js` | Validate v2 English docs against component-layout contracts by page type. | `node tools/scripts/component-layout-governance.js --scope full` | docs |
 | `tools/scripts/convert-rss-to-mdx.js` | Convert an RSS feed XML file into a structured MDX document. | `node tools/scripts/convert-rss-to-mdx.js --input v2/internal/assets/transcripts/ycomb.rss --output v2/internal/assets/transcripts/ycomb.mdx` | docs |
 | `tools/scripts/create-codex-pr.js` | Generate a codex PR body from task contract metadata and optionally open a prefilled GitHub pull request. | `node tools/scripts/create-codex-pr.js --create` | docs |

--- a/tests/script-index.md
+++ b/tests/script-index.md
@@ -14,6 +14,8 @@
 | `tests/integration/v2-wcag-audit.selftest.js` | Script-level self-tests for the v2 WCAG audit (local HTTP + Puppeteer axe run, and temp-file fix/stage behavior without Mintlify). | `node tests/integration/v2-wcag-audit.selftest.js` | docs |
 | `tests/run-all.js` | Utility script for tests/run-all.js. | `node tests/run-all.js` | docs |
 | `tests/run-pr-checks.js` | Run changed-file scoped validation checks for pull request CI, including Codex skill sync and codex task-contract enforcement. | `node tests/run-pr-checks.js --base-ref main` | docs |
+| `tests/unit/codex-commit.test.js` | Validate codex commit helper behavior for normal commits and explicit audited no-verify override handling. | `node tests/unit/codex-commit.test.js` | docs |
+| `tests/unit/codex-safe-merge-with-stash.test.js` | Validate safe merge helper behavior for clean merges, dirty-tree stash/restore, and conflict handling. | `node tests/unit/codex-safe-merge-with-stash.test.js` | docs |
 | `tests/unit/codex-skill-sync.test.js` | Validate template-driven Codex skill sync behavior including check drift, safe upsert, subset sync, and openai.yaml generation. | `node tests/unit/codex-skill-sync.test.js` | docs |
 | `tests/unit/create-codex-pr.test.js` | Validate codex PR body generation and dry-run create behavior from task-contract input. | `node tests/unit/create-codex-pr.test.js` | docs |
 | `tests/unit/docs-guide-sot.test.js` | Validate docs-guide source-of-truth coverage, README pointers, and generated index freshness. | `node tests/unit/docs-guide-sot.test.js` | docs |

--- a/tests/unit/codex-commit.test.js
+++ b/tests/unit/codex-commit.test.js
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+/**
+ * @script codex-commit.test
+ * @summary Validate codex commit helper behavior for normal commits and explicit audited no-verify override handling.
+ * @owner docs
+ * @scope tests/unit, tools/scripts/codex-commit.js
+ *
+ * @usage
+ *   node tests/unit/codex-commit.test.js
+ *
+ * @inputs
+ *   No required CLI flags.
+ *
+ * @outputs
+ *   - Console test summary
+ *
+ * @exit-codes
+ *   0 = all test cases passed
+ *   1 = one or more test cases failed
+ *
+ * @examples
+ *   node tests/unit/codex-commit.test.js
+ *
+ * @notes
+ *   Uses temporary git repositories and does not modify tracked repository files.
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const REPO_ROOT = process.cwd();
+const SCRIPT_PATH = path.join(REPO_ROOT, 'tools/scripts/codex-commit.js');
+
+function run(cmd, args, cwd) {
+  return spawnSync(cmd, args, { cwd, encoding: 'utf8' });
+}
+
+function runGit(args, cwd) {
+  const out = run('git', args, cwd);
+  if (out.status !== 0) {
+    throw new Error(`git ${args.join(' ')} failed: ${out.stderr || out.stdout}`);
+  }
+  return (out.stdout || '').trim();
+}
+
+function writeFile(absPath, content) {
+  fs.mkdirSync(path.dirname(absPath), { recursive: true });
+  fs.writeFileSync(absPath, content, 'utf8');
+}
+
+function mkRepo(prefix) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  runGit(['init', '-b', 'main'], dir);
+  runGit(['config', 'user.email', 'tests@example.com'], dir);
+  runGit(['config', 'user.name', 'test-runner'], dir);
+  writeFile(path.join(dir, 'file.txt'), 'init\n');
+  runGit(['add', 'file.txt'], dir);
+  runGit(['commit', '-m', 'init'], dir);
+  return dir;
+}
+
+function runScript(args, cwd) {
+  return run('node', [SCRIPT_PATH, ...args], cwd);
+}
+
+async function runTests() {
+  const failures = [];
+  const cases = [];
+
+  cases.push(async () => {
+    const repo = mkRepo('codex-commit-normal-');
+    writeFile(path.join(repo, 'file.txt'), 'normal\n');
+    runGit(['add', 'file.txt'], repo);
+
+    const exec = runScript(['--message', 'chore: normal commit'], repo);
+    assert.strictEqual(exec.status, 0, exec.stderr || exec.stdout);
+    const body = runGit(['log', '-1', '--pretty=%B'], repo);
+    assert.match(body, /chore: normal commit/);
+  });
+
+  cases.push(async () => {
+    const repo = mkRepo('codex-commit-reject-');
+    writeFile(path.join(repo, 'file.txt'), 'reject\n');
+    runGit(['add', 'file.txt'], repo);
+
+    const exec = runScript(['--message', 'chore: should fail', '--no-verify'], repo);
+    assert.strictEqual(exec.status, 1, 'no-verify without override must fail');
+    const output = `${exec.stdout}\n${exec.stderr}`;
+    assert.match(output, /requires --human-override true/i);
+  });
+
+  cases.push(async () => {
+    const repo = mkRepo('codex-commit-override-');
+    writeFile(path.join(repo, 'file.txt'), 'override\n');
+    runGit(['add', 'file.txt'], repo);
+
+    const exec = runScript(
+      [
+        '--message',
+        'chore: override commit',
+        '--no-verify',
+        '--human-override',
+        'true',
+        '--override-note',
+        'User said no-verify is allowed for this commit.'
+      ],
+      repo
+    );
+    assert.strictEqual(exec.status, 0, exec.stderr || exec.stdout);
+
+    const body = runGit(['log', '-1', '--pretty=%B'], repo);
+    assert.match(body, /\[override-audit\]/);
+    assert.match(body, /override_type: no-verify/);
+    assert.match(body, /requested_by: human/);
+    assert.match(body, /User said no-verify is allowed/);
+  });
+
+  for (let i = 0; i < cases.length; i += 1) {
+    const name = `case-${i + 1}`;
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      await cases[i]();
+      console.log(`   ✓ ${name}`);
+    } catch (error) {
+      failures.push(`${name}: ${error.message}`);
+    }
+  }
+
+  return {
+    passed: failures.length === 0,
+    total: cases.length,
+    errors: failures
+  };
+}
+
+if (require.main === module) {
+  runTests()
+    .then((result) => {
+      if (result.passed) {
+        console.log(`\n✅ codex-commit tests passed (${result.total} cases)`);
+        process.exit(0);
+      }
+      console.error(`\n❌ ${result.errors.length} codex-commit test failure(s)`);
+      result.errors.forEach((entry) => console.error(`  - ${entry}`));
+      process.exit(1);
+    })
+    .catch((error) => {
+      console.error(`\n❌ codex-commit tests crashed: ${error.message}`);
+      process.exit(1);
+    });
+}
+
+module.exports = { runTests };

--- a/tests/unit/codex-safe-merge-with-stash.test.js
+++ b/tests/unit/codex-safe-merge-with-stash.test.js
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+/**
+ * @script codex-safe-merge-with-stash.test
+ * @summary Validate safe merge helper behavior for clean merges, dirty-tree stash/restore, and conflict handling.
+ * @owner docs
+ * @scope tests/unit, tools/scripts/codex-safe-merge-with-stash.js
+ *
+ * @usage
+ *   node tests/unit/codex-safe-merge-with-stash.test.js
+ *
+ * @inputs
+ *   No required CLI flags.
+ *
+ * @outputs
+ *   - Console test summary
+ *
+ * @exit-codes
+ *   0 = all test cases passed
+ *   1 = one or more test cases failed
+ *
+ * @examples
+ *   node tests/unit/codex-safe-merge-with-stash.test.js
+ *
+ * @notes
+ *   Uses temporary git repositories and does not modify tracked repository files.
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const REPO_ROOT = process.cwd();
+const SCRIPT_PATH = path.join(REPO_ROOT, 'tools/scripts/codex-safe-merge-with-stash.js');
+
+function run(cmd, args, cwd) {
+  return spawnSync(cmd, args, { cwd, encoding: 'utf8' });
+}
+
+function runGit(args, cwd) {
+  const out = run('git', args, cwd);
+  if (out.status !== 0) {
+    throw new Error(`git ${args.join(' ')} failed: ${out.stderr || out.stdout}`);
+  }
+  return (out.stdout || '').trim();
+}
+
+function writeFile(absPath, content) {
+  fs.mkdirSync(path.dirname(absPath), { recursive: true });
+  fs.writeFileSync(absPath, content, 'utf8');
+}
+
+function mkRepo(prefix) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  runGit(['init', '-b', 'main'], dir);
+  runGit(['config', 'user.email', 'tests@example.com'], dir);
+  runGit(['config', 'user.name', 'test-runner'], dir);
+  writeFile(path.join(dir, 'app.txt'), 'base\n');
+  runGit(['add', 'app.txt'], dir);
+  runGit(['commit', '-m', 'init'], dir);
+  runGit(['checkout', '-b', 'feature'], dir);
+  return dir;
+}
+
+function runScript(args, cwd) {
+  return run('node', [SCRIPT_PATH, ...args], cwd);
+}
+
+async function runTests() {
+  const failures = [];
+  const cases = [];
+
+  cases.push(async () => {
+    const repo = mkRepo('codex-safe-merge-clean-');
+    runGit(['checkout', 'main'], repo);
+    writeFile(path.join(repo, 'app.txt'), 'base\nmain-change\n');
+    runGit(['add', 'app.txt'], repo);
+    runGit(['commit', '-m', 'main change'], repo);
+    runGit(['checkout', 'feature'], repo);
+
+    const exec = runScript(['--target', 'main'], repo);
+    assert.strictEqual(exec.status, 0, exec.stderr || exec.stdout);
+    const merged = fs.readFileSync(path.join(repo, 'app.txt'), 'utf8');
+    assert.match(merged, /main-change/, 'feature should include merged change');
+  });
+
+  cases.push(async () => {
+    const repo = mkRepo('codex-safe-merge-dirty-');
+    runGit(['checkout', 'main'], repo);
+    writeFile(path.join(repo, 'app.txt'), 'base\nmain-change\n');
+    runGit(['add', 'app.txt'], repo);
+    runGit(['commit', '-m', 'main change'], repo);
+    runGit(['checkout', 'feature'], repo);
+
+    writeFile(path.join(repo, 'local.txt'), 'local-dirty\n');
+    writeFile(path.join(repo, 'temp-untracked.txt'), 'temp\n');
+    runGit(['add', 'local.txt'], repo);
+
+    const exec = runScript(['--target', 'main'], repo);
+    assert.strictEqual(exec.status, 0, exec.stderr || exec.stdout);
+
+    const localTracked = fs.readFileSync(path.join(repo, 'local.txt'), 'utf8');
+    const localUntracked = fs.readFileSync(path.join(repo, 'temp-untracked.txt'), 'utf8');
+    assert.match(localTracked, /local-dirty/, 'tracked local file should be restored');
+    assert.match(localUntracked, /temp/, 'untracked local file should be restored');
+  });
+
+  cases.push(async () => {
+    const repo = mkRepo('codex-safe-merge-conflict-');
+    runGit(['checkout', 'main'], repo);
+    writeFile(path.join(repo, 'app.txt'), 'main-version\n');
+    runGit(['add', 'app.txt'], repo);
+    runGit(['commit', '-m', 'main update'], repo);
+    runGit(['checkout', 'feature'], repo);
+    writeFile(path.join(repo, 'app.txt'), 'feature-version\n');
+    runGit(['add', 'app.txt'], repo);
+    runGit(['commit', '-m', 'feature update'], repo);
+
+    writeFile(path.join(repo, 'dirty.txt'), 'dirty\n');
+    runGit(['add', 'dirty.txt'], repo);
+
+    const exec = runScript(['--target', 'main'], repo);
+    assert.strictEqual(exec.status, 1, 'merge conflict should fail');
+
+    const stashList = runGit(['stash', 'list'], repo);
+    assert.match(stashList, /codex-safe-merge:/, 'stash should be preserved when merge fails');
+  });
+
+  for (let i = 0; i < cases.length; i += 1) {
+    const name = `case-${i + 1}`;
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      await cases[i]();
+      console.log(`   ✓ ${name}`);
+    } catch (error) {
+      failures.push(`${name}: ${error.message}`);
+    }
+  }
+
+  return {
+    passed: failures.length === 0,
+    total: cases.length,
+    errors: failures
+  };
+}
+
+if (require.main === module) {
+  runTests()
+    .then((result) => {
+      if (result.passed) {
+        console.log(`\n✅ codex-safe-merge-with-stash tests passed (${result.total} cases)`);
+        process.exit(0);
+      }
+      console.error(`\n❌ ${result.errors.length} codex-safe-merge-with-stash test failure(s)`);
+      result.errors.forEach((entry) => console.error(`  - ${entry}`));
+      process.exit(1);
+    })
+    .catch((error) => {
+      console.error(`\n❌ codex-safe-merge-with-stash tests crashed: ${error.message}`);
+      process.exit(1);
+    });
+}
+
+module.exports = { runTests };

--- a/tools/script-index.md
+++ b/tools/script-index.md
@@ -15,6 +15,8 @@
 | `tools/scripts/audit-v2-usefulness.js` | Audit v2 MDX pages (excluding x-* directories) and emit page-level usefulness matrix rows with source-weighted 2026 accuracy verification fields. | `node tools/scripts/audit-v2-usefulness.js --mode full --accuracy-mode tiered` | docs |
 | `tools/scripts/check-component-errors.js` | Utility script for tools/scripts/check-component-errors.js. | `node tools/scripts/check-component-errors.js` | docs |
 | `tools/scripts/cleanup-quarantine-manager.js` | Classify cleanup candidates and optionally quarantine files with a reversible manifest. | `node tools/scripts/cleanup-quarantine-manager.js` | docs |
+| `tools/scripts/codex-commit.js` | Create commits through a guarded interface that supports audited human-requested no-verify overrides. | `node tools/scripts/codex-commit.js --message "chore: update docs"` | docs |
+| `tools/scripts/codex-safe-merge-with-stash.js` | Safely execute an explicit merge request by stashing local changes, merging a target ref, and restoring the stash. | `node tools/scripts/codex-safe-merge-with-stash.js --target docs-v2` | docs |
 | `tools/scripts/component-layout-governance.js` | Validate v2 English docs against component-layout contracts by page type. | `node tools/scripts/component-layout-governance.js --scope full` | docs |
 | `tools/scripts/convert-rss-to-mdx.js` | Convert an RSS feed XML file into a structured MDX document. | `node tools/scripts/convert-rss-to-mdx.js --input v2/internal/assets/transcripts/ycomb.rss --output v2/internal/assets/transcripts/ycomb.mdx` | docs |
 | `tools/scripts/create-codex-pr.js` | Generate a codex PR body from task contract metadata and optionally open a prefilled GitHub pull request. | `node tools/scripts/create-codex-pr.js --create` | docs |

--- a/tools/scripts/codex-commit.js
+++ b/tools/scripts/codex-commit.js
@@ -1,0 +1,225 @@
+#!/usr/bin/env node
+/**
+ * @script codex-commit
+ * @summary Create commits through a guarded interface that supports audited human-requested no-verify overrides.
+ * @owner docs
+ * @scope tools/scripts
+ *
+ * @usage
+ *   node tools/scripts/codex-commit.js --message "chore: update docs"
+ *
+ * @inputs
+ *   --message <text> Required commit subject line.
+ *   --no-verify Optional flag; only allowed with explicit human override fields.
+ *   --human-override <true|false> Required when --no-verify is used.
+ *   --override-note <text> Required when --no-verify is used.
+ *   --reason <text> Optional reason (default: user-directed override).
+ *   --dry-run Print the git command and commit body without executing.
+ *   --json Emit machine-readable result output.
+ *
+ * @outputs
+ *   - Commit on current branch
+ *   - Console summary
+ *
+ * @exit-codes
+ *   0 = commit command succeeded
+ *   1 = invalid arguments or git commit failed
+ *
+ * @examples
+ *   node tools/scripts/codex-commit.js --message "docs: update nav"
+ *
+ * @notes
+ *   Use no-verify only for explicit human requests and include audit metadata.
+ */
+
+const { spawnSync } = require('child_process');
+
+function parseArgs(argv) {
+  const args = {
+    message: '',
+    noVerify: false,
+    humanOverride: '',
+    overrideNote: '',
+    reason: 'user-directed override',
+    dryRun: false,
+    json: false
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+
+    if (token === '--message') {
+      args.message = String(argv[i + 1] || '').trim();
+      i += 1;
+      continue;
+    }
+    if (token.startsWith('--message=')) {
+      args.message = token.slice('--message='.length).trim();
+      continue;
+    }
+    if (token === '--no-verify') {
+      args.noVerify = true;
+      continue;
+    }
+    if (token === '--human-override') {
+      args.humanOverride = String(argv[i + 1] || '').trim();
+      i += 1;
+      continue;
+    }
+    if (token.startsWith('--human-override=')) {
+      args.humanOverride = token.slice('--human-override='.length).trim();
+      continue;
+    }
+    if (token === '--override-note') {
+      args.overrideNote = String(argv[i + 1] || '').trim();
+      i += 1;
+      continue;
+    }
+    if (token.startsWith('--override-note=')) {
+      args.overrideNote = token.slice('--override-note='.length).trim();
+      continue;
+    }
+    if (token === '--reason') {
+      args.reason = String(argv[i + 1] || '').trim() || args.reason;
+      i += 1;
+      continue;
+    }
+    if (token.startsWith('--reason=')) {
+      args.reason = token.slice('--reason='.length).trim() || args.reason;
+      continue;
+    }
+    if (token === '--dry-run') {
+      args.dryRun = true;
+      continue;
+    }
+    if (token === '--json') {
+      args.json = true;
+      continue;
+    }
+    if (token === '--help' || token === '-h') {
+      printUsage();
+      process.exit(0);
+    }
+
+    throw new Error(`Unknown argument: ${token}`);
+  }
+
+  if (!args.message) {
+    throw new Error('Missing required --message <text>');
+  }
+
+  if (args.noVerify) {
+    if (args.humanOverride !== 'true') {
+      throw new Error('--no-verify requires --human-override true');
+    }
+    if (!args.overrideNote) {
+      throw new Error('--no-verify requires --override-note "<explicit user instruction>"');
+    }
+  }
+
+  return args;
+}
+
+function printUsage() {
+  console.log('Usage: node tools/scripts/codex-commit.js --message "<text>" [--no-verify --human-override true --override-note "..."]');
+}
+
+function buildAuditBlock(args) {
+  if (!args.noVerify) return '';
+  return [
+    '[override-audit]',
+    'override_type: no-verify',
+    'requested_by: human',
+    `request_context: "${args.overrideNote.replace(/"/g, '\\"')}"`,
+    `reason: "${args.reason.replace(/"/g, '\\"')}"`,
+    `requested_at: "${new Date().toISOString()}"`
+  ].join('\n');
+}
+
+function runCommit(args, bodyBlock) {
+  const commitArgs = ['commit'];
+  if (args.noVerify) commitArgs.push('--no-verify');
+  commitArgs.push('-m', args.message);
+  if (bodyBlock) {
+    commitArgs.push('-m', bodyBlock);
+  }
+
+  return spawnSync('git', commitArgs, { encoding: 'utf8' });
+}
+
+function printResult(result, jsonMode) {
+  if (jsonMode) {
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    return;
+  }
+
+  if (result.passed) {
+    console.log(`✅ ${result.message}`);
+  } else {
+    console.error(`❌ ${result.message}`);
+  }
+
+  if (result.command) {
+    console.log(`Command: ${result.command}`);
+  }
+}
+
+function main() {
+  try {
+    const args = parseArgs(process.argv.slice(2));
+    const auditBlock = buildAuditBlock(args);
+    const commandPreview = `git commit${args.noVerify ? ' --no-verify' : ''} -m "${args.message}"${auditBlock ? ' -m "<override-audit>"' : ''}`;
+
+    if (args.dryRun) {
+      printResult(
+        {
+          passed: true,
+          message: 'Dry-run completed.',
+          command: commandPreview,
+          overrideAudit: auditBlock || null
+        },
+        args.json
+      );
+      process.exit(0);
+    }
+
+    const res = runCommit(args, auditBlock);
+    const output = `${String(res.stdout || '')}${String(res.stderr || '')}`.trim();
+
+    if (res.status !== 0) {
+      printResult(
+        {
+          passed: false,
+          message: output || 'git commit failed',
+          command: commandPreview
+        },
+        args.json
+      );
+      process.exit(1);
+    }
+
+    printResult(
+      {
+        passed: true,
+        message: 'Commit created successfully.',
+        command: commandPreview,
+        overrideAudit: auditBlock || null
+      },
+      args.json
+    );
+    process.exit(0);
+  } catch (error) {
+    printResult(
+      {
+        passed: false,
+        message: error.message
+      },
+      false
+    );
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  main();
+}

--- a/tools/scripts/codex-safe-merge-with-stash.js
+++ b/tools/scripts/codex-safe-merge-with-stash.js
@@ -1,0 +1,286 @@
+#!/usr/bin/env node
+/**
+ * @script codex-safe-merge-with-stash
+ * @summary Safely execute an explicit merge request by stashing local changes, merging a target ref, and restoring the stash.
+ * @owner docs
+ * @scope tools/scripts
+ *
+ * @usage
+ *   node tools/scripts/codex-safe-merge-with-stash.js --target docs-v2
+ *
+ * @inputs
+ *   --target <branch-or-ref> Required merge target.
+ *   --stash-untracked Whether to stash untracked files (default: true).
+ *   --dry-run Print planned git commands without mutating state.
+ *   --json Emit machine-readable result output.
+ *
+ * @outputs
+ *   - Console summary
+ *   - Optional JSON result object
+ *
+ * @exit-codes
+ *   0 = merge flow completed successfully
+ *   1 = invalid arguments or merge/stash failure
+ *
+ * @examples
+ *   node tools/scripts/codex-safe-merge-with-stash.js --target origin/docs-v2
+ *
+ * @notes
+ *   Designed for explicit human-requested merge operations in multi-agent workflows. No force-push or auto conflict resolution.
+ */
+
+const { spawnSync } = require('child_process');
+
+function parseArgs(argv) {
+  const args = {
+    target: '',
+    stashUntracked: true,
+    dryRun: false,
+    json: false
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (token === '--target') {
+      args.target = String(argv[i + 1] || '').trim();
+      i += 1;
+      continue;
+    }
+    if (token.startsWith('--target=')) {
+      args.target = token.slice('--target='.length).trim();
+      continue;
+    }
+    if (token === '--stash-untracked') {
+      args.stashUntracked = true;
+      continue;
+    }
+    if (token === '--no-stash-untracked') {
+      args.stashUntracked = false;
+      continue;
+    }
+    if (token === '--dry-run') {
+      args.dryRun = true;
+      continue;
+    }
+    if (token === '--json') {
+      args.json = true;
+      continue;
+    }
+    if (token === '--help' || token === '-h') {
+      printUsage();
+      process.exit(0);
+    }
+    throw new Error(`Unknown argument: ${token}`);
+  }
+
+  if (!args.target) {
+    throw new Error('Missing required --target <branch-or-ref>');
+  }
+
+  return args;
+}
+
+function printUsage() {
+  console.log('Usage: node tools/scripts/codex-safe-merge-with-stash.js --target <branch-or-ref> [--dry-run] [--json]');
+}
+
+function runGit(args, options = {}) {
+  const res = spawnSync('git', args, {
+    encoding: 'utf8',
+    ...options
+  });
+  return {
+    status: res.status,
+    stdout: String(res.stdout || ''),
+    stderr: String(res.stderr || ''),
+    ok: res.status === 0
+  };
+}
+
+function runGitOrThrow(args, options = {}) {
+  const res = runGit(args, options);
+  if (!res.ok) {
+    const detail = (res.stderr || res.stdout).trim() || `git ${args.join(' ')} failed`;
+    throw new Error(detail);
+  }
+  return res.stdout.trim();
+}
+
+function hasOriginRemote() {
+  const res = runGit(['remote', 'get-url', 'origin']);
+  return res.ok;
+}
+
+function getStashRefByMessage(marker) {
+  const list = runGitOrThrow(['stash', 'list', '--format=%gd|%s']);
+  if (!list) return '';
+  const line = list
+    .split('\n')
+    .map((entry) => entry.trim())
+    .find((entry) => entry.includes(marker));
+  if (!line) return '';
+  return line.split('|')[0].trim();
+}
+
+function getGitStatusPorcelain() {
+  return runGitOrThrow(['status', '--porcelain']);
+}
+
+function printResult(result, jsonMode) {
+  if (jsonMode) {
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    return;
+  }
+
+  const statusIcon = result.passed ? '✅' : '❌';
+  console.log(`${statusIcon} ${result.message}`);
+  if (result.actions && result.actions.length > 0) {
+    result.actions.forEach((action) => console.log(`  - ${action}`));
+  }
+  if (result.recovery && result.recovery.length > 0) {
+    console.log('Recovery steps:');
+    result.recovery.forEach((line) => console.log(`  - ${line}`));
+  }
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const actions = [];
+  const recovery = [];
+
+  try {
+    const branch = runGitOrThrow(['rev-parse', '--abbrev-ref', 'HEAD']);
+    const dirty = getGitStatusPorcelain().trim().length > 0;
+    const marker = `codex-safe-merge:${new Date().toISOString()}:${args.target}`;
+    let stashRef = '';
+
+    if (args.dryRun) {
+      actions.push(`would evaluate dirty tree on branch ${branch}`);
+      if (dirty) {
+        actions.push(
+          `would run git stash push ${args.stashUntracked ? '-u ' : ''}-m "${marker}"`
+        );
+      }
+      if (hasOriginRemote()) {
+        actions.push(`would run git fetch origin ${args.target}`);
+      }
+      actions.push(`would run git merge --no-edit ${args.target}`);
+      if (dirty) {
+        actions.push('would run git stash pop <stash-ref> after successful merge');
+      }
+
+      printResult(
+        {
+          passed: true,
+          message: 'Dry-run completed.',
+          branch,
+          target: args.target,
+          dirty,
+          actions,
+          recovery
+        },
+        args.json
+      );
+      process.exit(0);
+    }
+
+    if (dirty) {
+      const stashArgs = ['stash', 'push'];
+      if (args.stashUntracked) stashArgs.push('-u');
+      stashArgs.push('-m', marker);
+      runGitOrThrow(stashArgs);
+      stashRef = getStashRefByMessage(marker);
+      actions.push(`stashed local changes as ${stashRef || marker}`);
+    }
+
+    if (hasOriginRemote()) {
+      const fetchRes = runGit(['fetch', 'origin', args.target]);
+      if (!fetchRes.ok) {
+        actions.push(`fetch skipped/failed for target ${args.target}; proceeding with local refs`);
+      } else {
+        actions.push(`fetched target from origin: ${args.target}`);
+      }
+    }
+
+    const mergeRes = runGit(['merge', '--no-edit', args.target]);
+    if (!mergeRes.ok) {
+      actions.push(`merge failed for target ${args.target}`);
+      recovery.push('Resolve or abort merge explicitly (for example: git merge --abort).');
+      if (stashRef) {
+        recovery.push(`Stashed changes are preserved in ${stashRef}. Apply later with: git stash pop ${stashRef}`);
+      }
+
+      printResult(
+        {
+          passed: false,
+          message: `Merge failed for target ${args.target}.`,
+          branch,
+          target: args.target,
+          dirty,
+          stashRef,
+          actions,
+          recovery
+        },
+        args.json
+      );
+      process.exit(1);
+    }
+
+    actions.push(`merged target ${args.target} into ${branch}`);
+
+    if (stashRef) {
+      const popRes = runGit(['stash', 'pop', stashRef]);
+      if (!popRes.ok) {
+        actions.push(`stash pop failed for ${stashRef}`);
+        recovery.push('Resolve stash-pop conflicts and stage resolved files manually.');
+        recovery.push(`If needed, stash remains available as ${stashRef}.`);
+
+        printResult(
+          {
+            passed: false,
+            message: 'Merge succeeded but stash pop reported conflicts.',
+            branch,
+            target: args.target,
+            dirty,
+            stashRef,
+            actions,
+            recovery
+          },
+          args.json
+        );
+        process.exit(1);
+      }
+      actions.push(`restored stashed changes from ${stashRef}`);
+    }
+
+    printResult(
+      {
+        passed: true,
+        message: `Safe merge completed for target ${args.target}.`,
+        branch,
+        target: args.target,
+        dirty,
+        stashRef,
+        actions,
+        recovery
+      },
+      args.json
+    );
+    process.exit(0);
+  } catch (error) {
+    printResult(
+      {
+        passed: false,
+        message: error.message,
+        actions,
+        recovery
+      },
+      args.json
+    );
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  main();
+}


### PR DESCRIPTION
<!-- codex-pr-body-generated: task_id=782; branch=codex/782-workflow-softening-overrides; contract=.codex/task-contract.yaml -->

## Scope

- Task: #782
- Branch: `codex/782-workflow-softening-overrides`
- Base: `docs-v2`

In scope:
- `.codex/task-contract.yaml`
- `.github/AGENTS.md`
- `.github/augment-instructions.md`
- `README.md`
- `contribute/CONTRIBUTING/AGENT-INSTRUCTIONS.md`
- `contribute/CONTRIBUTING/GIT-HOOKS.md`
- `ai-tools/ai-rules/HUMAN-OVERRIDE-POLICY.md`
- `ai-tools/ai-rules/AI_GUIDELINES.md`
- `ai-tools/ai-rules/rules/git-safety.md`
- `ai-tools/ai-rules/rules/imported/AI_GUIDELINES.md`
- `ai-tools/ai-skills/templates/31-codex-task-isolation-standard.template.md`
- `tools/scripts/codex-safe-merge-with-stash.js`
- `tools/scripts/codex-commit.js`
- `tools/script-index.md`
- `tests/unit/codex-safe-merge-with-stash.test.js`
- `tests/unit/codex-commit.test.js`
- `tests/script-index.md`

Out of scope:
- `v1/`

Allowed generated files:
- `.codex/pr-body.generated.md`
- `docs-guide/indexes/scripts-index.mdx`

Changed files in this branch:
- `.codex/task-contract.yaml`
- `.github/AGENTS.md`
- `.github/augment-instructions.md`
- `README.md`
- `ai-tools/ai-rules/AI_GUIDELINES.md`
- `ai-tools/ai-rules/HUMAN-OVERRIDE-POLICY.md`
- `ai-tools/ai-rules/rules/git-safety.md`
- `ai-tools/ai-rules/rules/imported/AI_GUIDELINES.md`
- `ai-tools/ai-skills/templates/31-codex-task-isolation-standard.template.md`
- `contribute/CONTRIBUTING/AGENT-INSTRUCTIONS.md`
- `contribute/CONTRIBUTING/GIT-HOOKS.md`
- `docs-guide/indexes/scripts-index.mdx`
- `tests/script-index.md`
- `tests/unit/codex-commit.test.js`
- `tests/unit/codex-safe-merge-with-stash.test.js`
- `tools/script-index.md`
- `tools/scripts/codex-commit.js`
- `tools/scripts/codex-safe-merge-with-stash.js`

## Validation

Acceptance checks from `.codex/task-contract.yaml`:
- [ ] `node tests/unit/script-docs.test.js`
- [ ] `node tests/unit/codex-safe-merge-with-stash.test.js`
- [ ] `node tests/unit/codex-commit.test.js`
- [ ] `node tests/run-pr-checks.js --base-ref docs-v2`

Validation results:
- [ ] _(fill in outcomes before requesting final review)_

## Follow-up Tasks

- none

