### PR TITLE
[#788] Scoped Lpd Mint Dev Profiles

### DIFF
--- a/.codex/task-contract.yaml
+++ b/.codex/task-contract.yaml
@@ -1,34 +1,28 @@
-task_id: 782
+task_id: 788
+branch: codex/788-scoped-lpd-mint-dev-profiles
 base_branch: docs-v2
-branch: codex/782-workflow-softening-overrides
 scope_in:
   - .codex/task-contract.yaml
-  - .github/AGENTS.md
-  - .github/augment-instructions.md
+  - lpd
+  - tools/scripts/mint-dev.sh
+  - tools/scripts/dev/
+  - tests/unit/
+  - tests/run-all.js
+  - docs-guide/lpd.mdx
   - README.md
-  - contribute/CONTRIBUTING/AGENT-INSTRUCTIONS.md
-  - contribute/CONTRIBUTING/GIT-HOOKS.md
-  - ai-tools/ai-rules/HUMAN-OVERRIDE-POLICY.md
-  - ai-tools/ai-rules/AI_GUIDELINES.md
-  - ai-tools/ai-rules/rules/git-safety.md
-  - ai-tools/ai-rules/rules/imported/AI_GUIDELINES.md
-  - ai-tools/ai-skills/templates/31-codex-task-isolation-standard.template.md
-  - tools/scripts/codex-safe-merge-with-stash.js
-  - tools/scripts/codex-commit.js
   - tools/script-index.md
-  - tests/unit/codex-safe-merge-with-stash.test.js
-  - tests/unit/codex-commit.test.js
   - tests/script-index.md
-scope_out:
-  - v1/
+  - docs-guide/indexes/scripts-index.mdx
+scope_out: []
 allowed_generated:
   - .codex/pr-body.generated.md
-  - docs-guide/indexes/scripts-index.mdx
 acceptance_checks:
-  - node tests/unit/script-docs.test.js
-  - node tests/unit/codex-safe-merge-with-stash.test.js
-  - node tests/unit/codex-commit.test.js
-  - node tests/run-pr-checks.js --base-ref docs-v2
+  - node tests/unit/lpd-scoped-mint-dev.test.js
+  - node tests/unit/script-docs.test.js --files tools/scripts/dev/generate-mint-dev-scope.js --files tests/unit/lpd-scoped-mint-dev.test.js --check-indexes
+  - node tools/scripts/dev/generate-mint-dev-scope.js --repo-root . --versions v2 --languages en --tabs Developers --disable-openapi --print-only
+  - bash lpd dev --dry-run --scoped --scope-version v2 --scope-language en --scope-tab Developers --scope-prefix v2/gateways --disable-openapi
 risk_flags:
-  - ci-impact
+  - performance
+  - cli-contract
+  - docs-navigation
 follow_up_issues: []

--- a/README.md
+++ b/README.md
@@ -38,6 +38,18 @@ bash lpd setup --yes
 lpd dev
 ```
 
+For very large `docs.json` runs (multi-version/language) use scoped dev profile mode:
+
+```bash
+lpd dev --scoped --scope-version v2 --scope-language en --scope-tab Developers
+```
+
+Interactive scoped picker:
+
+```bash
+lpd dev --scoped --scope-interactive
+```
+
 If `lpd` is not on PATH yet:
 
 ```bash
@@ -69,6 +81,11 @@ Recovery:
 
 1. Use `lpd dev` (or `bash tools/scripts/mint-dev.sh`) so the launcher applies the patch preflight and uses a watcher-safe path fallback.
 2. Re-run `bash tools/scripts/dev/ensure-mint-watcher-patch.sh --apply` after `mint update`.
+
+For very large docs trees with sluggish route transitions:
+
+1. Run `lpd dev --scoped ...` to load only the active version/language/tab/prefix.
+2. Add `--skip-external-fetch` during local iterations when external snippets do not need refresh.
 
 ## Core Capabilities (At a Glance)
 

--- a/docs-guide/indexes/scripts-index.mdx
+++ b/docs-guide/indexes/scripts-index.mdx
@@ -65,6 +65,7 @@ Run command: node tests/unit/script-docs.test.js --write --rebuild-indexes
 | `tests/unit/docs-navigation.test.js` | Validate docs.json page-entry syntax in check-only mode by default, with optional report writing and approved remaps. | `./lpd tests unit docs-navigation.test` | docs |
 | `tests/unit/docs-usefulness-accuracy-verifier.test.js` | Validate source-weighted 2026 accuracy verification rules (GitHub vs DeepWiki precedence, freshness, fallback, and cache reuse). | `node tests/unit/docs-usefulness-accuracy-verifier.test.js` | docs |
 | `tests/unit/links-imports.test.js` | Utility script for tests/unit/links-imports.test.js. | `node tests/unit/links-imports.test.js` | docs |
+| `tests/unit/lpd-scoped-mint-dev.test.js` | Validate scoped lpd mint-dev profile filtering, generated .mintignore exclusions, and dry-run flag wiring. | `node tests/unit/lpd-scoped-mint-dev.test.js` | docs |
 | `tests/unit/mdx-guards.test.js` | Enforce MDX guardrails for globals imports, math delimiters, and markdown table line breaks. | `node tests/unit/mdx-guards.test.js` | docs |
 | `tests/unit/mdx.test.js` | Utility script for tests/unit/mdx.test.js. | `node tests/unit/mdx.test.js` | docs |
 | `tests/unit/openapi-reference-audit.test.js` | Unit tests for OpenAPI reference audit parsing, mapping, validation findings, and conservative autofix behavior. | `node tests/unit/openapi-reference-audit.test.js` | docs |
@@ -114,6 +115,7 @@ Run command: node tests/unit/script-docs.test.js --write --rebuild-indexes
 | `tools/scripts/dev/add-callouts.js` | Utility script for tools/scripts/dev/add-callouts.js. | `node tools/scripts/dev/add-callouts.js` | docs |
 | `tools/scripts/dev/batch-update-og-image.sh` | Utility script for tools/scripts/dev/batch-update-og-image.sh. | `bash tools/scripts/dev/batch-update-og-image.sh` | docs |
 | `tools/scripts/dev/ensure-mint-watcher-patch.sh` | Ensure Mint local-preview watcher disables glob expansion in repo paths. | `bash tools/scripts/dev/ensure-mint-watcher-patch.sh --check` | docs |
+| `tools/scripts/dev/generate-mint-dev-scope.js` | Build deterministic Mint dev scoped profiles (docs.json + .mintignore) for large navigation trees. | `node tools/scripts/dev/generate-mint-dev-scope.js --versions v2 --languages en --tabs Developers` | docs |
 | `tools/scripts/dev/replace-og-image.py` | Utility script for tools/scripts/dev/replace-og-image.py. | `python3 tools/scripts/dev/replace-og-image.py` | docs |
 | `tools/scripts/dev/seo-generator-safe.js` | Utility script for tools/scripts/dev/seo-generator-safe.js. | `node tools/scripts/dev/seo-generator-safe.js` | docs |
 | `tools/scripts/dev/test-add-callouts.js` | Utility script for tools/scripts/dev/test-add-callouts.js. | `node tools/scripts/dev/test-add-callouts.js` | docs |

--- a/docs-guide/lpd.mdx
+++ b/docs-guide/lpd.mdx
@@ -114,8 +114,8 @@ lpd tools dev test-add-callouts -- --help
     { Command: "lpd version", "Flags available": "--json (global prefix)", Purpose: "CLI version", "JSON-capable": "Yes" },
     { Command: "lpd setup", "Flags available": "--yes, --no-tools, --no-tests, --no-hooks, --with-mintlify, --no-cli, --json", Purpose: "Bootstrap dependencies, hooks, and PATH wiring", "JSON-capable": "Yes" },
     { Command: "lpd doctor", "Flags available": "--strict, --json", Purpose: "Environment and repo-readiness checks", "JSON-capable": "Yes" },
-    { Command: "lpd dev", "Flags available": "--test, --test-mode, --script, --script=, --dry-run, --json, --", Purpose: "Run local docs dev launcher", "JSON-capable": "Yes" },
-    { Command: "lpd mint dev", "Flags available": "-- (pass-through), --json (global prefix)", Purpose: "Alias to lpd dev", "JSON-capable": "Yes" },
+    { Command: "lpd dev", "Flags available": "--test, --test-mode, --script, --script=, --dry-run, --scoped, --scope-interactive, --scope-file, --scope-version, --scope-language, --scope-tab, --scope-prefix, --skip-external-fetch, --disable-openapi, --json, --", Purpose: "Run local docs dev launcher (optionally with scoped dev docs profile)", "JSON-capable": "Yes" },
+    { Command: "lpd mint dev", "Flags available": "same as lpd dev; --json (global prefix)", Purpose: "Alias to lpd dev", "JSON-capable": "Yes" },
     { Command: "lpd test", "Flags available": "--staged, --full, --browser, --domain, --wcag, --wcag-no-fix, --link-audit-external, --base-url, --json", Purpose: "Run tests and optional audits", "JSON-capable": "Yes" },
     { Command: "lpd ci", "Flags available": "--skip-browser, --base-url, --json", Purpose: "Run CI-like local validation", "JSON-capable": "Yes" },
     { Command: "lpd ai-sitemap", "Flags available": "--write, --check, --json", Purpose: "Generate/validate sitemap-ai.xml", "JSON-capable": "Yes" },
@@ -275,7 +275,7 @@ For deeper test/audit script behaviour and owning paths, see [`quality-gates`](.
 
     **Usage**
     ```bash
-    lpd dev [--test] [--test-mode fast|staged|full] [--script <path>] [--script=<path>] [--dry-run] [--json] [-- ...mint args]
+    lpd dev [--test] [--test-mode fast|staged|full] [--script <path>] [--script=<path>] [--dry-run] [--scoped] [--scope-interactive] [--scope-file <path>] [--scope-version <csv>] [--scope-language <csv>] [--scope-tab <csv>] [--scope-prefix <csv>] [--skip-external-fetch] [--disable-openapi] [--json] [-- ...mint args]
     ```
 
     **Examples**
@@ -284,6 +284,8 @@ For deeper test/audit script behaviour and owning paths, see [`quality-gates`](.
     lpd dev --test --test-mode staged
     lpd dev --dry-run -- --port 3333
     lpd dev --script tools/scripts/mint-dev.sh -- --port 3001
+    lpd dev --scoped --scope-version v2 --scope-language en --scope-tab Developers
+    lpd dev --scoped --scope-interactive
     ```
 
     **Flags**
@@ -299,6 +301,33 @@ For deeper test/audit script behaviour and owning paths, see [`quality-gates`](.
     <ResponseField name="--dry-run" type="boolean" default="false">
       Prints the resolved launcher command and exits.
     </ResponseField>
+    <ResponseField name="--scoped" type="boolean" default="false">
+      Enables scoped dev profile generation so Mint runs against a reduced dev-only `docs.json` and `.mintignore` in `/tmp/lpd-mint-dev/<hash>`.
+    </ResponseField>
+    <ResponseField name="--scope-interactive" type="boolean" default="false">
+      Prompts for versions, languages, tabs, and route prefixes before generating the scoped dev profile.
+    </ResponseField>
+    <ResponseField name="--scope-file <path>" type="string" default="">
+      Reads scoped profile selections from a JSON file (`versions`, `languages`, `tabs`, `prefixes`, optional `disableOpenapi`).
+    </ResponseField>
+    <ResponseField name="--scope-version <csv>" type="string" default="all">
+      Limits navigation versions included in the scoped profile (repeatable).
+    </ResponseField>
+    <ResponseField name="--scope-language <csv>" type="string" default="all">
+      Limits languages included in the scoped profile (repeatable).
+    </ResponseField>
+    <ResponseField name="--scope-tab <csv>" type="string" default="all">
+      Limits tabs included in the scoped profile (repeatable).
+    </ResponseField>
+    <ResponseField name="--scope-prefix <csv>" type="string" default="all">
+      Limits docs routes by prefix (for example: `v2/gateways`, `v2/about`), useful for very large nav trees.
+    </ResponseField>
+    <ResponseField name="--skip-external-fetch" type="boolean" default="false">
+      Sets `MINT_SKIP_EXTERNAL_FETCH=1` so external snippets fetch is skipped for this run.
+    </ResponseField>
+    <ResponseField name="--disable-openapi" type="boolean" default="false">
+      Excludes OpenAPI API-reference routes from the scoped profile (`--scoped` mode only).
+    </ResponseField>
     <ResponseField name="--json" type="boolean" default="false">
       Enables JSON status envelope output.
     </ResponseField>
@@ -313,12 +342,13 @@ For deeper test/audit script behaviour and owning paths, see [`quality-gates`](.
 
     **Usage**
     ```bash
-    lpd mint dev [-- ...mint args]
+    lpd mint dev [--scoped] [--scope-...] [-- ...mint args]
     ```
 
     **Examples**
     ```bash
     lpd mint dev
+    lpd mint dev --scoped --scope-version v2 --scope-language en --scope-tab Developers
     lpd mint dev -- --port 3333
     ```
   </ResponseField>
@@ -774,6 +804,20 @@ Pass a port through the launcher:
 
 ```bash
 lpd dev -- --port 3334
+```
+
+### Slow startup or slow route changes on very large `docs.json`
+
+Use scoped dev mode so Mint loads only the version/language/tab/prefix you are actively editing:
+
+```bash
+lpd dev --scoped --scope-version v2 --scope-language en --scope-tab Developers
+```
+
+Interactive picker:
+
+```bash
+lpd dev --scoped --scope-interactive
 ```
 
 ## JSON Output

--- a/lpd
+++ b/lpd
@@ -46,12 +46,12 @@ Usage:
     - flags: `--strict` makes warnings fail.
     - info: Check local environment and repo readiness.
 
-  lpd dev [--test] [--test-mode fast|staged|full] [--script <path>] [-- ...mint args]
-    - flags: run advisory tests first, override launcher script, pass-through Mintlify args.
+  lpd dev [--test] [--test-mode fast|staged|full] [--script <path>] [--scoped] [--scope-...] [-- ...mint args]
+    - flags: run advisory tests first, optional scoped docs profile for large docs.json, override launcher script, pass-through Mintlify args.
     - info: Run local docs dev launcher.
 
-  lpd mint dev [-- ...mint args]
-    - flags: pass-through Mintlify args.
+  lpd mint dev [--scoped] [--scope-...] [-- ...mint args]
+    - flags: same as `lpd dev`, plus pass-through Mintlify args.
     - info: Compatibility alias to `lpd dev`.
 
   lpd test [--staged|--full] [--browser] [--domain v1|v2|both] [--wcag] [--wcag-no-fix] [--link-audit-external] [--base-url URL]
@@ -84,6 +84,9 @@ Examples:
 
   lpd dev --test --test-mode staged -- --port 3333
     - Runs staged checks, then launches docs server on port 3333.
+
+  lpd dev --scoped --scope-version v2 --scope-language en --scope-tab Developers
+    - Launches Mint with a reduced dev-only docs profile for faster startup and route transitions.
 
   lpd test --browser
     - Runs tests plus browser integration checks.
@@ -137,7 +140,7 @@ Command Groups:
   core
     lpd setup [--yes] [--no-tools] [--no-tests] [--no-hooks] [--with-mintlify] [--no-cli]
     lpd doctor [--strict] [--json]
-    lpd dev [--test] [--test-mode fast|staged|full] [-- ...mint args]
+    lpd dev [--test] [--test-mode fast|staged|full] [--scoped] [--scope-...] [-- ...mint args]
     lpd test [--staged|--full] [--browser] [--domain v1|v2|both] [--wcag] [--wcag-no-fix] [--link-audit-external] [--base-url URL]
     lpd ai-sitemap [--write|--check] [--json]
     lpd ci [--skip-browser] [--base-url URL]
@@ -918,6 +921,15 @@ cmd_dev() {
     local test_mode="fast"
     local script_path="$REPO_ROOT/tools/scripts/mint-dev.sh"
     local dry_run=0
+    local scoped_mode=0
+    local scope_interactive=0
+    local scope_file=""
+    local scope_versions=""
+    local scope_languages=""
+    local scope_tabs=""
+    local scope_prefixes=""
+    local skip_external_fetch=0
+    local disable_openapi=0
     local -a mint_args
     mint_args=()
 
@@ -948,12 +960,126 @@ cmd_dev() {
             --dry-run)
                 dry_run=1
                 ;;
+            --scoped)
+                scoped_mode=1
+                ;;
+            --scope-interactive)
+                scoped_mode=1
+                scope_interactive=1
+                ;;
+            --scope-file)
+                if [ "$#" -lt 2 ]; then
+                    finish 1 "dev" "--scope-file requires a path."
+                    return 1
+                fi
+                scoped_mode=1
+                scope_file="$2"
+                shift
+                ;;
+            --scope-file=*)
+                scoped_mode=1
+                scope_file="${1#--scope-file=}"
+                ;;
+            --scope-version)
+                if [ "$#" -lt 2 ]; then
+                    finish 1 "dev" "--scope-version requires a value."
+                    return 1
+                fi
+                scoped_mode=1
+                if [ -n "$scope_versions" ]; then
+                    scope_versions="$scope_versions,$2"
+                else
+                    scope_versions="$2"
+                fi
+                shift
+                ;;
+            --scope-version=*)
+                scoped_mode=1
+                if [ -n "$scope_versions" ]; then
+                    scope_versions="$scope_versions,${1#--scope-version=}"
+                else
+                    scope_versions="${1#--scope-version=}"
+                fi
+                ;;
+            --scope-language)
+                if [ "$#" -lt 2 ]; then
+                    finish 1 "dev" "--scope-language requires a value."
+                    return 1
+                fi
+                scoped_mode=1
+                if [ -n "$scope_languages" ]; then
+                    scope_languages="$scope_languages,$2"
+                else
+                    scope_languages="$2"
+                fi
+                shift
+                ;;
+            --scope-language=*)
+                scoped_mode=1
+                if [ -n "$scope_languages" ]; then
+                    scope_languages="$scope_languages,${1#--scope-language=}"
+                else
+                    scope_languages="${1#--scope-language=}"
+                fi
+                ;;
+            --scope-tab)
+                if [ "$#" -lt 2 ]; then
+                    finish 1 "dev" "--scope-tab requires a value."
+                    return 1
+                fi
+                scoped_mode=1
+                if [ -n "$scope_tabs" ]; then
+                    scope_tabs="$scope_tabs,$2"
+                else
+                    scope_tabs="$2"
+                fi
+                shift
+                ;;
+            --scope-tab=*)
+                scoped_mode=1
+                if [ -n "$scope_tabs" ]; then
+                    scope_tabs="$scope_tabs,${1#--scope-tab=}"
+                else
+                    scope_tabs="${1#--scope-tab=}"
+                fi
+                ;;
+            --scope-prefix)
+                if [ "$#" -lt 2 ]; then
+                    finish 1 "dev" "--scope-prefix requires a value."
+                    return 1
+                fi
+                scoped_mode=1
+                if [ -n "$scope_prefixes" ]; then
+                    scope_prefixes="$scope_prefixes,$2"
+                else
+                    scope_prefixes="$2"
+                fi
+                shift
+                ;;
+            --scope-prefix=*)
+                scoped_mode=1
+                if [ -n "$scope_prefixes" ]; then
+                    scope_prefixes="$scope_prefixes,${1#--scope-prefix=}"
+                else
+                    scope_prefixes="${1#--scope-prefix=}"
+                fi
+                ;;
+            --skip-external-fetch)
+                skip_external_fetch=1
+                ;;
+            --disable-openapi)
+                disable_openapi=1
+                ;;
+            --scope-*)
+                finish 1 "dev" "Unknown scoped option: $1"
+                return 1
+                ;;
             --json)
                 GLOBAL_JSON=1
                 ;;
             --help|-h)
                 cat <<'EOF'
-Usage: lpd dev [--test] [--test-mode fast|staged|full] [--script <path>] [--dry-run] [-- ...mint args]
+Usage: lpd dev [--test] [--test-mode fast|staged|full] [--script <path>] [--dry-run] [--scoped] [--scope-interactive] [--scope-file <path>] [--scope-version <csv>] [--scope-language <csv>] [--scope-tab <csv>] [--scope-prefix <csv>] [--skip-external-fetch] [--disable-openapi] [-- ...mint args]
 EOF
                 return 0
                 ;;
@@ -985,6 +1111,33 @@ EOF
     fi
 
     if [ "$dry_run" = "1" ]; then
+        if [ "$scoped_mode" = "1" ]; then
+            echo "Scoped mint profile: enabled"
+            if [ "$scope_interactive" = "1" ]; then
+                echo "  scope_interactive: true"
+            fi
+            if [ -n "$scope_file" ]; then
+                echo "  scope_file: $scope_file"
+            fi
+            if [ -n "$scope_versions" ]; then
+                echo "  scope_versions: $scope_versions"
+            fi
+            if [ -n "$scope_languages" ]; then
+                echo "  scope_languages: $scope_languages"
+            fi
+            if [ -n "$scope_tabs" ]; then
+                echo "  scope_tabs: $scope_tabs"
+            fi
+            if [ -n "$scope_prefixes" ]; then
+                echo "  scope_prefixes: $scope_prefixes"
+            fi
+        fi
+        if [ "$skip_external_fetch" = "1" ]; then
+            echo "External fetch: disabled"
+        fi
+        if [ "$disable_openapi" = "1" ]; then
+            echo "OpenAPI docs scope: disabled"
+        fi
         printf 'Dry run:'
         printf ' %q' "$script_path"
         if [ "${#mint_args[@]}" -gt 0 ]; then
@@ -992,6 +1145,45 @@ EOF
         fi
         printf '\n'
         return 0
+    fi
+
+    local -a env_vars
+    env_vars=()
+    if [ "$scoped_mode" = "1" ]; then
+        env_vars+=("LPD_SCOPED_MINT_DEV=1")
+    fi
+    if [ "$scope_interactive" = "1" ]; then
+        env_vars+=("LPD_MINT_SCOPE_INTERACTIVE=1")
+    fi
+    if [ -n "$scope_file" ]; then
+        env_vars+=("LPD_MINT_SCOPE_FILE=$scope_file")
+    fi
+    if [ -n "$scope_versions" ]; then
+        env_vars+=("LPD_MINT_SCOPE_VERSIONS=$scope_versions")
+    fi
+    if [ -n "$scope_languages" ]; then
+        env_vars+=("LPD_MINT_SCOPE_LANGUAGES=$scope_languages")
+    fi
+    if [ -n "$scope_tabs" ]; then
+        env_vars+=("LPD_MINT_SCOPE_TABS=$scope_tabs")
+    fi
+    if [ -n "$scope_prefixes" ]; then
+        env_vars+=("LPD_MINT_SCOPE_PREFIXES=$scope_prefixes")
+    fi
+    if [ "$skip_external_fetch" = "1" ]; then
+        env_vars+=("MINT_SKIP_EXTERNAL_FETCH=1")
+    fi
+    if [ "$disable_openapi" = "1" ]; then
+        env_vars+=("LPD_MINT_DISABLE_OPENAPI=1")
+    fi
+
+    if [ "${#env_vars[@]}" -gt 0 ]; then
+        if [ "${#mint_args[@]}" -gt 0 ]; then
+            env "${env_vars[@]}" "$script_path" "${mint_args[@]}"
+        else
+            env "${env_vars[@]}" "$script_path"
+        fi
+        return
     fi
 
     if [ "${#mint_args[@]}" -gt 0 ]; then

--- a/tests/run-all.js
+++ b/tests/run-all.js
@@ -37,6 +37,7 @@ const spellingTests = require('./unit/spelling.test');
 const qualityTests = require('./unit/quality.test');
 const linksImportsTests = require('./unit/links-imports.test');
 const docsNavigationTests = require('./unit/docs-navigation.test');
+const lpdScopedMintDevTests = require('./unit/lpd-scoped-mint-dev.test');
 const scriptDocsTests = require('./unit/script-docs.test');
 const pagesIndexGenerator = require('../tools/scripts/generate-pages-index');
 const browserTests = require('./integration/browser.test');
@@ -83,6 +84,18 @@ function hasMdxGuardsRelevance(stagedFiles) {
 function hasDocsNavigationRelevance(stagedFiles) {
   if (!stagedOnly) return true;
   return hasAnyPrefix(stagedFiles, ['docs.json', 'tests/unit/docs-navigation.test.js']);
+}
+
+function hasLpdScopedMintDevRelevance(stagedFiles) {
+  if (!stagedOnly) return true;
+  return hasAnyExact(stagedFiles, [
+    'lpd',
+    'docs.json',
+    '.mintignore',
+    'tools/scripts/mint-dev.sh',
+    'tools/scripts/dev/generate-mint-dev-scope.js',
+    'tests/unit/lpd-scoped-mint-dev.test.js'
+  ]);
 }
 
 function hasGeneratedBannerRelevance(stagedFiles) {
@@ -182,6 +195,16 @@ async function runAllTests() {
   } else {
     console.log('\n🧭 Running Docs Navigation Validation...');
     console.log('   skipped (no staged docs-navigation-owned paths)');
+  }
+
+  if (hasLpdScopedMintDevRelevance(stagedFiles)) {
+    console.log('\n🚀 Running LPD Scoped Mint Dev Tests...');
+    const scopedMintDevResult = await lpdScopedMintDevTests.runTests();
+    totalErrors += scopedMintDevResult.errors.length;
+    console.log(`   ${scopedMintDevResult.errors.length} errors, 0 warnings`);
+  } else {
+    console.log('\n🚀 Running LPD Scoped Mint Dev Tests...');
+    console.log('   skipped (no staged scoped-mint-owned paths)');
   }
 
   // Script Docs Enforcement

--- a/tests/script-index.md
+++ b/tests/script-index.md
@@ -22,6 +22,7 @@
 | `tests/unit/docs-navigation.test.js` | Validate docs.json page-entry syntax in check-only mode by default, with optional report writing and approved remaps. | `./lpd tests unit docs-navigation.test` | docs |
 | `tests/unit/docs-usefulness-accuracy-verifier.test.js` | Validate source-weighted 2026 accuracy verification rules (GitHub vs DeepWiki precedence, freshness, fallback, and cache reuse). | `node tests/unit/docs-usefulness-accuracy-verifier.test.js` | docs |
 | `tests/unit/links-imports.test.js` | Utility script for tests/unit/links-imports.test.js. | `node tests/unit/links-imports.test.js` | docs |
+| `tests/unit/lpd-scoped-mint-dev.test.js` | Validate scoped lpd mint-dev profile filtering, generated .mintignore exclusions, and dry-run flag wiring. | `node tests/unit/lpd-scoped-mint-dev.test.js` | docs |
 | `tests/unit/mdx-guards.test.js` | Enforce MDX guardrails for globals imports, math delimiters, and markdown table line breaks. | `node tests/unit/mdx-guards.test.js` | docs |
 | `tests/unit/mdx.test.js` | Utility script for tests/unit/mdx.test.js. | `node tests/unit/mdx.test.js` | docs |
 | `tests/unit/openapi-reference-audit.test.js` | Unit tests for OpenAPI reference audit parsing, mapping, validation findings, and conservative autofix behavior. | `node tests/unit/openapi-reference-audit.test.js` | docs |

--- a/tests/unit/lpd-scoped-mint-dev.test.js
+++ b/tests/unit/lpd-scoped-mint-dev.test.js
@@ -1,0 +1,277 @@
+#!/usr/bin/env node
+/**
+ * @script lpd-scoped-mint-dev.test
+ * @summary Validate scoped lpd mint-dev profile filtering, generated .mintignore exclusions, and dry-run flag wiring.
+ * @owner docs
+ * @scope tests/unit, lpd, tools/scripts/mint-dev.sh, tools/scripts/dev/generate-mint-dev-scope.js
+ *
+ * @usage
+ *   node tests/unit/lpd-scoped-mint-dev.test.js
+ *
+ * @inputs
+ *   No required CLI flags.
+ *
+ * @outputs
+ *   - Console summary of scoped-mint-dev test assertions.
+ *
+ * @exit-codes
+ *   0 = all test cases passed
+ *   1 = one or more test cases failed
+ *
+ * @examples
+ *   node tests/unit/lpd-scoped-mint-dev.test.js
+ *
+ * @notes
+ *   Uses fixture navigation and temporary directories; does not mutate tracked repository files.
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+const {
+  collectRoutesFromNavigation,
+  collectOptionsFromNavigation,
+  buildScopedNavigation,
+  buildScopedMetadata,
+  buildScopedMintignore
+} = require('../../tools/scripts/dev/generate-mint-dev-scope');
+
+const REPO_ROOT = process.cwd();
+const LPD_PATH = path.join(REPO_ROOT, 'lpd');
+const SCOPE_SCRIPT_PATH = path.join(REPO_ROOT, 'tools/scripts/dev/generate-mint-dev-scope.js');
+
+const SAMPLE_NAVIGATION = {
+  versions: [
+    {
+      version: 'v2',
+      languages: [
+        {
+          language: 'en',
+          tabs: [
+            {
+              tab: 'Developers',
+              anchors: [
+                {
+                  anchor: 'Build',
+                  groups: [
+                    {
+                      group: 'Dev',
+                      pages: ['v2/dev/get-started', 'v2/dev/api-reference/auth']
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              tab: 'Gateways',
+              anchors: [
+                {
+                  anchor: 'Run',
+                  groups: [
+                    {
+                      group: 'Gateway',
+                      pages: ['v2/gateways/overview']
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          language: 'es',
+          tabs: [
+            {
+              tab: 'Developers',
+              anchors: [
+                {
+                  anchor: 'Construir',
+                  groups: [
+                    {
+                      group: 'Dev',
+                      pages: ['v2/es/dev/get-started']
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      version: 'v1',
+      languages: [
+        {
+          language: 'en',
+          tabs: [
+            {
+              tab: 'Legacy',
+              anchors: [
+                {
+                  anchor: 'Legacy',
+                  groups: [
+                    {
+                      group: 'Legacy',
+                      pages: ['v1/legacy/overview']
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};
+
+function runLpd(args) {
+  return spawnSync('bash', [LPD_PATH, ...args], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8'
+  });
+}
+
+function runScopeScript(args, cwd) {
+  return spawnSync('node', [SCOPE_SCRIPT_PATH, ...args], {
+    cwd,
+    encoding: 'utf8'
+  });
+}
+
+function mkTmpDir(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function writeFile(absPath, content) {
+  fs.mkdirSync(path.dirname(absPath), { recursive: true });
+  fs.writeFileSync(absPath, content, 'utf8');
+}
+
+async function runTests() {
+  const failures = [];
+  const cases = [];
+
+  cases.push(async () => {
+    const selection = {
+      versions: ['v2'],
+      languages: ['en'],
+      tabs: ['Developers'],
+      prefixes: ['v2/dev'],
+      disableOpenapi: true
+    };
+    const scoped = buildScopedNavigation(SAMPLE_NAVIGATION, selection);
+    const routes = collectRoutesFromNavigation(scoped);
+    assert.deepStrictEqual(routes, ['v2/dev/get-started']);
+  });
+
+  cases.push(async () => {
+    const selection = {
+      versions: ['v2'],
+      languages: ['en'],
+      tabs: ['Developers'],
+      prefixes: ['v2/dev'],
+      disableOpenapi: true
+    };
+    const optionData = collectOptionsFromNavigation(SAMPLE_NAVIGATION);
+    const allRoutes = collectRoutesFromNavigation(SAMPLE_NAVIGATION);
+    const scopedRoutes = ['v2/dev/get-started'];
+    const metadata = buildScopedMetadata(selection, optionData, allRoutes, scopedRoutes);
+    const scopedMintignore = buildScopedMintignore('# base ignore\n', metadata);
+    assert.match(scopedMintignore, /\/v1\/\*\*/, 'should exclude unselected version');
+    assert.match(scopedMintignore, /\/v2\/es\/\*\*/, 'should exclude unselected language directory');
+    assert.match(scopedMintignore, /api-reference/, 'should include openapi exclusion patterns');
+  });
+
+  cases.push(async () => {
+    const run = runLpd([
+      'dev',
+      '--dry-run',
+      '--scoped',
+      '--scope-version',
+      'v2',
+      '--scope-language',
+      'en',
+      '--scope-tab',
+      'Developers',
+      '--scope-prefix',
+      'v2/dev',
+      '--disable-openapi'
+    ]);
+    assert.strictEqual(run.status, 0, `lpd dry-run failed: ${run.stderr || run.stdout}`);
+    assert.match(run.stdout, /Scoped mint profile: enabled/);
+    assert.match(run.stdout, /scope_versions:\s*v2/);
+    assert.match(run.stdout, /scope_languages:\s*en/);
+    assert.match(run.stdout, /scope_tabs:\s*Developers/);
+    assert.match(run.stdout, /OpenAPI docs scope: disabled/);
+    assert.match(run.stdout, /tools\/scripts\/mint-dev\.sh/);
+  });
+
+  cases.push(async () => {
+    const run = runLpd(['dev', '--dry-run', '--', '--port', '3333']);
+    assert.strictEqual(run.status, 0, `lpd pass-through dry-run failed: ${run.stderr || run.stdout}`);
+    assert.doesNotMatch(run.stdout, /Scoped mint profile: enabled/);
+    assert.match(run.stdout, /--port/);
+    assert.match(run.stdout, /3333/);
+  });
+
+  cases.push(async () => {
+    const tmp = mkTmpDir('lpd-scope-test-');
+    const docs = {
+      $schema: 'https://mintlify.com/docs.json',
+      theme: 'palm',
+      name: 'Fixture Docs',
+      navigation: SAMPLE_NAVIGATION
+    };
+    writeFile(path.join(tmp, 'docs.json'), `${JSON.stringify(docs, null, 2)}\n`);
+    writeFile(path.join(tmp, '.mintignore'), '# fixture\n');
+
+    const run = runScopeScript(
+      ['--repo-root', tmp, '--versions', 'v2', '--languages', 'en', '--tabs', 'Developers', '--disable-openapi', '--print-only'],
+      REPO_ROOT
+    );
+    assert.strictEqual(run.status, 0, `scope generator failed: ${run.stderr || run.stdout}`);
+    const payload = JSON.parse(String(run.stdout || '{}').trim());
+    assert.ok(payload.routeCounts.original > payload.routeCounts.scoped, 'scoped profile should reduce route count');
+    assert.strictEqual(payload.routeCounts.scoped, 1, 'expected Developers tab route count after OpenAPI filter');
+  });
+
+  for (let index = 0; index < cases.length; index += 1) {
+    const label = `case-${index + 1}`;
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      await cases[index]();
+      console.log(`   ✓ ${label}`);
+    } catch (error) {
+      failures.push(`${label}: ${error.message}`);
+    }
+  }
+
+  return {
+    passed: failures.length === 0,
+    total: cases.length,
+    errors: failures
+  };
+}
+
+if (require.main === module) {
+  runTests()
+    .then((result) => {
+      if (result.passed) {
+        console.log(`\n✅ lpd scoped mint-dev tests passed (${result.total} cases)`);
+        process.exit(0);
+      }
+      console.error(`\n❌ ${result.errors.length} lpd scoped mint-dev test failure(s)`);
+      result.errors.forEach((entry) => console.error(`  - ${entry}`));
+      process.exit(1);
+    })
+    .catch((error) => {
+      console.error(`\n❌ lpd scoped mint-dev tests crashed: ${error.message}`);
+      process.exit(1);
+    });
+}
+
+module.exports = { runTests };

--- a/tools/script-index.md
+++ b/tools/script-index.md
@@ -150,6 +150,7 @@
 | `tools/scripts/dev/add-callouts.js` | Utility script for tools/scripts/dev/add-callouts.js. | `node tools/scripts/dev/add-callouts.js` | docs |
 | `tools/scripts/dev/batch-update-og-image.sh` | Utility script for tools/scripts/dev/batch-update-og-image.sh. | `bash tools/scripts/dev/batch-update-og-image.sh` | docs |
 | `tools/scripts/dev/ensure-mint-watcher-patch.sh` | Ensure Mint local-preview watcher disables glob expansion in repo paths. | `bash tools/scripts/dev/ensure-mint-watcher-patch.sh --check` | docs |
+| `tools/scripts/dev/generate-mint-dev-scope.js` | Build deterministic Mint dev scoped profiles (docs.json + .mintignore) for large navigation trees. | `node tools/scripts/dev/generate-mint-dev-scope.js --versions v2 --languages en --tabs Developers` | docs |
 | `tools/scripts/dev/replace-og-image.py` | Utility script for tools/scripts/dev/replace-og-image.py. | `python3 tools/scripts/dev/replace-og-image.py` | docs |
 | `tools/scripts/dev/seo-generator-safe.js` | Utility script for tools/scripts/dev/seo-generator-safe.js. | `node tools/scripts/dev/seo-generator-safe.js` | docs |
 | `tools/scripts/dev/test-add-callouts.js` | Utility script for tools/scripts/dev/test-add-callouts.js. | `node tools/scripts/dev/test-add-callouts.js` | docs |

--- a/tools/scripts/dev/generate-mint-dev-scope.js
+++ b/tools/scripts/dev/generate-mint-dev-scope.js
@@ -1,0 +1,764 @@
+#!/usr/bin/env node
+/**
+ * @script generate-mint-dev-scope
+ * @summary Build deterministic Mint dev scoped profiles (docs.json + .mintignore) for large navigation trees.
+ * @owner docs
+ * @scope tools/scripts/dev, docs.json, .mintignore
+ *
+ * @usage
+ *   node tools/scripts/dev/generate-mint-dev-scope.js --versions v2 --languages en --tabs Developers
+ *   node tools/scripts/dev/generate-mint-dev-scope.js --interactive --workspace-base /tmp/lpd-mint-dev
+ *
+ * @inputs
+ *   --repo-root <path> Optional repo root (default: process.cwd()).
+ *   --workspace-base <path> Optional workspace base directory (default: /tmp/lpd-mint-dev).
+ *   --scope-file <path> JSON file with versions/languages/tabs/prefixes arrays.
+ *   --versions <csv> Version filter(s), repeatable.
+ *   --languages <csv> Language filter(s), repeatable.
+ *   --tabs <csv> Tab filter(s), repeatable.
+ *   --prefixes <csv> Route prefix filter(s), repeatable.
+ *   --interactive Prompt for selections (TTY required).
+ *   --disable-openapi Exclude api-reference routes from scoped docs.json and .mintignore.
+ *   --print-only Print scoped metadata only; do not create /tmp workspace.
+ *
+ * @outputs
+ *   - JSON payload to stdout with workspace path + scope statistics.
+ *   - Scoped docs.json and .mintignore in /tmp/lpd-mint-dev/<hash>/ (unless --print-only).
+ *
+ * @exit-codes
+ *   0 = success
+ *   1 = invalid input, empty scope result, or runtime failure
+ *
+ * @examples
+ *   node tools/scripts/dev/generate-mint-dev-scope.js --versions v2 --languages en --tabs Developers --prefixes v2/gateways
+ *   node tools/scripts/dev/generate-mint-dev-scope.js --scope-file tools/config/mint-dev-scope.json --disable-openapi
+ *
+ * @notes
+ *   The generated workspace is a symlink scaffold over repo root with scoped docs.json/.mintignore overrides.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const crypto = require('crypto');
+const readline = require('readline');
+
+const STRUCTURAL_ARRAY_KEYS = ['versions', 'languages', 'tabs', 'anchors', 'groups', 'pages'];
+
+function printUsage() {
+  console.log(
+    [
+      'Usage: node tools/scripts/dev/generate-mint-dev-scope.js [options]',
+      '',
+      'Options:',
+      '  --repo-root <path>',
+      '  --workspace-base <path>',
+      '  --scope-file <path>',
+      '  --versions <csv>          (repeatable)',
+      '  --languages <csv>         (repeatable)',
+      '  --tabs <csv>              (repeatable)',
+      '  --prefixes <csv>          (repeatable)',
+      '  --interactive',
+      '  --disable-openapi',
+      '  --print-only',
+      '  --help'
+    ].join('\n')
+  );
+}
+
+function splitCsv(value) {
+  return String(value || '')
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function uniqStrings(values) {
+  return [...new Set((values || []).map((entry) => String(entry || '').trim()).filter(Boolean))];
+}
+
+function normalizeRoute(value) {
+  return String(value || '')
+    .trim()
+    .replace(/^\/+/, '')
+    .replace(/\/+$/, '');
+}
+
+function normalizeForCompare(value) {
+  return String(value || '').trim().toLowerCase();
+}
+
+function routeMatchesPrefix(route, prefix) {
+  const normalizedRoute = normalizeRoute(route);
+  const normalizedPrefix = normalizeRoute(prefix);
+  if (!normalizedRoute || !normalizedPrefix) return false;
+  return normalizedRoute === normalizedPrefix || normalizedRoute.startsWith(`${normalizedPrefix}/`);
+}
+
+function isLanguageSegment(value) {
+  const segment = String(value || '').trim();
+  return /^[a-z]{2}(?:-[A-Za-z]{2})?$/.test(segment);
+}
+
+function isLikelyRouteEntry(value) {
+  const route = normalizeRoute(value);
+  if (!route) return false;
+  if (route.startsWith('http://') || route.startsWith('https://')) return false;
+  if (route === '-') return false;
+  return route.includes('/');
+}
+
+function isOpenapiRoute(route) {
+  const normalized = normalizeRoute(route);
+  return normalized.includes('/api-reference/') || normalized.endsWith('/api-reference');
+}
+
+function shouldKeepRouteEntry(routeValue, context) {
+  const route = normalizeRoute(routeValue);
+  if (!route) return false;
+  if (!isLikelyRouteEntry(route)) return false;
+  if (context.disableOpenapi && isOpenapiRoute(route)) return false;
+  if (context.prefixes.length === 0) return true;
+  return context.prefixes.some((prefix) => routeMatchesPrefix(route, prefix));
+}
+
+function deriveSectionPrefix(routeValue) {
+  const route = normalizeRoute(routeValue);
+  if (!route) return '';
+  const segments = route.split('/').filter(Boolean);
+  if (segments.length < 2) return route;
+  if (/^v\d+$/.test(segments[0])) {
+    if (segments.length >= 3 && isLanguageSegment(segments[1])) {
+      return segments.slice(0, 3).join('/');
+    }
+    return segments.slice(0, 2).join('/');
+  }
+  return segments.slice(0, 2).join('/');
+}
+
+function collectRoutesFromPages(pages, outSet) {
+  if (!Array.isArray(pages)) return;
+  for (const entry of pages) {
+    if (typeof entry === 'string') {
+      const route = normalizeRoute(entry);
+      if (isLikelyRouteEntry(route)) outSet.add(route);
+      continue;
+    }
+    if (entry && typeof entry === 'object') {
+      visitNavigationNode(entry, outSet);
+    }
+  }
+}
+
+function visitNavigationNode(node, outSet) {
+  if (!node || typeof node !== 'object') return;
+  if (Array.isArray(node.pages)) collectRoutesFromPages(node.pages, outSet);
+  if (Array.isArray(node.groups)) node.groups.forEach((group) => visitNavigationNode(group, outSet));
+  if (Array.isArray(node.anchors)) node.anchors.forEach((anchor) => visitNavigationNode(anchor, outSet));
+  if (Array.isArray(node.tabs)) node.tabs.forEach((tab) => visitNavigationNode(tab, outSet));
+  if (Array.isArray(node.languages)) node.languages.forEach((language) => visitNavigationNode(language, outSet));
+  if (Array.isArray(node.versions)) node.versions.forEach((version) => visitNavigationNode(version, outSet));
+}
+
+function collectRoutesFromNavigation(navigation) {
+  const routes = new Set();
+  visitNavigationNode(navigation, routes);
+  return [...routes].sort();
+}
+
+function parseArgs(argv) {
+  const out = {
+    repoRoot: process.cwd(),
+    workspaceBase: path.join(os.tmpdir(), 'lpd-mint-dev'),
+    scopeFile: '',
+    versions: [],
+    languages: [],
+    tabs: [],
+    prefixes: [],
+    interactive: false,
+    disableOpenapi: false,
+    printOnly: false,
+    help: false
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (token === '--help' || token === '-h') {
+      out.help = true;
+      continue;
+    }
+    if (token === '--repo-root') {
+      out.repoRoot = String(argv[i + 1] || '').trim();
+      i += 1;
+      continue;
+    }
+    if (token.startsWith('--repo-root=')) {
+      out.repoRoot = token.slice('--repo-root='.length).trim();
+      continue;
+    }
+    if (token === '--workspace-base') {
+      out.workspaceBase = String(argv[i + 1] || '').trim();
+      i += 1;
+      continue;
+    }
+    if (token.startsWith('--workspace-base=')) {
+      out.workspaceBase = token.slice('--workspace-base='.length).trim();
+      continue;
+    }
+    if (token === '--scope-file') {
+      out.scopeFile = String(argv[i + 1] || '').trim();
+      i += 1;
+      continue;
+    }
+    if (token.startsWith('--scope-file=')) {
+      out.scopeFile = token.slice('--scope-file='.length).trim();
+      continue;
+    }
+    if (token === '--versions' || token === '--scope-version') {
+      out.versions.push(...splitCsv(argv[i + 1] || ''));
+      i += 1;
+      continue;
+    }
+    if (token.startsWith('--versions=') || token.startsWith('--scope-version=')) {
+      out.versions.push(...splitCsv(token.split('=').slice(1).join('=')));
+      continue;
+    }
+    if (token === '--languages' || token === '--scope-language') {
+      out.languages.push(...splitCsv(argv[i + 1] || ''));
+      i += 1;
+      continue;
+    }
+    if (token.startsWith('--languages=') || token.startsWith('--scope-language=')) {
+      out.languages.push(...splitCsv(token.split('=').slice(1).join('=')));
+      continue;
+    }
+    if (token === '--tabs' || token === '--scope-tab') {
+      out.tabs.push(...splitCsv(argv[i + 1] || ''));
+      i += 1;
+      continue;
+    }
+    if (token.startsWith('--tabs=') || token.startsWith('--scope-tab=')) {
+      out.tabs.push(...splitCsv(token.split('=').slice(1).join('=')));
+      continue;
+    }
+    if (token === '--prefixes' || token === '--scope-prefix') {
+      out.prefixes.push(...splitCsv(argv[i + 1] || ''));
+      i += 1;
+      continue;
+    }
+    if (token.startsWith('--prefixes=') || token.startsWith('--scope-prefix=')) {
+      out.prefixes.push(...splitCsv(token.split('=').slice(1).join('=')));
+      continue;
+    }
+    if (token === '--interactive') {
+      out.interactive = true;
+      continue;
+    }
+    if (token === '--disable-openapi') {
+      out.disableOpenapi = true;
+      continue;
+    }
+    if (token === '--print-only') {
+      out.printOnly = true;
+      continue;
+    }
+    throw new Error(`Unknown option: ${token}`);
+  }
+
+  out.repoRoot = out.repoRoot ? path.resolve(out.repoRoot) : process.cwd();
+  out.workspaceBase = out.workspaceBase ? path.resolve(out.workspaceBase) : path.join(os.tmpdir(), 'lpd-mint-dev');
+  out.versions = uniqStrings(out.versions);
+  out.languages = uniqStrings(out.languages);
+  out.tabs = uniqStrings(out.tabs);
+  out.prefixes = uniqStrings(out.prefixes.map(normalizeRoute));
+  return out;
+}
+
+function loadScopeFile(scopeFile, repoRoot) {
+  if (!scopeFile) {
+    return {
+      versions: [],
+      languages: [],
+      tabs: [],
+      prefixes: [],
+      disableOpenapi: false
+    };
+  }
+
+  const absolutePath = path.isAbsolute(scopeFile) ? scopeFile : path.join(repoRoot, scopeFile);
+  const payload = JSON.parse(fs.readFileSync(absolutePath, 'utf8'));
+  return {
+    versions: uniqStrings(payload.versions || payload.scope_versions || []),
+    languages: uniqStrings(payload.languages || payload.scope_languages || []),
+    tabs: uniqStrings(payload.tabs || payload.scope_tabs || []),
+    prefixes: uniqStrings((payload.prefixes || payload.scope_prefixes || []).map(normalizeRoute)),
+    disableOpenapi: Boolean(payload.disableOpenapi || payload.disable_openapi)
+  };
+}
+
+function collectOptionsFromNavigation(navigation) {
+  const versions = new Set();
+  const tabsByVersionLanguage = new Map();
+  const languagesByVersion = new Map();
+
+  const versionEntries = Array.isArray(navigation && navigation.versions) ? navigation.versions : [];
+  for (const versionEntry of versionEntries) {
+    const versionName = String(versionEntry && versionEntry.version ? versionEntry.version : '').trim();
+    if (!versionName) continue;
+    versions.add(versionName);
+    const versionKey = normalizeForCompare(versionName);
+    if (!languagesByVersion.has(versionKey)) languagesByVersion.set(versionKey, new Set());
+
+    const languageEntries = Array.isArray(versionEntry.languages) ? versionEntry.languages : [];
+    for (const languageEntry of languageEntries) {
+      const languageName = String(languageEntry && languageEntry.language ? languageEntry.language : '').trim();
+      if (!languageName) continue;
+      languagesByVersion.get(versionKey).add(languageName);
+
+      const tabs = Array.isArray(languageEntry.tabs) ? languageEntry.tabs : [];
+      const tabMapKey = `${versionKey}::${normalizeForCompare(languageName)}`;
+      if (!tabsByVersionLanguage.has(tabMapKey)) tabsByVersionLanguage.set(tabMapKey, new Set());
+
+      for (const tabEntry of tabs) {
+        const tabName = String(tabEntry && tabEntry.tab ? tabEntry.tab : '').trim();
+        if (!tabName) continue;
+        tabsByVersionLanguage.get(tabMapKey).add(tabName);
+      }
+    }
+  }
+
+  return {
+    versions: [...versions].sort(),
+    tabsByVersionLanguage,
+    languagesByVersion
+  };
+}
+
+function resolveSelectionInput(rawInput, options) {
+  const input = String(rawInput || '').trim();
+  if (!input) return [];
+
+  const byIndex = new Map();
+  const byValue = new Map();
+  options.forEach((option, index) => {
+    byIndex.set(String(index + 1), option);
+    byValue.set(normalizeForCompare(option), option);
+  });
+
+  const tokens = splitCsv(input);
+  const out = [];
+  for (const token of tokens) {
+    if (byIndex.has(token)) {
+      out.push(byIndex.get(token));
+      continue;
+    }
+    const normalized = normalizeForCompare(token);
+    if (byValue.has(normalized)) {
+      out.push(byValue.get(normalized));
+      continue;
+    }
+    throw new Error(`Invalid selection token: ${token}`);
+  }
+  return uniqStrings(out);
+}
+
+function matchesSelection(value, selectedSet) {
+  if (!selectedSet || selectedSet.size === 0) return true;
+  return selectedSet.has(normalizeForCompare(value));
+}
+
+function pruneNavigationNode(node, context) {
+  if (!node || typeof node !== 'object') return null;
+  if (Array.isArray(node)) {
+    const items = node.map((entry) => pruneNavigationNode(entry, context)).filter(Boolean);
+    return items.length > 0 ? items : null;
+  }
+
+  const out = { ...node };
+
+  if (Array.isArray(node.versions)) {
+    out.versions = node.versions
+      .filter((entry) => matchesSelection(entry && entry.version, context.versionSet))
+      .map((entry) => pruneNavigationNode(entry, context))
+      .filter(Boolean);
+  }
+
+  if (Array.isArray(node.languages)) {
+    out.languages = node.languages
+      .filter((entry) => matchesSelection(entry && entry.language, context.languageSet))
+      .map((entry) => pruneNavigationNode(entry, context))
+      .filter(Boolean);
+  }
+
+  if (Array.isArray(node.tabs)) {
+    out.tabs = node.tabs
+      .filter((entry) => matchesSelection(entry && entry.tab, context.tabSet))
+      .map((entry) => pruneNavigationNode(entry, context))
+      .filter(Boolean);
+  }
+
+  if (Array.isArray(node.anchors)) {
+    out.anchors = node.anchors
+      .map((entry) => pruneNavigationNode(entry, context))
+      .filter(Boolean);
+  }
+
+  if (Array.isArray(node.groups)) {
+    out.groups = node.groups
+      .map((entry) => pruneNavigationNode(entry, context))
+      .filter(Boolean);
+  }
+
+  if (Array.isArray(node.pages)) {
+    const scopedPages = [];
+    for (const entry of node.pages) {
+      if (typeof entry === 'string') {
+        if (shouldKeepRouteEntry(entry, context)) {
+          scopedPages.push(normalizeRoute(entry));
+        }
+        continue;
+      }
+      if (!entry || typeof entry !== 'object') continue;
+      const pruned = pruneNavigationNode(entry, context);
+      if (pruned) scopedPages.push(pruned);
+    }
+    out.pages = scopedPages;
+  }
+
+  const hasStructuralArrays = STRUCTURAL_ARRAY_KEYS.some((key) => Array.isArray(node[key]));
+  if (!hasStructuralArrays) return out;
+
+  const hasAnyContent = STRUCTURAL_ARRAY_KEYS.some((key) => {
+    return !Array.isArray(out[key]) || out[key].length > 0;
+  });
+
+  if (!hasAnyContent) return null;
+  return out;
+}
+
+function buildScopedNavigation(navigation, selection) {
+  const context = {
+    versionSet: new Set(selection.versions.map(normalizeForCompare)),
+    languageSet: new Set(selection.languages.map(normalizeForCompare)),
+    tabSet: new Set(selection.tabs.map(normalizeForCompare)),
+    prefixes: selection.prefixes.map(normalizeRoute).filter(Boolean),
+    disableOpenapi: Boolean(selection.disableOpenapi)
+  };
+  return pruneNavigationNode(navigation, context);
+}
+
+function buildScopedMintignore(baseContent, scopedMetadata) {
+  const lines = String(baseContent || '').split('\n');
+  const appendSet = new Set();
+  const append = (line) => {
+    const value = String(line || '').trim();
+    if (!value || appendSet.has(value)) return;
+    appendSet.add(value);
+  };
+
+  if (scopedMetadata.excludedVersions.length > 0 || scopedMetadata.excludedLanguagePaths.length > 0) {
+    append('# LPD scoped profile (generated): excluded versions/languages');
+  }
+  scopedMetadata.excludedVersions.forEach((version) => append(`/${version}/**`));
+  scopedMetadata.excludedLanguagePaths.forEach((entry) => append(entry));
+
+  if (scopedMetadata.excludedSectionPrefixes.length > 0) {
+    append('# LPD scoped profile (generated): excluded section prefixes');
+    scopedMetadata.excludedSectionPrefixes.forEach((prefix) => append(`/${prefix}/**`));
+  }
+
+  if (scopedMetadata.disableOpenapi) {
+    append('# LPD scoped profile (generated): OpenAPI routes excluded');
+    append('/v2/**/api-reference/**');
+    append('/v2/**/api-reference.mdx');
+  }
+
+  if (appendSet.size === 0) {
+    return lines.join('\n').replace(/\n*$/, '\n');
+  }
+
+  const merged = [...lines];
+  if (merged.length === 0 || merged[merged.length - 1].trim() !== '') merged.push('');
+  merged.push(...appendSet);
+  return merged.join('\n').replace(/\n*$/, '\n');
+}
+
+function buildScopedMetadata(selection, optionData, allRoutes, scopedRoutes) {
+  const availableVersions = optionData.versions;
+  const selectedVersionSet = new Set(selection.versions.map(normalizeForCompare));
+  const selectedLanguageSet = new Set(selection.languages.map(normalizeForCompare));
+
+  const excludedVersions = availableVersions
+    .filter((version) => selectedVersionSet.size > 0 && !selectedVersionSet.has(normalizeForCompare(version)))
+    .map((version) => normalizeRoute(version));
+
+  const excludedLanguagePaths = [];
+  for (const version of availableVersions) {
+    if (selectedVersionSet.size > 0 && !selectedVersionSet.has(normalizeForCompare(version))) continue;
+    const langSet = optionData.languagesByVersion.get(normalizeForCompare(version));
+    if (!langSet || langSet.size === 0) continue;
+    for (const language of langSet) {
+      const langNorm = normalizeForCompare(language);
+      if (selectedLanguageSet.size === 0 || selectedLanguageSet.has(langNorm)) continue;
+      if (langNorm === 'en') continue;
+      excludedLanguagePaths.push(`/${normalizeRoute(version)}/${normalizeRoute(language)}/**`);
+    }
+  }
+
+  const allSections = new Set(allRoutes.map(deriveSectionPrefix).filter(Boolean));
+  const selectedSections = new Set(
+    (selection.prefixes.length > 0 ? selection.prefixes : scopedRoutes).map(deriveSectionPrefix).filter(Boolean)
+  );
+  const excludedSectionPrefixes = [...allSections]
+    .filter((section) => selectedSections.size > 0 && !selectedSections.has(section))
+    .sort();
+
+  return {
+    excludedVersions: uniqStrings(excludedVersions),
+    excludedLanguagePaths: uniqStrings(excludedLanguagePaths),
+    excludedSectionPrefixes,
+    disableOpenapi: Boolean(selection.disableOpenapi)
+  };
+}
+
+function ensureWorkspaceScaffold(repoRoot, workspaceDir) {
+  fs.mkdirSync(workspaceDir, { recursive: true });
+  const overrideNames = new Set(['docs.json', '.mintignore', '.lpd-scope.json']);
+  const repoEntries = fs.readdirSync(repoRoot, { withFileTypes: true });
+  const repoNames = new Set(repoEntries.map((entry) => entry.name));
+
+  for (const entry of repoEntries) {
+    const name = entry.name;
+    if (name === 'docs.json' || name === '.mintignore') continue;
+    const source = path.join(repoRoot, name);
+    const target = path.join(workspaceDir, name);
+    fs.rmSync(target, { recursive: true, force: true });
+    const symlinkType = entry.isDirectory() ? 'dir' : 'file';
+    fs.symlinkSync(source, target, symlinkType);
+  }
+
+  for (const name of fs.readdirSync(workspaceDir)) {
+    if (overrideNames.has(name)) continue;
+    if (!repoNames.has(name)) {
+      fs.rmSync(path.join(workspaceDir, name), { recursive: true, force: true });
+    }
+  }
+}
+
+function createWorkspaceHash(repoRoot, selection, docsStat, mintignoreStat) {
+  const payload = {
+    repoRoot: fs.realpathSync(repoRoot),
+    selection,
+    docsMtimeMs: docsStat.mtimeMs,
+    mintignoreMtimeMs: mintignoreStat ? mintignoreStat.mtimeMs : 0
+  };
+  return crypto.createHash('sha1').update(JSON.stringify(payload)).digest('hex').slice(0, 16);
+}
+
+async function promptSelectMany(rl, label, options, defaultSelection, allowAllByEmpty) {
+  const defaults = uniqStrings(defaultSelection);
+  const defaultLabel = defaults.length > 0 ? defaults.join(', ') : allowAllByEmpty ? 'all' : 'none';
+  const promptLine = `Select ${label} (comma values or indices; Enter=${defaultLabel}): `;
+
+  for (;;) {
+    console.error(`\n${label}:`);
+    options.forEach((option, index) => {
+      console.error(`  ${index + 1}. ${option}`);
+    });
+    const answer = await new Promise((resolve) => rl.question(promptLine, resolve));
+    const trimmed = String(answer || '').trim();
+    if (!trimmed) {
+      return allowAllByEmpty && defaults.length === 0 ? [] : defaults;
+    }
+    if (trimmed === '*') {
+      return [];
+    }
+    try {
+      return resolveSelectionInput(trimmed, options);
+    } catch (error) {
+      console.error(`Invalid selection: ${error.message}`);
+    }
+  }
+}
+
+function availableTabs(optionData, selectedVersions, selectedLanguages) {
+  const versionSet = new Set(selectedVersions.map(normalizeForCompare));
+  const languageSet = new Set(selectedLanguages.map(normalizeForCompare));
+  const out = new Set();
+
+  for (const [key, tabSet] of optionData.tabsByVersionLanguage.entries()) {
+    const [versionKey, languageKey] = key.split('::');
+    if (versionSet.size > 0 && !versionSet.has(versionKey)) continue;
+    if (languageSet.size > 0 && !languageSet.has(languageKey)) continue;
+    tabSet.forEach((tab) => out.add(tab));
+  }
+  return [...out].sort();
+}
+
+async function promptForSelection(initialSelection, optionData, allRoutes) {
+  if (!process.stdin.isTTY) {
+    throw new Error('--interactive requires a TTY terminal');
+  }
+
+  const rl = readline.createInterface({ input: process.stdin, output: process.stderr });
+  try {
+    const versions = await promptSelectMany(rl, 'versions', optionData.versions, initialSelection.versions, true);
+
+    const languageOptions = (() => {
+      if (versions.length === 0) {
+        const all = new Set();
+        for (const languageSet of optionData.languagesByVersion.values()) {
+          languageSet.forEach((language) => all.add(language));
+        }
+        return [...all].sort();
+      }
+      const selected = new Set();
+      versions.forEach((version) => {
+        const languageSet = optionData.languagesByVersion.get(normalizeForCompare(version));
+        if (!languageSet) return;
+        languageSet.forEach((language) => selected.add(language));
+      });
+      return [...selected].sort();
+    })();
+
+    const languages = await promptSelectMany(rl, 'languages', languageOptions, initialSelection.languages, true);
+    const tabOptions = availableTabs(optionData, versions, languages);
+    const tabs = await promptSelectMany(rl, 'tabs', tabOptions, initialSelection.tabs, true);
+
+    const prefixOptions = uniqStrings(allRoutes.map(deriveSectionPrefix).filter(Boolean));
+    const prefixes = await promptSelectMany(
+      rl,
+      'route prefixes (optional; use * or Enter for all)',
+      prefixOptions,
+      initialSelection.prefixes,
+      true
+    );
+
+    const disableOpenapiAnswer = await new Promise((resolve) =>
+      rl.question(`Disable OpenAPI routes? [y/N] (${initialSelection.disableOpenapi ? 'current: yes' : 'current: no'}): `, resolve)
+    );
+    const disableOpenapi = /^(y|yes)$/i.test(String(disableOpenapiAnswer || '').trim())
+      ? true
+      : initialSelection.disableOpenapi && !String(disableOpenapiAnswer || '').trim();
+
+    return {
+      versions,
+      languages,
+      tabs,
+      prefixes,
+      disableOpenapi
+    };
+  } finally {
+    rl.close();
+  }
+}
+
+async function createScopedProfile(args) {
+  const docsPath = path.join(args.repoRoot, 'docs.json');
+  const mintignorePath = path.join(args.repoRoot, '.mintignore');
+  if (!fs.existsSync(docsPath)) throw new Error(`docs.json not found at ${docsPath}`);
+
+  const docs = JSON.parse(fs.readFileSync(docsPath, 'utf8'));
+  if (!docs || typeof docs !== 'object' || !docs.navigation) {
+    throw new Error('docs.json is missing required "navigation" object');
+  }
+
+  const optionData = collectOptionsFromNavigation(docs.navigation);
+  const allRoutes = collectRoutesFromNavigation(docs.navigation);
+  const fromScopeFile = loadScopeFile(args.scopeFile, args.repoRoot);
+
+  let selection = {
+    versions: uniqStrings([...fromScopeFile.versions, ...args.versions]),
+    languages: uniqStrings([...fromScopeFile.languages, ...args.languages]),
+    tabs: uniqStrings([...fromScopeFile.tabs, ...args.tabs]),
+    prefixes: uniqStrings([...fromScopeFile.prefixes, ...args.prefixes].map(normalizeRoute)),
+    disableOpenapi: Boolean(fromScopeFile.disableOpenapi || args.disableOpenapi)
+  };
+
+  if (args.interactive) {
+    selection = await promptForSelection(selection, optionData, allRoutes);
+  }
+
+  const scopedNavigation = buildScopedNavigation(docs.navigation, selection);
+  if (!scopedNavigation) {
+    throw new Error('Scoped profile removed all navigation nodes. Relax version/language/tab/prefix filters.');
+  }
+
+  const scopedDocs = { ...docs, navigation: scopedNavigation };
+  const scopedRoutes = collectRoutesFromNavigation(scopedDocs.navigation);
+  if (scopedRoutes.length === 0) {
+    throw new Error('Scoped profile resolved to zero routes. Relax version/language/tab/prefix filters.');
+  }
+
+  const mintignoreBase = fs.existsSync(mintignorePath) ? fs.readFileSync(mintignorePath, 'utf8') : '';
+  const metadata = buildScopedMetadata(selection, optionData, allRoutes, scopedRoutes);
+  const scopedMintignore = buildScopedMintignore(mintignoreBase, metadata);
+
+  const docsStat = fs.statSync(docsPath);
+  const mintignoreStat = fs.existsSync(mintignorePath) ? fs.statSync(mintignorePath) : null;
+  const scopeHash = createWorkspaceHash(args.repoRoot, selection, docsStat, mintignoreStat);
+  const workspaceDir = path.join(args.workspaceBase, scopeHash);
+
+  if (!args.printOnly) {
+    ensureWorkspaceScaffold(args.repoRoot, workspaceDir);
+    fs.writeFileSync(path.join(workspaceDir, 'docs.json'), `${JSON.stringify(scopedDocs, null, 2)}\n`, 'utf8');
+    fs.writeFileSync(path.join(workspaceDir, '.mintignore'), scopedMintignore, 'utf8');
+    fs.writeFileSync(
+      path.join(workspaceDir, '.lpd-scope.json'),
+      `${JSON.stringify(
+        {
+          generatedAt: new Date().toISOString(),
+          sourceRepoRoot: args.repoRoot,
+          selection,
+          routeCounts: {
+            original: allRoutes.length,
+            scoped: scopedRoutes.length
+          }
+        },
+        null,
+        2
+      )}\n`,
+      'utf8'
+    );
+  }
+
+  return {
+    workspaceDir,
+    scopeHash,
+    selection,
+    routeCounts: {
+      original: allRoutes.length,
+      scoped: scopedRoutes.length
+    },
+    disabledOpenapi: Boolean(selection.disableOpenapi)
+  };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printUsage();
+    return;
+  }
+  const result = await createScopedProfile(args);
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(`Error: ${error.message}`);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  parseArgs,
+  loadScopeFile,
+  collectRoutesFromNavigation,
+  collectOptionsFromNavigation,
+  deriveSectionPrefix,
+  buildScopedNavigation,
+  buildScopedMintignore,
+  buildScopedMetadata,
+  createScopedProfile
+};

