### PR TITLE
refactor: Update 404 page with professional messaging and brand guidelines

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -3354,8 +3354,8 @@
   "errors": {
     "404": {
       "redirect": false,
-      "title": "Ruh oh. This page doesn't exist.",
-      "description": "<Frame><img src=\"https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExN2FteDJ4bno5MHU5Y3QxdGx3eWR2emdhejRhc2c1Y2d3ejY5ajlxMSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Ju7l5y9osyymQ/giphy.gif\" alt=\"Rick Roll\" /></Frame><br/><br/>Sorry About That."
+      "title": "Page not found",
+      "description": "The page you're looking for doesn't exist or may have been moved. Head back to the <a href='/'>homepage</a> to find what you need."
     }
   },
   "redirects": [

--- a/style.css
+++ b/style.css
@@ -260,31 +260,6 @@ button.text-left.text-gray-600.text-sm.font-medium {
   background-color: #18794e !important;
 }
 
-/* Error 404 Styling */
-#error-description > span > div > div {
-  border: 1px solid #18794e !important;
-}
-
-body
-  > div.relative.antialiased.text-gray-500.dark\:text-gray-400
-  > div.peer-\[\.is-not-custom\]\:lg\:flex.peer-\[\.is-custom\]\:\[\&\>div\:first-child\]\:\!hidden.peer-\[\.is-custom\]\:\[\&\>div\:first-child\]\:sm\:\!hidden.peer-\[\.is-custom\]\:\[\&\>div\:first-child\]\:md\:\!hidden.peer-\[\.is-custom\]\:\[\&\>div\:first-child\]\:lg\:\!hidden.peer-\[\.is-custom\]\:\[\&\>div\:first-child\]\:xl\:\!hidden
-  > div.flex.flex-col.items-center.justify-center.w-full.max-w-lg.overflow-x-hidden.mx-auto.py-48.px-5.text-center.\*\:text-center.gap-y-8.not-found-container
-  > div {
-  margin-top: -5rem;
-}
-
-#error-description
-  > span
-  > div
-  > div
-  > div.relative.rounded-xl.overflow-hidden.flex.justify-center
-  > img {
-  width: 500px;
-  aspect-ratio: 4 / 3;
-  object-fit: cover;
-  /* border: 1px solid #fff; */
-}
-
 /* Step List Color Icons Styling */
 /* #content > div.steps > div > div.absolute.ml-\[-13px\].py-2 > div {
   background-color: #18794e !important;


### PR DESCRIPTION
Remove the embedded Rick Roll GIF and informal copy from the 404 page, replacing it with a clean text-only message and homepage link that aligns with Livepeer brand guidelines. Clean up associated CSS that styled the now-removed image.