--- a/tools/scripts/mint-dev.sh
+++ b/tools/scripts/mint-dev.sh
@@ -27,6 +27,16 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 MINT_WORKDIR="$REPO_ROOT"
+SCOPE_GENERATOR="$REPO_ROOT/tools/scripts/dev/generate-mint-dev-scope.js"
+SCOPED_MODE="${LPD_SCOPED_MINT_DEV:-0}"
+SCOPE_INTERACTIVE="${LPD_MINT_SCOPE_INTERACTIVE:-0}"
+SCOPE_FILE="${LPD_MINT_SCOPE_FILE:-}"
+SCOPE_VERSIONS="${LPD_MINT_SCOPE_VERSIONS:-}"
+SCOPE_LANGUAGES="${LPD_MINT_SCOPE_LANGUAGES:-}"
+SCOPE_TABS="${LPD_MINT_SCOPE_TABS:-}"
+SCOPE_PREFIXES="${LPD_MINT_SCOPE_PREFIXES:-}"
+DISABLE_OPENAPI="${LPD_MINT_DISABLE_OPENAPI:-0}"
+MINT_LOCK_FILE=""
 
 # chokidar treats glob metacharacters in watch paths as patterns. If the repo
 # path includes brackets (common in worktree names), change events can be lost.
@@ -49,6 +59,111 @@ if path_has_glob_meta "$REPO_ROOT"; then
     MINT_WORKDIR="$WATCH_SAFE_LINK"
     echo "Using watcher-safe path for mint dev: $MINT_WORKDIR"
 fi
+
+mint_lock_file_path() {
+    local repo_hash
+    repo_hash="$(printf '%s' "$REPO_ROOT" | cksum | awk '{print $1}')"
+    echo "/tmp/lpd-mint-dev-lock-${repo_hash}.pid"
+}
+
+ensure_no_active_mint_dev() {
+    local lock_file="$1"
+    if [ ! -f "$lock_file" ]; then
+        return 0
+    fi
+
+    local existing_pid existing_workdir
+    existing_pid="$(sed -n '1p' "$lock_file" 2>/dev/null || true)"
+    existing_workdir="$(sed -n '2p' "$lock_file" 2>/dev/null || true)"
+
+    if [ -n "$existing_pid" ] && kill -0 "$existing_pid" 2>/dev/null; then
+        echo "Error: mint dev is already running for this repository." >&2
+        echo "  pid: $existing_pid" >&2
+        if [ -n "$existing_workdir" ]; then
+            echo "  workspace: $existing_workdir" >&2
+        fi
+        echo "Stop the existing process before launching another dev session." >&2
+        exit 1
+    fi
+
+    rm -f "$lock_file"
+}
+
+cleanup_lock_file() {
+    if [ -n "$MINT_LOCK_FILE" ]; then
+        rm -f "$MINT_LOCK_FILE"
+    fi
+}
+
+build_scoped_workspace() {
+    if ! command -v node >/dev/null 2>&1; then
+        echo "Error: node is required for --scoped dev profile generation." >&2
+        exit 1
+    fi
+
+    if [ ! -f "$SCOPE_GENERATOR" ]; then
+        echo "Error: scoped profile generator not found: $SCOPE_GENERATOR" >&2
+        exit 1
+    fi
+
+    local -a scope_cmd
+    scope_cmd=(node "$SCOPE_GENERATOR" --repo-root "$REPO_ROOT")
+
+    if [ "$SCOPE_INTERACTIVE" = "1" ]; then
+        scope_cmd+=(--interactive)
+    fi
+    if [ -n "$SCOPE_FILE" ]; then
+        scope_cmd+=(--scope-file "$SCOPE_FILE")
+    fi
+    if [ -n "$SCOPE_VERSIONS" ]; then
+        scope_cmd+=(--versions "$SCOPE_VERSIONS")
+    fi
+    if [ -n "$SCOPE_LANGUAGES" ]; then
+        scope_cmd+=(--languages "$SCOPE_LANGUAGES")
+    fi
+    if [ -n "$SCOPE_TABS" ]; then
+        scope_cmd+=(--tabs "$SCOPE_TABS")
+    fi
+    if [ -n "$SCOPE_PREFIXES" ]; then
+        scope_cmd+=(--prefixes "$SCOPE_PREFIXES")
+    fi
+    if [ "$DISABLE_OPENAPI" = "1" ]; then
+        scope_cmd+=(--disable-openapi)
+    fi
+
+    local scope_json
+    if ! scope_json="$("${scope_cmd[@]}")"; then
+        echo "Error: failed to generate scoped Mint workspace." >&2
+        exit 1
+    fi
+
+    local parsed
+    if ! parsed="$(printf '%s' "$scope_json" | node -e '
+let input = "";
+process.stdin.on("data", (chunk) => { input += chunk; });
+process.stdin.on("end", () => {
+  const payload = JSON.parse(input);
+  const original = payload && payload.routeCounts ? Number(payload.routeCounts.original || 0) : 0;
+  const scoped = payload && payload.routeCounts ? Number(payload.routeCounts.scoped || 0) : 0;
+  const data = [payload.workspaceDir || "", payload.scopeHash || "", String(original), String(scoped)];
+  process.stdout.write(data.join("|"));
+});
+')"; then
+        echo "Error: invalid scoped profile output from generator." >&2
+        exit 1
+    fi
+
+    local scoped_workspace scope_hash original_routes scoped_routes
+    IFS='|' read -r scoped_workspace scope_hash original_routes scoped_routes <<< "$parsed"
+
+    if [ -z "$scoped_workspace" ] || [ ! -d "$scoped_workspace" ]; then
+        echo "Error: scoped workspace path is invalid: $scoped_workspace" >&2
+        exit 1
+    fi
+
+    MINT_WORKDIR="$scoped_workspace"
+    echo "Using scoped Mint workspace: $MINT_WORKDIR (routes ${scoped_routes}/${original_routes}, hash ${scope_hash})"
+}
 
 cd "$REPO_ROOT"
 
@@ -89,5 +204,19 @@ fi
 echo "Fetching external snippets..."
 bash tools/scripts/snippets/fetch-external-docs.sh
 
+if [ "$SCOPED_MODE" = "1" ]; then
+    build_scoped_workspace
+elif [ "$DISABLE_OPENAPI" = "1" ]; then
+    echo "Warning: --disable-openapi has no effect without --scoped."
+fi
+
+MINT_LOCK_FILE="$(mint_lock_file_path)"
+ensure_no_active_mint_dev "$MINT_LOCK_FILE"
+{
+    echo "$$"
+    echo "$MINT_WORKDIR"
+} > "$MINT_LOCK_FILE"
+trap cleanup_lock_file EXIT INT TERM
+
 cd "$MINT_WORKDIR"
-exec mint dev "$@"
+mint dev "$@"


### PR DESCRIPTION
<!-- codex-pr-body-generated: task_id=788; branch=codex/788-scoped-lpd-mint-dev-profiles; contract=.codex/task-contract.yaml -->

## Scope

- Task: #788
- Branch: `codex/788-scoped-lpd-mint-dev-profiles`
- Base: `docs-v2`

In scope:
- `.codex/task-contract.yaml`
- `lpd`
- `tools/scripts/mint-dev.sh`
- `tools/scripts/dev/`
- `tests/unit/`
- `tests/run-all.js`
- `docs-guide/lpd.mdx`
- `README.md`
- `tools/script-index.md`
- `tests/script-index.md`
- `docs-guide/indexes/scripts-index.mdx`

Out of scope:
- none

Allowed generated files:
- `.codex/pr-body.generated.md`

Changed files in this branch:
- `.codex/task-contract.yaml`
- `README.md`
- `docs-guide/indexes/scripts-index.mdx`
- `docs-guide/lpd.mdx`
- `lpd`
- `tests/run-all.js`
- `tests/script-index.md`
- `tests/unit/lpd-scoped-mint-dev.test.js`
- `tools/script-index.md`
- `tools/scripts/dev/generate-mint-dev-scope.js`
- `tools/scripts/mint-dev.sh`

## Validation

Acceptance checks from `.codex/task-contract.yaml`:
- [ ] `node tests/unit/lpd-scoped-mint-dev.test.js`
- [ ] `node tests/unit/script-docs.test.js --files tools/scripts/dev/generate-mint-dev-scope.js --files tests/unit/lpd-scoped-mint-dev.test.js --check-indexes`
- [ ] `node tools/scripts/dev/generate-mint-dev-scope.js --repo-root . --versions v2 --languages en --tabs Developers --disable-openapi --print-only`
- [ ] `bash lpd dev --dry-run --scoped --scope-version v2 --scope-language en --scope-tab Developers --scope-prefix v2/gateways --disable-openapi`

Validation results:
- [ ] _(fill in outcomes before requesting final review)_

## Follow-up Tasks

- none

