### PR TITLE
feat(skills): broaden fact research coverage

### DIFF
--- a/.codex/task-contract.yaml
+++ b/.codex/task-contract.yaml
@@ -1,50 +1,22 @@
 task_id: 20260316
-branch: codex/20260316-ownerless-rollout
+branch: codex/20260316-research-skill-improvements
 base_branch: docs-v2-dev
 scope_in:
   - .codex/task-contract.yaml
-  - .githooks/script-index.md
-  - .github/script-index.md
-  - docs-guide/catalog/scripts-catalog.mdx
-  - docs-guide/tooling/lpd-cli.mdx
-  - docs-index.json
-  - lpd
-  - snippets/automations/script-index.md
-  - tasks/scripts/script-index.md
-  - tests/script-index.md
-  - tests/README.md
-  - tests/unit/
-  - tools/config/ownerless-governance-surfaces.json
-  - tools/config/script-index.md
-  - tools/lib/script-governance-config.js
-  - tools/lib/script-header-utils.js
-  - tools/lib/script-index.md
-  - tools/notion/script-index.md
-  - tools/script-index.md
-  - tools/scripts/new-script.js
-  - tools/scripts/orchestrators/repair-governance.js
-  - tools/scripts/validators/governance/audit-script-inventory.js
-  - tools/scripts/validators/governance/review-governance-repair-checklist.js
+  - tasks/reports/repo-ops
+  - tasks/research/claims
+  - tests/unit/docs-fact-registry.test.js
+  - tests/unit/docs-page-research-pr-report.test.js
+  - tests/unit/docs-page-research.test.js
+  - tools/scripts/docs-fact-registry.js
+  - tools/scripts/docs-page-research-pr-report.js
+  - tools/scripts/docs-page-research.js
 scope_out: []
 allowed_generated:
-  - .githooks/script-index.md
-  - .github/script-index.md
-  - docs-guide/catalog/scripts-catalog.mdx
-  - docs-index.json
-  - snippets/automations/script-index.md
-  - tasks/scripts/script-index.md
-  - tests/script-index.md
-  - tools/config/script-index.md
-  - tools/lib/script-index.md
-  - tools/notion/script-index.md
-  - tools/script-index.md
+  - .codex/pr-body.generated.md
 acceptance_checks:
-  - node tests/unit/audit-script-inventory-repair-rules.test.js
-  - node tests/unit/repair-governance.test.js
-  - node tests/unit/script-docs.test.js
-  - node tests/unit/ownerless-governance.test.js
-  - node tests/unit/docs-guide-sot.test.js
   - node tests/run-all.js --staged --skip-browser
   - node tests/run-pr-checks.js --base-ref docs-v2-dev
-risk_flags: []
+risk_flags:
+  - experimental-research
 follow_up_issues: []

--- a/tasks/reports/repo-ops/2026-03-16-page-content-research-pilot-gateway-pricing-clearinghouse.json
+++ b/tasks/reports/repo-ops/2026-03-16-page-content-research-pilot-gateway-pricing-clearinghouse.json
@@ -1,0 +1,1025 @@
+{
+  "generated_at": "2026-03-16T03:50:20.935Z",
+  "scope": {
+    "target_files": [
+      "v2/gateways/guides/payments-and-pricing/clearinghouse-guide.mdx",
+      "v2/gateways/guides/payments-and-pricing/payment-guide.mdx",
+      "v2/gateways/guides/payments-and-pricing/pricing-strategy.mdx",
+      "v2/gateways/guides/payments-and-pricing/remote-signers.mdx",
+      "v2/gateways/guides/roadmap-and-funding/naap-multi-tenancy.mdx",
+      "v2/gateways/guides/roadmap-and-funding/operator-support.mdx"
+    ]
+  },
+  "claims_reviewed": [
+    {
+      "file": "v2/gateways/guides/payments-and-pricing/clearinghouse-guide.mdx",
+      "extracted_claims": [
+        "{ / TODO: Terminology Validation: Ensure the terminology and definitions used in this page is consistent with the resources/glossary terminology Verify: ~~Mermaid diagrams use theme colours~~ (N/A ASCII diagram kept intentionally) ~~Fontawesome icons are used on accordions and tabs~~ ~~Tables use StyledTable component~~ ~~No em dashes are used (instead use standard )~~ UK spelling is used ~~Headers are concise and technical no long headers or questions (aim for max 3 words)~~ ~~CustomDivider is used~~ Placeholders for Media & Video Resources are in comments with a TODO for a human.",
+        "(N/A) ~~REVIEW flags are in JSX flags for a human.~~ Human: H1 removed (was repeating frontmatter title) \"Why clearinghouses exist\" removed (redundant with payment guide router) \"Clearinghouse vs remote signer\" trimmed to brief statement with link PM internals cross referenced instead of duplicated Voice converted to entity led throughout Port 8937 → 8935 Broken link payment paths → payment guide Em dashes removed /} Protocol status: The clearinghouse protocol was implemented in and and is operational.",
+        "Public Use Status No public clearinghouse service has reached general availability as of early 2026.",
+        "Note that Payment Clearinghouses are designed to become independent economic actors in the Livepeer Network providing services for a fee to end users.",
+        "A clearinghouse manages payments, not the pipeline.",
+        "Building A Clearinghouse For operators building gateway as a service infrastructure (a \"Provider\" or NaaP operator), the minimum components are: Component Purpose Starting point Remote signer instances ETH custody and PM signing User management API key issuance, SIWE login Standard web auth + SIWE libraries Accounting service Track usage per API key, manage credits Custom or off the shelf billing tooling Billing layer Invoice developers in chosen currency Stripe, crypto payment processors, etc.",
+        "Current Status Beta While a fully productionised public clearinghouse matures, the following access points exist: Community remote signer (testing): hosted by Elite Encoder, free ETH for testing.",
+        "Livepeer Tools: the current community tool suite for network monitoring and Gateway observability.",
+        "Video transcoding operators have no clearinghouse option at present: remote signing is not supported for that workload, so self management is the only path."
+      ],
+      "matched_claim_families": [
+        "gw-clearinghouse-public-readiness",
+        "gw-community-signer-testing-surface"
+      ]
+    },
+    {
+      "file": "v2/gateways/guides/payments-and-pricing/payment-guide.mdx",
+      "extracted_claims": [
+        "Livepeer fees between Gateways and Orchestrators are settled in ETH on Arbitrum One via probabilistic micropayment (PM) tickets.",
+        "Gateways can configure price caps in wei or in USD (converted at runtime via a Chainlink price feed).",
+        "Next step: Video On chain video gateway } icon=\"link\" Video transcoding requires the on chain self managed path.",
+        "Remote signing is not supported for video workloads.",
+        "Next step: Dual On chain dual gateway } icon=\"link\" Because the video component requires on chain payments, a dual gateway follows the on chain self managed path.",
+        "Fund the gateway, then configure pricing for both video (per pixel) and AI (per pipeline).",
+        "Function { On chain Processes } { Off chain Delegates } Protocol integration Connects to Livepeer protocol on Arbitrum None no blockchain interaction at the gateway Orchestrator discovery Automatic via protocol Manual ( ) or via discovery endpoint Payment signing Gateway signs PM tickets directly Remote signer or clearinghouse signs tickets ETH required in gateway Yes deposit + reserve on Arbitrum No held by signer or clearinghouse Private key in gateway Yes No Video transcoding Supported Not supported (requires on chain) AI inference Supported Supported (Live AI via remote signer) Off chain does not mean free.",
+        "Supported for Live AI workloads and SDK based gateways.",
+        "Not supported for video transcoding.",
+        "No public clearinghouse is at general availability as of early 2026.",
+        "Set maximum prices per pipeline and model."
+      ],
+      "matched_claim_families": [
+        "gw-clearinghouse-public-readiness",
+        "gw-community-signer-testing-surface",
+        "gw-price-cap-role"
+      ]
+    },
+    {
+      "file": "v2/gateways/guides/payments-and-pricing/pricing-strategy.mdx",
+      "extracted_claims": [
+        "Pricing Mechanics Livepeer workload fees are denominated in ETH (wei), with an option to configure caps in USD (converted at runtime via a ).",
+        "Query current rates via or before setting caps.",
+        "The gateway calculates fees based on the resolution and length of each transcoded segment.",
+        "Video transcoding requires on chain operational mode.",
+        "Key flags: Flag Type Default Description int (wei) or USD string (any price) Maximum price per pixels int How many pixels constitute one pricing unit bool Accept any price if no Orchestrators are in range Fee calculation: The effective cap is wei per pixels.",
+        "A 1920x1080 frame contains 2,073,600 pixels.",
+        "With a cap of 1,000 wei per pixel and of 1, that frame costs at most 2,073,600 wei (about 0.000002 ETH).",
+        "USD pricing To configure caps in USD rather than wei, pass a USD value: This requires a Chainlink ETH/USD price feed configured via .",
+        "USD denominated pricing with a Chainlink feed stabilises the effective cost but requires the oracle to be reachable and accurate.",
+        "Each pipeline and model can have its own price cap, and the unit of measurement varies by pipeline type.",
+        "Payment types The AI payment system uses three models depending on the pipeline: Payment type Used for Unit Per pixel Image and video generation pipelines Per request Single output pipelines One payment per API call Live video interval Live AI (live video to video) Time based, every N seconds The pipeline uses interval based payments controlled by .",
+        "All other AI pipelines use per pixel or per request models based on their output type."
+      ],
+      "matched_claim_families": [
+        "gw-price-cap-role"
+      ]
+    },
+    {
+      "file": "v2/gateways/guides/payments-and-pricing/remote-signers.mdx",
+      "extracted_claims": [
+        "Current scope: Realtime AI Video (live video to video) workloads only.",
+        "Remote signing is not supported for video transcoding.",
+        "Remote signers were introduced in and , in January 2026.",
+        "signature When a Gateway contacts an Orchestrator, it must provide an authentication signature.",
+        "HTTP 480 expired ticket params If the signer returns HTTP status 480, the ticket parameters from the Orchestrator have expired.",
+        "Prerequisites A binary that includes remote signer support (confirm with ; see for the implementation) A funded Ethereum account on Arbitrum One for the signer (the Gateway itself needs no ETH) An Arbitrum RPC endpoint accessible from the signer host Network connectivity from the Gateway host to the signer service Running the Signer Run in signer mode on a dedicated host or process: The signer service binds to port 7936 by default.",
+        "This port must be reachable from the Gateway host.",
+        "Check that payments are flowing via : Operational Rules Running a remote signer in production requires attention to a few non obvious rules.",
+        "This state must be passed back to the next call for the same session.",
+        "Do not make concurrent calls for the same session.",
+        "State advances sequentially; concurrent calls produce conflicting states and invalid tickets.",
+        "Multiple sessions can run concurrently, each with their own state chain."
+      ],
+      "matched_claim_families": [
+        "gw-community-signer-testing-surface"
+      ]
+    },
+    {
+      "file": "v2/gateways/guides/roadmap-and-funding/naap-multi-tenancy.mdx",
+      "extracted_claims": [
+        "From the Discord discussion that defined this model: \"The user never interacts with Livepeer contracts.",
+        "Multi tenant architecture Authentication flow Tenant isolation Each customer (tenant) operates within boundaries set by their API key: Isolation concern How NaaP handles it Request quotas Per key rate limits (requests/minute, requests/day) Usage caps Per key maximum usage (pixels, inferences, minutes) Billing separation Per key usage tracking for independent invoicing Failure isolation One customer exceeding quota does not affect others Data separation Per key logs and metrics Orchestrator affinity For premium tenants, you can configure orchestrator routing preferences: Route premium customers to high tier orchestrators (lower latency, higher reliability) Route budget customers to standard orchestrators Route specific workload types to capability matched orchestrators This is configured at the middleware layer using or per request path.",
+        "Building the product layer Option 1: Use the NaaP reference implementation The fastest path.",
+        "What you get out of the box: JWT auth via SIWE API key generation and management Usage tracking per key Dashboard UI What you still need to build: Payment integration (Stripe, crypto billing, etc.) Custom pricing tiers Customer onboarding flow Production monitoring and alerting Option 2: Build your own product layer If your platform has specific requirements that NaaP does not cover, build your own using standard middleware patterns.",
+        "Billing integration What to meter Workload type Metering unit How to capture Video transcoding Minutes of transcoded video Gateway result metadata Batch AI (text to image, etc.) Output pixels or number of generations Gateway result metadata Live AI (LV2V) Seconds of processed stream Session duration tracking LLM Output tokens Gateway result metadata Audio to text Seconds of input audio Request metadata Pricing models Model Description Used by Per request Charge per API call or per inference job API providers, Daydream Per minute Charge per minute of video transcoded or live AI processed Livepeer Studio Subscription Monthly access fee regardless of usage SaaS gateway products Usage based Charge per unit (per pixel, per generation, per token) Direct API products Free + SPE funded No charge to users; costs covered by treasury grant Livepeer Cloud SPE Credits Pre purchased credits debited per job Hybrid platforms Your margin is the difference between what you charge customers and what you pay orchestrators.",
+        "Receives customer payments in your chosen currency (fiat, USDC, credits) 2.",
+        "Maintains an ETH hot wallet funded from customer revenue 3.",
+        "Acts as the remote signer for your gateway generating payment tickets backed by the ETH balance 4."
+      ],
+      "matched_claim_families": [
+        "gw-price-cap-role"
+      ]
+    },
+    {
+      "file": "v2/gateways/guides/roadmap-and-funding/operator-support.mdx",
+      "extracted_claims": [
+        "The Livepeer ecosystem provides funding, programmes, and community resources for Gateway operators at every stage from first time builders to production platform operators.",
+        "Currently funded SPEs operating Gateways: SPE What it funds Status Livepeer Cloud SPE Free public AI and video Gateways Active LLM SPE LLM inference routing on the Livepeer network Active How to propose an SPE: 1.",
+        "Engage the community on and 2.",
+        "Write a proposal with clear public benefit, verifiable milestones, and realistic budget 3.",
+        "Post to the Livepeer Forum for community discussion 4.",
+        "Submit for on chain governance vote (token holder approval) 5.",
+        "Execute and report on milestones For the full SPE guide, see .",
+        "The Livepeer Foundation runs a programme for startups and teams building AI powered video products on Livepeer.",
+        "Accepted teams receive: Network resources and compute credits Technical support from the Livepeer engineering team Investor introductions and go to market guidance Community visibility This programme is specifically for teams building products that route AI inference through the Livepeer network.",
+        "The AI Video Startup Programme runs in cohorts.",
+        "Check or the for current application windows.",
+        "Forum threads are indexed by search engines and serve as a permanent record."
+      ],
+      "matched_claim_families": [
+        "gw-clearinghouse-public-readiness",
+        "gw-community-signer-testing-surface",
+        "gw-discord-community-signal",
+        "gw-spe-funded-provider-examples",
+        "gw-startup-program-current"
+      ]
+    }
+  ],
+  "verified_claims": [
+    {
+      "claim_id": "gw-price-cap-role",
+      "claim_family": "price-cap-role",
+      "entity": "gateway",
+      "canonical_owner": "v2/gateways/guides/payments-and-pricing/pricing-strategy.mdx",
+      "registry_status": "verified",
+      "status": "verified",
+      "freshness_class": "review-on-change",
+      "confidence": "high",
+      "summary": "Gateway pricing docs should keep the role of caps aligned: on-chain caps act as marketplace filters, while off-chain caps act as safety ceilings for known orchestrators. The same claim family also covers how `-ignoreMaxPriceIfNeeded` changes job-failure behavior.",
+      "evidence": [
+        {
+          "type": "repo-file",
+          "ref": "v2/gateways/guides/payments-and-pricing/pricing-strategy.mdx",
+          "checked_on": "2026-03-16",
+          "ok": true,
+          "matched": true,
+          "summary": "repo evidence matched"
+        },
+        {
+          "type": "repo-file",
+          "ref": "v2/gateways/guides/roadmap-and-funding/naap-multi-tenancy.mdx",
+          "checked_on": "2026-03-16",
+          "ok": true,
+          "matched": true,
+          "summary": "repo evidence matched"
+        }
+      ],
+      "page_observations": [
+        {
+          "file": "v2/gateways/guides/payments-and-pricing/pricing-strategy.mdx",
+          "snippets": [
+            "The Operational mode determines context: on chain gateways filter Orchestrators from an open marketplace, while off chain gateways set safety ceilings for known Orchestrators specified via .",
+            "The price cap acts as a marketplace filter it determines the range of the network the gateway can access.",
+            "In this context, the price cap acts as a safety ceiling it prevents unexpected cost spikes if an Orchestrator raises prices, but it does not filter from a marketplace."
+          ],
+          "values": []
+        },
+        {
+          "file": "v2/gateways/guides/payments-and-pricing/payment-guide.mdx",
+          "snippets": [],
+          "values": []
+        },
+        {
+          "file": "v2/gateways/guides/roadmap-and-funding/naap-multi-tenancy.mdx",
+          "snippets": [],
+          "values": []
+        }
+      ],
+      "propagation_queue": [
+        {
+          "file": "v2/gateways/guides/payments-and-pricing/payment-guide.mdx",
+          "page_class": "guide",
+          "role": "dependent-page",
+          "action": "update-now",
+          "claim_id": "gw-price-cap-role"
+        },
+        {
+          "file": "v2/gateways/guides/payments-and-pricing/pricing-strategy.mdx",
+          "page_class": "guide",
+          "role": "canonical-owner",
+          "action": "update-now",
+          "claim_id": "gw-price-cap-role"
+        },
+        {
+          "file": "v2/gateways/guides/roadmap-and-funding/naap-multi-tenancy.mdx",
+          "page_class": "guide",
+          "role": "dependent-page",
+          "action": "update-now",
+          "claim_id": "gw-price-cap-role"
+        }
+      ],
+      "contradictions": [],
+      "notes": "This is a routing-and-cost semantics family, not a navigation concern. It exists to catch factual drift in how gateway operators reason about price caps and fallback behavior."
+    }
+  ],
+  "conflicted_claims": [
+    {
+      "claim_id": "gw-clearinghouse-public-readiness",
+      "claim_family": "clearinghouse-public-readiness",
+      "entity": "gateway",
+      "canonical_owner": "v2/gateways/guides/payments-and-pricing/clearinghouse-guide.mdx",
+      "registry_status": "time-sensitive",
+      "status": "conflicted",
+      "freshness_class": "review-periodic",
+      "confidence": "low",
+      "summary": "Gateway payment docs should describe clearinghouse status with current precision: the protocol is implemented, but no public clearinghouse is generally available yet. Community-hosted signer access is a testing bridge, not evidence of GA.",
+      "evidence": [
+        {
+          "type": "github-pr",
+          "ref": "https://github.com/livepeer/go-livepeer/pull/3791",
+          "checked_on": "2026-03-16",
+          "ok": true,
+          "matched": true,
+          "summary": "GitHub evidence matched"
+        },
+        {
+          "type": "github-pr",
+          "ref": "https://github.com/livepeer/go-livepeer/pull/3822",
+          "checked_on": "2026-03-16",
+          "ok": true,
+          "matched": true,
+          "summary": "GitHub evidence matched"
+        },
+        {
+          "type": "repo-file",
+          "ref": "v2/gateways/guides/payments-and-pricing/clearinghouse-guide.mdx",
+          "checked_on": "2026-03-16",
+          "ok": true,
+          "matched": true,
+          "summary": "repo evidence matched"
+        }
+      ],
+      "page_observations": [
+        {
+          "file": "v2/gateways/guides/payments-and-pricing/clearinghouse-guide.mdx",
+          "snippets": [
+            "Public Use Status No public clearinghouse service has reached general availability as of early 2026.",
+            "The community remote signer hosted by Elite Encoder ( ) provides a testing surface in the interim.",
+            "Current Status Beta While a fully productionised public clearinghouse matures, the following access points exist: Community remote signer (testing): hosted by Elite Encoder, free ETH for testing."
+          ],
+          "values": [
+            "general availability",
+            "public clearinghouse"
+          ]
+        },
+        {
+          "file": "v2/gateways/guides/payments-and-pricing/payment-guide.mdx",
+          "snippets": [
+            "Once a public clearinghouse reaches GA, this becomes a pure API key sign up.",
+            "No public clearinghouse is at general availability as of early 2026."
+          ],
+          "values": [
+            "general availability",
+            "public clearinghouse"
+          ]
+        },
+        {
+          "file": "v2/gateways/guides/roadmap-and-funding/operator-support.mdx",
+          "snippets": [],
+          "values": []
+        }
+      ],
+      "propagation_queue": [
+        {
+          "file": "v2/gateways/guides/payments-and-pricing/clearinghouse-guide.mdx",
+          "page_class": "guide",
+          "role": "canonical-owner",
+          "action": "verify-only",
+          "claim_id": "gw-clearinghouse-public-readiness"
+        },
+        {
+          "file": "v2/gateways/guides/payments-and-pricing/payment-guide.mdx",
+          "page_class": "guide",
+          "role": "dependent-page",
+          "action": "verify-only",
+          "claim_id": "gw-clearinghouse-public-readiness"
+        },
+        {
+          "file": "v2/gateways/guides/roadmap-and-funding/operator-support.mdx",
+          "page_class": "guide",
+          "role": "dependent-page",
+          "action": "verify-only",
+          "claim_id": "gw-clearinghouse-public-readiness"
+        }
+      ],
+      "contradictions": [
+        {
+          "claim_family": "clearinghouse-public-readiness",
+          "claim_id": "gw-clearinghouse-public-readiness",
+          "pages": [
+            {
+              "file": "v2/gateways/guides/payments-and-pricing/clearinghouse-guide.mdx",
+              "values": [
+                "general availability",
+                "public clearinghouse"
+              ],
+              "snippet": "Public Use Status No public clearinghouse service has reached general availability as of early 2026."
+            },
+            {
+              "file": "v2/gateways/guides/payments-and-pricing/payment-guide.mdx",
+              "values": [
+                "general availability",
+                "public clearinghouse"
+              ],
+              "snippet": "Once a public clearinghouse reaches GA, this becomes a pure API key sign up."
+            }
+          ],
+          "best_known_truth": "Gateway payment docs should describe clearinghouse status with current precision: the protocol is implemented, but no public clearinghouse is generally available yet. Community-hosted signer access is a testing bridge, not evidence of GA.",
+          "confidence": "low",
+          "recommended_action": "verify-more"
+        }
+      ],
+      "notes": "This family should stay explicit about protocol readiness versus public-service readiness. The docs should not blur implementation status into GA claims."
+    },
+    {
+      "claim_id": "gw-discord-community-signal",
+      "claim_family": "community-signal",
+      "entity": "gateway",
+      "canonical_owner": "v2/gateways/guides/operator-considerations/production-gateways.mdx",
+      "registry_status": "unverified",
+      "status": "conflicted",
+      "freshness_class": "review-periodic",
+      "confidence": "low",
+      "summary": "When gateway docs rely on community support or current market/pricing conditions, the research runner should surface any repo-available Discord/community signals instead of treating chat as invisible.",
+      "evidence": [
+        {
+          "type": "repo-file",
+          "ref": ".github/workflows/discord-issue-intake.yml",
+          "checked_on": "2026-03-16",
+          "ok": true,
+          "matched": true,
+          "summary": "repo evidence matched"
+        }
+      ],
+      "page_observations": [
+        {
+          "file": "v2/gateways/guides/operator-considerations/production-gateways.mdx",
+          "snippets": [
+            "This page documents real applications and community projects that are already running, gives you tooling references, and points to Foundation programmes for new builders.",
+            "AI workloads generated over $63,700 in revenue in Q2 2025 (over 55% of total protocol fees) Related: the Cloud SPE has built a custom Ollama based AI Runner optimised for GPUs with as little as 8GB VRAM Gateway Projects livepeer python gateway (j0sh) Community Project What it is: A Python implementation of the Livepeer gateway client.",
+            "Repository: Examples: Community Remote Signer (Elite Encoder) Community Project What it is: A publicly hosted remote signer endpoint maintained by community operator Elite Encoder.",
+            "What it enables: Any developer can run an off chain gateway without holding any ETH, by pointing at this community signer."
+          ],
+          "values": [
+            "Community",
+            "community"
+          ]
+        },
+        {
+          "file": "v2/gateways/guides/roadmap-and-funding/operator-support.mdx",
+          "snippets": [
+            "The Livepeer ecosystem provides funding, programmes, and community resources for Gateway operators at every stage from first time builders to production platform operators.",
+            "This page covers what support is available and how to access it.",
+            "Engage the community on and 2.",
+            "Post to the Livepeer Forum for community discussion 4."
+          ],
+          "values": [
+            "community"
+          ]
+        }
+      ],
+      "propagation_queue": [
+        {
+          "file": "v2/gateways/guides/operator-considerations/production-gateways.mdx",
+          "page_class": "guide",
+          "role": "canonical-owner",
+          "action": "verify-only",
+          "claim_id": "gw-discord-community-signal"
+        },
+        {
+          "file": "v2/gateways/guides/roadmap-and-funding/operator-support.mdx",
+          "page_class": "guide",
+          "role": "dependent-page",
+          "action": "verify-only",
+          "claim_id": "gw-discord-community-signal"
+        }
+      ],
+      "contradictions": [
+        {
+          "claim_family": "community-signal",
+          "claim_id": "gw-discord-community-signal",
+          "pages": [
+            {
+              "file": "v2/gateways/guides/operator-considerations/production-gateways.mdx",
+              "values": [
+                "Community",
+                "community"
+              ],
+              "snippet": "This page documents real applications and community projects that are already running, gives you tooling references, and points to Foundation programmes for new builders."
+            },
+            {
+              "file": "v2/gateways/guides/roadmap-and-funding/operator-support.mdx",
+              "values": [
+                "community"
+              ],
+              "snippet": "The Livepeer ecosystem provides funding, programmes, and community resources for Gateway operators at every stage from first time builders to production platform operators."
+            }
+          ],
+          "best_known_truth": "When gateway docs rely on community support or current market/pricing conditions, the research runner should surface any repo-available Discord/community signals instead of treating chat as invisible.",
+          "confidence": "low",
+          "recommended_action": "verify-more"
+        }
+      ],
+      "notes": "Phase 1 only uses persisted or repo-available Discord signals, not live chat ingestion."
+    },
+    {
+      "claim_id": "gw-spe-funded-provider-examples",
+      "claim_family": "ecosystem-provider-examples",
+      "entity": "gateway",
+      "canonical_owner": "v2/gateways/guides/operator-considerations/production-gateways.mdx",
+      "registry_status": "verified",
+      "status": "conflicted",
+      "freshness_class": "review-periodic",
+      "confidence": "low",
+      "summary": "Gateway comparison and support pages should only present provider examples that are still backed by current SPE/governance or public project evidence.",
+      "evidence": [
+        {
+          "type": "forum-topic",
+          "ref": "https://forum.livepeer.org/t/spe-milestone-report/3035",
+          "checked_on": "2026-03-16",
+          "ok": true,
+          "matched": true,
+          "summary": "forum topic matched"
+        }
+      ],
+      "page_observations": [
+        {
+          "file": "v2/gateways/guides/operator-considerations/production-gateways.mdx",
+          "snippets": [
+            "Gateway Operators Operator Model Gateway type Daydream Livepeer Product Commercial AI video product; subscription and per use pricing AI gateway embedded in product Livepeer Studio Livepeer Product Video API for developers; per minute pricing Video gateway (on chain) Public Livepeer Cloud SPE SPE Funded Free public gateways funded by treasury SPE grant AI and video Public LLM SPE SPE Funded LLM inference routing on Livepeer network AI gateway (LLM focused) Public Streamplace SPE Funded Decentralised livestreaming platform (AT Protocol); embedded gateway Video gateway embedded in product Commercial Products Daydream Livepeer Inc.",
+            "Streamplace SPE funded Commercial Product What it is: A decentralised livestreaming platform built on the AT Protocol (Bluesky ecosystem).",
+            "Streamplace enables peer to peer live video broadcasting with no centralised infrastructure requirement.",
+            "Gateway role: Streamplace embeds a Livepeer video gateway directly in its platform to handle live transcoding."
+          ],
+          "values": [
+            "LLM",
+            "Livepeer Cloud",
+            "Streamplace"
+          ]
+        },
+        {
+          "file": "v2/gateways/guides/roadmap-and-funding/operator-support.mdx",
+          "snippets": [
+            "Funding Paths Special Purpose Entity (SPE) grants fund Gateway operators through the Livepeer treasury governance process.",
+            "SPEs run public Gateways that serve the broader network public access, new capabilities, increased demand without needing a commercial revenue stream from day one.",
+            "Currently funded SPEs operating Gateways: SPE What it funds Status Livepeer Cloud SPE Free public AI and video Gateways Active LLM SPE LLM inference routing on the Livepeer network Active How to propose an SPE: 1.",
+            "Execute and report on milestones For the full SPE guide, see ."
+          ],
+          "values": [
+            "LLM",
+            "Livepeer Cloud"
+          ]
+        },
+        {
+          "file": "v2/gateways/guides/roadmap-and-funding/spe-grant-model.mdx",
+          "snippets": [
+            "Some Livepeer Gateway operators are funded by the Livepeer treasury through a Special Purpose Entity (SPE) grant.",
+            "A Special Purpose Entity (SPE) is an organisation funded by the Livepeer treasury through a governance proposal.",
+            "SPEs are purpose built: each one has a defined mandate, a requested budget, and milestones it is accountable to deliver.",
+            "Token holders vote on SPE proposals."
+          ],
+          "values": []
+        }
+      ],
+      "propagation_queue": [
+        {
+          "file": "v2/gateways/guides/operator-considerations/production-gateways.mdx",
+          "page_class": "guide",
+          "role": "canonical-owner",
+          "action": "verify-only",
+          "claim_id": "gw-spe-funded-provider-examples"
+        },
+        {
+          "file": "v2/gateways/guides/roadmap-and-funding/operator-support.mdx",
+          "page_class": "guide",
+          "role": "dependent-page",
+          "action": "verify-only",
+          "claim_id": "gw-spe-funded-provider-examples"
+        },
+        {
+          "file": "v2/gateways/guides/roadmap-and-funding/spe-grant-model.mdx",
+          "page_class": "guide",
+          "role": "dependent-page",
+          "action": "verify-only",
+          "claim_id": "gw-spe-funded-provider-examples"
+        }
+      ],
+      "contradictions": [
+        {
+          "claim_family": "ecosystem-provider-examples",
+          "claim_id": "gw-spe-funded-provider-examples",
+          "pages": [
+            {
+              "file": "v2/gateways/guides/operator-considerations/production-gateways.mdx",
+              "values": [
+                "LLM",
+                "Livepeer Cloud",
+                "Streamplace"
+              ],
+              "snippet": "Gateway Operators Operator Model Gateway type Daydream Livepeer Product Commercial AI video product; subscription and per use pricing AI gateway embedded in product Livepeer Studio Livepeer Product Video API for developers; per minute pricing Video gateway (on chain) Public Livepeer Cloud SPE SPE Funded Free public gateways funded by treasury SPE grant AI and video Public LLM SPE SPE Funded LLM inference routing on Livepeer network AI gateway (LLM focused) Public Streamplace SPE Funded Decentralised livestreaming platform (AT Protocol); embedded gateway Video gateway embedded in product Commercial Products Daydream Livepeer Inc."
+            },
+            {
+              "file": "v2/gateways/guides/roadmap-and-funding/operator-support.mdx",
+              "values": [
+                "LLM",
+                "Livepeer Cloud"
+              ],
+              "snippet": "Funding Paths Special Purpose Entity (SPE) grants fund Gateway operators through the Livepeer treasury governance process."
+            },
+            {
+              "file": "v2/gateways/guides/roadmap-and-funding/spe-grant-model.mdx",
+              "values": [],
+              "snippet": "Some Livepeer Gateway operators are funded by the Livepeer treasury through a Special Purpose Entity (SPE) grant."
+            }
+          ],
+          "best_known_truth": "Gateway comparison and support pages should only present provider examples that are still backed by current SPE/governance or public project evidence.",
+          "confidence": "low",
+          "recommended_action": "verify-more"
+        }
+      ],
+      "notes": "Provider listings are high-risk for factual drift and should be tied to public evidence."
+    }
+  ],
+  "time_sensitive_claims": [
+    {
+      "claim_id": "gw-community-signer-testing-surface",
+      "claim_family": "community-signer-testing-surface",
+      "entity": "gateway",
+      "canonical_owner": "v2/gateways/guides/payments-and-pricing/payment-guide.mdx",
+      "registry_status": "time-sensitive",
+      "status": "time-sensitive",
+      "freshness_class": "review-periodic",
+      "confidence": "medium",
+      "summary": "Docs that mention the Elite Encoder community signer should keep its role narrow and explicit: a repo/community-backed testing surface for early off-chain experimentation, not a generic production recommendation.",
+      "evidence": [
+        {
+          "type": "repo-discord-signal",
+          "ref": ".github/workflows/discord-issue-intake.yml",
+          "checked_on": "2026-03-16",
+          "ok": true,
+          "matched": true,
+          "summary": "repo Discord/community signal matched"
+        },
+        {
+          "type": "repo-file",
+          "ref": "v2/gateways/guides/payments-and-pricing/payment-guide.mdx",
+          "checked_on": "2026-03-16",
+          "ok": true,
+          "matched": true,
+          "summary": "repo evidence matched"
+        },
+        {
+          "type": "repo-file",
+          "ref": "v2/gateways/guides/roadmap-and-funding/operator-support.mdx",
+          "checked_on": "2026-03-16",
+          "ok": true,
+          "matched": true,
+          "summary": "repo evidence matched"
+        }
+      ],
+      "page_observations": [
+        {
+          "file": "v2/gateways/guides/payments-and-pricing/payment-guide.mdx",
+          "snippets": [
+            "For testing, use the community signer at ."
+          ],
+          "values": []
+        },
+        {
+          "file": "v2/gateways/guides/payments-and-pricing/clearinghouse-guide.mdx",
+          "snippets": [
+            "The community remote signer hosted by Elite Encoder ( ) provides a testing surface in the interim."
+          ],
+          "values": []
+        },
+        {
+          "file": "v2/gateways/guides/payments-and-pricing/remote-signers.mdx",
+          "snippets": [
+            "Security With a remote signer correctly deployed: The Gateway process holds no Ethereum private key A fully compromised Gateway cannot sign payment tickets or drain ETH funds independently The signer's state is cryptographically signed and cannot be forged by the Gateway Multiple Gateway instances can be keyless, reducing the blast radius of any single compromise What a remote signer does not protect against: A compromise of the signer service itself (the signer holds the actual key) Unlimited ticket requests from a compromised Gateway (rate limiting is the signer's responsibility) Video transcoding workloads (not in scope) Community Signer A community operated remote signer is available for testing and early development: Elite Encoder Remote Signer: This instance provides free ETH for testing."
+          ],
+          "values": []
+        },
+        {
+          "file": "v2/gateways/guides/roadmap-and-funding/operator-support.mdx",
+          "snippets": [
+            "The community signer is not for production workloads without understanding the custody implications."
+          ],
+          "values": []
+        }
+      ],
+      "propagation_queue": [
+        {
+          "file": "v2/gateways/guides/payments-and-pricing/clearinghouse-guide.mdx",
+          "page_class": "guide",
+          "role": "dependent-page",
+          "action": "verify-only",
+          "claim_id": "gw-community-signer-testing-surface"
+        },
+        {
+          "file": "v2/gateways/guides/payments-and-pricing/payment-guide.mdx",
+          "page_class": "guide",
+          "role": "canonical-owner",
+          "action": "verify-only",
+          "claim_id": "gw-community-signer-testing-surface"
+        },
+        {
+          "file": "v2/gateways/guides/payments-and-pricing/remote-signers.mdx",
+          "page_class": "guide",
+          "role": "dependent-page",
+          "action": "verify-only",
+          "claim_id": "gw-community-signer-testing-surface"
+        },
+        {
+          "file": "v2/gateways/guides/roadmap-and-funding/operator-support.mdx",
+          "page_class": "guide",
+          "role": "dependent-page",
+          "action": "verify-only",
+          "claim_id": "gw-community-signer-testing-surface"
+        }
+      ],
+      "contradictions": [],
+      "notes": "Phase 1 evidence should use repo-available community signals plus current docs, not live Discord scraping. This family keeps that role visible in the outputs."
+    },
+    {
+      "claim_id": "gw-startup-program-current",
+      "claim_family": "programme-availability",
+      "entity": "gateway",
+      "canonical_owner": "v2/gateways/guides/roadmap-and-funding/operator-support.mdx",
+      "registry_status": "time-sensitive",
+      "status": "time-sensitive",
+      "freshness_class": "review-periodic",
+      "confidence": "medium",
+      "summary": "Gateway support content should only describe the AI Video Startup Program with the level of certainty supported by current official and forum evidence.",
+      "evidence": [
+        {
+          "type": "official-page",
+          "ref": "https://www.livepeer.org/dev-hub",
+          "checked_on": "2026-03-16",
+          "ok": true,
+          "matched": true,
+          "summary": "official page matched"
+        },
+        {
+          "type": "forum-topic",
+          "ref": "https://forum.livepeer.org/t/2024-end-of-year-update-livepeer-cloud-spe/2678",
+          "checked_on": "2026-03-16",
+          "ok": true,
+          "matched": true,
+          "summary": "forum topic matched"
+        }
+      ],
+      "page_observations": [
+        {
+          "file": "v2/gateways/guides/roadmap-and-funding/operator-support.mdx",
+          "snippets": [
+            "The AI Video Startup Programme runs in cohorts."
+          ],
+          "values": []
+        },
+        {
+          "file": "v2/gateways/guides/roadmap-and-funding/spe-grant-model.mdx",
+          "snippets": [
+            "If you are an individual developer looking to experiment, the AI Video Startup Programme is the more appropriate route.",
+            "Gateway tutorials, operator support, community tooling ( ).",
+            "SPE vs AI Video Startup Programme These are two different things serving different purposes: SPE grant AI Video Startup Programme For Organisations building public benefit gateway infrastructure Individual developers or startups building AI powered products on Livepeer Funding source LPT treasury Foundation budget Accountability On chain governance + milestone reporting Foundation programme management Timeline Multi month proposals with defined terms Programme cohort Suitable for Public gateways, ecosystem tooling, clearinghouse infrastructure App development, using (not necessarily running) Livepeer Further reading Livepeer Forum (proposals and discussion): Livepeer governance overview: see the Community and Governance tab in these docs Cloud SPE gateway and tutorials: NaaP dashboard reference implementation: Next steps Commercial business models for gateway operators who do not need treasury funding."
+          ],
+          "values": []
+        }
+      ],
+      "propagation_queue": [
+        {
+          "file": "v2/gateways/guides/roadmap-and-funding/operator-support.mdx",
+          "page_class": "guide",
+          "role": "canonical-owner",
+          "action": "verify-only",
+          "claim_id": "gw-startup-program-current"
+        },
+        {
+          "file": "v2/gateways/guides/roadmap-and-funding/spe-grant-model.mdx",
+          "page_class": "guide",
+          "role": "dependent-page",
+          "action": "verify-only",
+          "claim_id": "gw-startup-program-current"
+        }
+      ],
+      "contradictions": [],
+      "notes": "Current availability and cohort timing must be checked against current public surfaces."
+    }
+  ],
+  "unverified_or_historical_claims": [],
+  "cross_page_contradictions": [
+    {
+      "claim_family": "clearinghouse-public-readiness",
+      "claim_id": "gw-clearinghouse-public-readiness",
+      "pages": [
+        {
+          "file": "v2/gateways/guides/payments-and-pricing/clearinghouse-guide.mdx",
+          "values": [
+            "general availability",
+            "public clearinghouse"
+          ],
+          "snippet": "Public Use Status No public clearinghouse service has reached general availability as of early 2026."
+        },
+        {
+          "file": "v2/gateways/guides/payments-and-pricing/payment-guide.mdx",
+          "values": [
+            "general availability",
+            "public clearinghouse"
+          ],
+          "snippet": "Once a public clearinghouse reaches GA, this becomes a pure API key sign up."
+        }
+      ],
+      "best_known_truth": "Gateway payment docs should describe clearinghouse status with current precision: the protocol is implemented, but no public clearinghouse is generally available yet. Community-hosted signer access is a testing bridge, not evidence of GA.",
+      "confidence": "low",
+      "recommended_action": "verify-more"
+    },
+    {
+      "claim_family": "community-signal",
+      "claim_id": "gw-discord-community-signal",
+      "pages": [
+        {
+          "file": "v2/gateways/guides/operator-considerations/production-gateways.mdx",
+          "values": [
+            "Community",
+            "community"
+          ],
+          "snippet": "This page documents real applications and community projects that are already running, gives you tooling references, and points to Foundation programmes for new builders."
+        },
+        {
+          "file": "v2/gateways/guides/roadmap-and-funding/operator-support.mdx",
+          "values": [
+            "community"
+          ],
+          "snippet": "The Livepeer ecosystem provides funding, programmes, and community resources for Gateway operators at every stage from first time builders to production platform operators."
+        }
+      ],
+      "best_known_truth": "When gateway docs rely on community support or current market/pricing conditions, the research runner should surface any repo-available Discord/community signals instead of treating chat as invisible.",
+      "confidence": "low",
+      "recommended_action": "verify-more"
+    },
+    {
+      "claim_family": "ecosystem-provider-examples",
+      "claim_id": "gw-spe-funded-provider-examples",
+      "pages": [
+        {
+          "file": "v2/gateways/guides/operator-considerations/production-gateways.mdx",
+          "values": [
+            "LLM",
+            "Livepeer Cloud",
+            "Streamplace"
+          ],
+          "snippet": "Gateway Operators Operator Model Gateway type Daydream Livepeer Product Commercial AI video product; subscription and per use pricing AI gateway embedded in product Livepeer Studio Livepeer Product Video API for developers; per minute pricing Video gateway (on chain) Public Livepeer Cloud SPE SPE Funded Free public gateways funded by treasury SPE grant AI and video Public LLM SPE SPE Funded LLM inference routing on Livepeer network AI gateway (LLM focused) Public Streamplace SPE Funded Decentralised livestreaming platform (AT Protocol); embedded gateway Video gateway embedded in product Commercial Products Daydream Livepeer Inc."
+        },
+        {
+          "file": "v2/gateways/guides/roadmap-and-funding/operator-support.mdx",
+          "values": [
+            "LLM",
+            "Livepeer Cloud"
+          ],
+          "snippet": "Funding Paths Special Purpose Entity (SPE) grants fund Gateway operators through the Livepeer treasury governance process."
+        },
+        {
+          "file": "v2/gateways/guides/roadmap-and-funding/spe-grant-model.mdx",
+          "values": [],
+          "snippet": "Some Livepeer Gateway operators are funded by the Livepeer treasury through a Special Purpose Entity (SPE) grant."
+        }
+      ],
+      "best_known_truth": "Gateway comparison and support pages should only present provider examples that are still backed by current SPE/governance or public project evidence.",
+      "confidence": "low",
+      "recommended_action": "verify-more"
+    }
+  ],
+  "propagation_queue": [
+    {
+      "file": "v2/gateways/guides/operator-considerations/production-gateways.mdx",
+      "page_class": "guide",
+      "role": "canonical-owner",
+      "action": "verify-only",
+      "claim_id": "gw-discord-community-signal"
+    },
+    {
+      "file": "v2/gateways/guides/operator-considerations/production-gateways.mdx",
+      "page_class": "guide",
+      "role": "canonical-owner",
+      "action": "verify-only",
+      "claim_id": "gw-spe-funded-provider-examples"
+    },
+    {
+      "file": "v2/gateways/guides/payments-and-pricing/clearinghouse-guide.mdx",
+      "page_class": "guide",
+      "role": "canonical-owner",
+      "action": "verify-only",
+      "claim_id": "gw-clearinghouse-public-readiness"
+    },
+    {
+      "file": "v2/gateways/guides/payments-and-pricing/clearinghouse-guide.mdx",
+      "page_class": "guide",
+      "role": "dependent-page",
+      "action": "verify-only",
+      "claim_id": "gw-community-signer-testing-surface"
+    },
+    {
+      "file": "v2/gateways/guides/payments-and-pricing/payment-guide.mdx",
+      "page_class": "guide",
+      "role": "dependent-page",
+      "action": "verify-only",
+      "claim_id": "gw-clearinghouse-public-readiness"
+    },
+    {
+      "file": "v2/gateways/guides/payments-and-pricing/payment-guide.mdx",
+      "page_class": "guide",
+      "role": "canonical-owner",
+      "action": "verify-only",
+      "claim_id": "gw-community-signer-testing-surface"
+    },
+    {
+      "file": "v2/gateways/guides/payments-and-pricing/payment-guide.mdx",
+      "page_class": "guide",
+      "role": "dependent-page",
+      "action": "update-now",
+      "claim_id": "gw-price-cap-role"
+    },
+    {
+      "file": "v2/gateways/guides/payments-and-pricing/pricing-strategy.mdx",
+      "page_class": "guide",
+      "role": "canonical-owner",
+      "action": "update-now",
+      "claim_id": "gw-price-cap-role"
+    },
+    {
+      "file": "v2/gateways/guides/payments-and-pricing/remote-signers.mdx",
+      "page_class": "guide",
+      "role": "dependent-page",
+      "action": "verify-only",
+      "claim_id": "gw-community-signer-testing-surface"
+    },
+    {
+      "file": "v2/gateways/guides/roadmap-and-funding/naap-multi-tenancy.mdx",
+      "page_class": "guide",
+      "role": "dependent-page",
+      "action": "update-now",
+      "claim_id": "gw-price-cap-role"
+    },
+    {
+      "file": "v2/gateways/guides/roadmap-and-funding/operator-support.mdx",
+      "page_class": "guide",
+      "role": "dependent-page",
+      "action": "verify-only",
+      "claim_id": "gw-clearinghouse-public-readiness"
+    },
+    {
+      "file": "v2/gateways/guides/roadmap-and-funding/operator-support.mdx",
+      "page_class": "guide",
+      "role": "dependent-page",
+      "action": "verify-only",
+      "claim_id": "gw-community-signer-testing-surface"
+    },
+    {
+      "file": "v2/gateways/guides/roadmap-and-funding/operator-support.mdx",
+      "page_class": "guide",
+      "role": "dependent-page",
+      "action": "verify-only",
+      "claim_id": "gw-discord-community-signal"
+    },
+    {
+      "file": "v2/gateways/guides/roadmap-and-funding/operator-support.mdx",
+      "page_class": "guide",
+      "role": "dependent-page",
+      "action": "verify-only",
+      "claim_id": "gw-spe-funded-provider-examples"
+    },
+    {
+      "file": "v2/gateways/guides/roadmap-and-funding/operator-support.mdx",
+      "page_class": "guide",
+      "role": "canonical-owner",
+      "action": "verify-only",
+      "claim_id": "gw-startup-program-current"
+    },
+    {
+      "file": "v2/gateways/guides/roadmap-and-funding/spe-grant-model.mdx",
+      "page_class": "guide",
+      "role": "dependent-page",
+      "action": "verify-only",
+      "claim_id": "gw-spe-funded-provider-examples"
+    },
+    {
+      "file": "v2/gateways/guides/roadmap-and-funding/spe-grant-model.mdx",
+      "page_class": "guide",
+      "role": "dependent-page",
+      "action": "verify-only",
+      "claim_id": "gw-startup-program-current"
+    }
+  ],
+  "evidence_sources": [
+    {
+      "claim_id": "gw-clearinghouse-public-readiness",
+      "type": "github-pr",
+      "ref": "https://github.com/livepeer/go-livepeer/pull/3791",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "GitHub evidence matched"
+    },
+    {
+      "claim_id": "gw-clearinghouse-public-readiness",
+      "type": "github-pr",
+      "ref": "https://github.com/livepeer/go-livepeer/pull/3822",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "GitHub evidence matched"
+    },
+    {
+      "claim_id": "gw-clearinghouse-public-readiness",
+      "type": "repo-file",
+      "ref": "v2/gateways/guides/payments-and-pricing/clearinghouse-guide.mdx",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "repo evidence matched"
+    },
+    {
+      "claim_id": "gw-community-signer-testing-surface",
+      "type": "repo-discord-signal",
+      "ref": ".github/workflows/discord-issue-intake.yml",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "repo Discord/community signal matched"
+    },
+    {
+      "claim_id": "gw-community-signer-testing-surface",
+      "type": "repo-file",
+      "ref": "v2/gateways/guides/payments-and-pricing/payment-guide.mdx",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "repo evidence matched"
+    },
+    {
+      "claim_id": "gw-community-signer-testing-surface",
+      "type": "repo-file",
+      "ref": "v2/gateways/guides/roadmap-and-funding/operator-support.mdx",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "repo evidence matched"
+    },
+    {
+      "claim_id": "gw-discord-community-signal",
+      "type": "repo-file",
+      "ref": ".github/workflows/discord-issue-intake.yml",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "repo evidence matched"
+    },
+    {
+      "claim_id": "gw-price-cap-role",
+      "type": "repo-file",
+      "ref": "v2/gateways/guides/payments-and-pricing/pricing-strategy.mdx",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "repo evidence matched"
+    },
+    {
+      "claim_id": "gw-price-cap-role",
+      "type": "repo-file",
+      "ref": "v2/gateways/guides/roadmap-and-funding/naap-multi-tenancy.mdx",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "repo evidence matched"
+    },
+    {
+      "claim_id": "gw-spe-funded-provider-examples",
+      "type": "forum-topic",
+      "ref": "https://forum.livepeer.org/t/spe-milestone-report/3035",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "forum topic matched"
+    },
+    {
+      "claim_id": "gw-startup-program-current",
+      "type": "official-page",
+      "ref": "https://www.livepeer.org/dev-hub",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "official page matched"
+    },
+    {
+      "claim_id": "gw-startup-program-current",
+      "type": "forum-topic",
+      "ref": "https://forum.livepeer.org/t/2024-end-of-year-update-livepeer-cloud-spe/2678",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "forum topic matched"
+    }
+  ],
+  "validation": {
+    "target_files": 6,
+    "claim_families": 6,
+    "contradictions": 3,
+    "evidence_sources": 12
+  }
+}

--- a/tasks/reports/repo-ops/2026-03-16-page-content-research-pilot-gateway-pricing-clearinghouse.md
+++ b/tasks/reports/repo-ops/2026-03-16-page-content-research-pilot-gateway-pricing-clearinghouse.md
@@ -1,0 +1,164 @@
+# Docs Page Research Report
+
+## Scope
+
+- `v2/gateways/guides/payments-and-pricing/clearinghouse-guide.mdx`
+- `v2/gateways/guides/payments-and-pricing/payment-guide.mdx`
+- `v2/gateways/guides/payments-and-pricing/pricing-strategy.mdx`
+- `v2/gateways/guides/payments-and-pricing/remote-signers.mdx`
+- `v2/gateways/guides/roadmap-and-funding/naap-multi-tenancy.mdx`
+- `v2/gateways/guides/roadmap-and-funding/operator-support.mdx`
+
+## Claims Reviewed
+
+- `v2/gateways/guides/payments-and-pricing/clearinghouse-guide.mdx`
+  - claim families: `gw-clearinghouse-public-readiness`, `gw-community-signer-testing-surface`
+  - extracted: \{ / TODO: Terminology Validation: Ensure the terminology and definitions used in this page is consistent with the resources/glossary terminology Verify: ~~Mermaid diagrams use theme colours~~ (N/A ASCII diagram kept intentionally) ~~Fontawesome icons are used on accordions and tabs~~ ~~Tables use StyledTable component~~ ~~No em dashes are used (instead use standard )~~ UK spelling is used ~~Headers are concise and technical no long headers or questions (aim for max 3 words)~~ ~~CustomDivider is used~~ Placeholders for Media & Video Resources are in comments with a TODO for a human.
+  - extracted: (N/A) ~~REVIEW flags are in JSX flags for a human.~~ Human: H1 removed (was repeating frontmatter title) "Why clearinghouses exist" removed (redundant with payment guide router) "Clearinghouse vs remote signer" trimmed to brief statement with link PM internals cross referenced instead of duplicated Voice converted to entity led throughout Port 8937 → 8935 Broken link payment paths → payment guide Em dashes removed /\} Protocol status: The clearinghouse protocol was implemented in and and is operational.
+  - extracted: Public Use Status No public clearinghouse service has reached general availability as of early 2026.
+  - extracted: Note that Payment Clearinghouses are designed to become independent economic actors in the Livepeer Network providing services for a fee to end users.
+- `v2/gateways/guides/payments-and-pricing/payment-guide.mdx`
+  - claim families: `gw-clearinghouse-public-readiness`, `gw-community-signer-testing-surface`, `gw-price-cap-role`
+  - extracted: Livepeer fees between Gateways and Orchestrators are settled in ETH on Arbitrum One via probabilistic micropayment (PM) tickets.
+  - extracted: Gateways can configure price caps in wei or in USD (converted at runtime via a Chainlink price feed).
+  - extracted: Next step: Video On chain video gateway \} icon="link" Video transcoding requires the on chain self managed path.
+  - extracted: Remote signing is not supported for video workloads.
+- `v2/gateways/guides/payments-and-pricing/pricing-strategy.mdx`
+  - claim families: `gw-price-cap-role`
+  - extracted: Pricing Mechanics Livepeer workload fees are denominated in ETH (wei), with an option to configure caps in USD (converted at runtime via a ).
+  - extracted: Query current rates via or before setting caps.
+  - extracted: The gateway calculates fees based on the resolution and length of each transcoded segment.
+  - extracted: Video transcoding requires on chain operational mode.
+- `v2/gateways/guides/payments-and-pricing/remote-signers.mdx`
+  - claim families: `gw-community-signer-testing-surface`
+  - extracted: Current scope: Realtime AI Video (live video to video) workloads only.
+  - extracted: Remote signing is not supported for video transcoding.
+  - extracted: Remote signers were introduced in and , in January 2026.
+  - extracted: signature When a Gateway contacts an Orchestrator, it must provide an authentication signature.
+- `v2/gateways/guides/roadmap-and-funding/naap-multi-tenancy.mdx`
+  - claim families: `gw-price-cap-role`
+  - extracted: From the Discord discussion that defined this model: "The user never interacts with Livepeer contracts.
+  - extracted: Multi tenant architecture Authentication flow Tenant isolation Each customer (tenant) operates within boundaries set by their API key: Isolation concern How NaaP handles it Request quotas Per key rate limits (requests/minute, requests/day) Usage caps Per key maximum usage (pixels, inferences, minutes) Billing separation Per key usage tracking for independent invoicing Failure isolation One customer exceeding quota does not affect others Data separation Per key logs and metrics Orchestrator affinity For premium tenants, you can configure orchestrator routing preferences: Route premium customers to high tier orchestrators (lower latency, higher reliability) Route budget customers to standard orchestrators Route specific workload types to capability matched orchestrators This is configured at the middleware layer using or per request path.
+  - extracted: Building the product layer Option 1: Use the NaaP reference implementation The fastest path.
+  - extracted: What you get out of the box: JWT auth via SIWE API key generation and management Usage tracking per key Dashboard UI What you still need to build: Payment integration (Stripe, crypto billing, etc.) Custom pricing tiers Customer onboarding flow Production monitoring and alerting Option 2: Build your own product layer If your platform has specific requirements that NaaP does not cover, build your own using standard middleware patterns.
+- `v2/gateways/guides/roadmap-and-funding/operator-support.mdx`
+  - claim families: `gw-clearinghouse-public-readiness`, `gw-community-signer-testing-surface`, `gw-discord-community-signal`, `gw-spe-funded-provider-examples`, `gw-startup-program-current`
+  - extracted: The Livepeer ecosystem provides funding, programmes, and community resources for Gateway operators at every stage from first time builders to production platform operators.
+  - extracted: Currently funded SPEs operating Gateways: SPE What it funds Status Livepeer Cloud SPE Free public AI and video Gateways Active LLM SPE LLM inference routing on the Livepeer network Active How to propose an SPE: 1.
+  - extracted: Engage the community on and 2.
+  - extracted: Write a proposal with clear public benefit, verifiable milestones, and realistic budget 3.
+
+## Verified Claims
+
+- `gw-price-cap-role` (verified, high)
+  - owner: `v2/gateways/guides/payments-and-pricing/pricing-strategy.mdx`
+  - summary: Gateway pricing docs should keep the role of caps aligned: on-chain caps act as marketplace filters, while off-chain caps act as safety ceilings for known orchestrators. The same claim family also covers how `-ignoreMaxPriceIfNeeded` changes job-failure behavior.
+
+## Conflicted Claims
+
+- `gw-clearinghouse-public-readiness` (conflicted, low)
+  - owner: `v2/gateways/guides/payments-and-pricing/clearinghouse-guide.mdx`
+  - summary: Gateway payment docs should describe clearinghouse status with current precision: the protocol is implemented, but no public clearinghouse is generally available yet. Community-hosted signer access is a testing bridge, not evidence of GA.
+- `gw-discord-community-signal` (conflicted, low)
+  - owner: `v2/gateways/guides/operator-considerations/production-gateways.mdx`
+  - summary: When gateway docs rely on community support or current market/pricing conditions, the research runner should surface any repo-available Discord/community signals instead of treating chat as invisible.
+- `gw-spe-funded-provider-examples` (conflicted, low)
+  - owner: `v2/gateways/guides/operator-considerations/production-gateways.mdx`
+  - summary: Gateway comparison and support pages should only present provider examples that are still backed by current SPE/governance or public project evidence.
+
+## Time-Sensitive Claims
+
+- `gw-community-signer-testing-surface` (time-sensitive, medium)
+  - owner: `v2/gateways/guides/payments-and-pricing/payment-guide.mdx`
+  - summary: Docs that mention the Elite Encoder community signer should keep its role narrow and explicit: a repo/community-backed testing surface for early off-chain experimentation, not a generic production recommendation.
+- `gw-startup-program-current` (time-sensitive, medium)
+  - owner: `v2/gateways/guides/roadmap-and-funding/operator-support.mdx`
+  - summary: Gateway support content should only describe the AI Video Startup Program with the level of certainty supported by current official and forum evidence.
+
+## Unverified / Historical Claims
+
+- None
+
+## Cross-Page Contradictions
+
+- `gw-clearinghouse-public-readiness` (clearinghouse-public-readiness)
+  - action: verify-more
+  - `v2/gateways/guides/payments-and-pricing/clearinghouse-guide.mdx`: general availability, public clearinghouse
+  - `v2/gateways/guides/payments-and-pricing/payment-guide.mdx`: general availability, public clearinghouse
+- `gw-discord-community-signal` (community-signal)
+  - action: verify-more
+  - `v2/gateways/guides/operator-considerations/production-gateways.mdx`: Community, community
+  - `v2/gateways/guides/roadmap-and-funding/operator-support.mdx`: community
+- `gw-spe-funded-provider-examples` (ecosystem-provider-examples)
+  - action: verify-more
+  - `v2/gateways/guides/operator-considerations/production-gateways.mdx`: LLM, Livepeer Cloud, Streamplace
+  - `v2/gateways/guides/roadmap-and-funding/operator-support.mdx`: LLM, Livepeer Cloud
+  - `v2/gateways/guides/roadmap-and-funding/spe-grant-model.mdx`: Some Livepeer Gateway operators are funded by the Livepeer treasury through a Special Purpose Entity (SPE) grant.
+
+## Propagation Queue
+
+| File | Class | Role | Action | Claim |
+|---|---|---|---|---|
+| `v2/gateways/guides/operator-considerations/production-gateways.mdx` | guide | canonical-owner | verify-only | `gw-discord-community-signal` |
+| `v2/gateways/guides/operator-considerations/production-gateways.mdx` | guide | canonical-owner | verify-only | `gw-spe-funded-provider-examples` |
+| `v2/gateways/guides/payments-and-pricing/clearinghouse-guide.mdx` | guide | canonical-owner | verify-only | `gw-clearinghouse-public-readiness` |
+| `v2/gateways/guides/payments-and-pricing/clearinghouse-guide.mdx` | guide | dependent-page | verify-only | `gw-community-signer-testing-surface` |
+| `v2/gateways/guides/payments-and-pricing/payment-guide.mdx` | guide | dependent-page | verify-only | `gw-clearinghouse-public-readiness` |
+| `v2/gateways/guides/payments-and-pricing/payment-guide.mdx` | guide | canonical-owner | verify-only | `gw-community-signer-testing-surface` |
+| `v2/gateways/guides/payments-and-pricing/payment-guide.mdx` | guide | dependent-page | update-now | `gw-price-cap-role` |
+| `v2/gateways/guides/payments-and-pricing/pricing-strategy.mdx` | guide | canonical-owner | update-now | `gw-price-cap-role` |
+| `v2/gateways/guides/payments-and-pricing/remote-signers.mdx` | guide | dependent-page | verify-only | `gw-community-signer-testing-surface` |
+| `v2/gateways/guides/roadmap-and-funding/naap-multi-tenancy.mdx` | guide | dependent-page | update-now | `gw-price-cap-role` |
+| `v2/gateways/guides/roadmap-and-funding/operator-support.mdx` | guide | dependent-page | verify-only | `gw-clearinghouse-public-readiness` |
+| `v2/gateways/guides/roadmap-and-funding/operator-support.mdx` | guide | dependent-page | verify-only | `gw-community-signer-testing-surface` |
+| `v2/gateways/guides/roadmap-and-funding/operator-support.mdx` | guide | dependent-page | verify-only | `gw-discord-community-signal` |
+| `v2/gateways/guides/roadmap-and-funding/operator-support.mdx` | guide | dependent-page | verify-only | `gw-spe-funded-provider-examples` |
+| `v2/gateways/guides/roadmap-and-funding/operator-support.mdx` | guide | canonical-owner | verify-only | `gw-startup-program-current` |
+| `v2/gateways/guides/roadmap-and-funding/spe-grant-model.mdx` | guide | dependent-page | verify-only | `gw-spe-funded-provider-examples` |
+| `v2/gateways/guides/roadmap-and-funding/spe-grant-model.mdx` | guide | dependent-page | verify-only | `gw-startup-program-current` |
+
+## Evidence Sources
+
+- `gw-clearinghouse-public-readiness` → github-pr: https://github.com/livepeer/go-livepeer/pull/3791
+  - checked: 2026-03-16
+  - result: GitHub evidence matched
+- `gw-clearinghouse-public-readiness` → github-pr: https://github.com/livepeer/go-livepeer/pull/3822
+  - checked: 2026-03-16
+  - result: GitHub evidence matched
+- `gw-clearinghouse-public-readiness` → repo-file: v2/gateways/guides/payments-and-pricing/clearinghouse-guide.mdx
+  - checked: 2026-03-16
+  - result: repo evidence matched
+- `gw-community-signer-testing-surface` → repo-discord-signal: .github/workflows/discord-issue-intake.yml
+  - checked: 2026-03-16
+  - result: repo Discord/community signal matched
+- `gw-community-signer-testing-surface` → repo-file: v2/gateways/guides/payments-and-pricing/payment-guide.mdx
+  - checked: 2026-03-16
+  - result: repo evidence matched
+- `gw-community-signer-testing-surface` → repo-file: v2/gateways/guides/roadmap-and-funding/operator-support.mdx
+  - checked: 2026-03-16
+  - result: repo evidence matched
+- `gw-discord-community-signal` → repo-file: .github/workflows/discord-issue-intake.yml
+  - checked: 2026-03-16
+  - result: repo evidence matched
+- `gw-price-cap-role` → repo-file: v2/gateways/guides/payments-and-pricing/pricing-strategy.mdx
+  - checked: 2026-03-16
+  - result: repo evidence matched
+- `gw-price-cap-role` → repo-file: v2/gateways/guides/roadmap-and-funding/naap-multi-tenancy.mdx
+  - checked: 2026-03-16
+  - result: repo evidence matched
+- `gw-spe-funded-provider-examples` → forum-topic: https://forum.livepeer.org/t/spe-milestone-report/3035
+  - checked: 2026-03-16
+  - result: forum topic matched
+- `gw-startup-program-current` → official-page: https://www.livepeer.org/dev-hub
+  - checked: 2026-03-16
+  - result: official page matched
+- `gw-startup-program-current` → forum-topic: https://forum.livepeer.org/t/2024-end-of-year-update-livepeer-cloud-spe/2678
+  - checked: 2026-03-16
+  - result: forum topic matched
+
+## Validation
+
+- target_files: 6
+- claim_families: 6
+- contradictions: 3
+- evidence_sources: 12

--- a/tasks/reports/repo-ops/2026-03-16-page-content-research-pilot-orchestrator-sla-session-cap.json
+++ b/tasks/reports/repo-ops/2026-03-16-page-content-research-pilot-orchestrator-sla-session-cap.json
@@ -1,0 +1,1838 @@
+{
+  "generated_at": "2026-03-16T03:50:18.849Z",
+  "scope": {
+    "target_files": [
+      "v2/orchestrators/guides/ai-and-job-workloads/ai-workloads-guide.mdx",
+      "v2/orchestrators/guides/ai-and-job-workloads/batch-ai-setup.mdx",
+      "v2/orchestrators/guides/ai-and-job-workloads/video-transcoding.mdx",
+      "v2/orchestrators/guides/deployment-details/dual-workload-setup.mdx",
+      "v2/orchestrators/guides/deployment-details/requirements.mdx",
+      "v2/orchestrators/guides/operator-considerations/business-case.mdx"
+    ]
+  },
+  "claims_reviewed": [
+    {
+      "file": "v2/orchestrators/guides/ai-and-job-workloads/ai-workloads-guide.mdx",
+      "extracted_claims": [
+        "Livepeer's AI subnet launched in Q3 2024 and has grown to become the primary source of new fee revenue for orchestrators.",
+        "AI pipelines run alongside your existing node using dedicated AI Runner containers.",
+        "Your orchestrator advertises capabilities — which pipelines it supports and at what price — and gateways route matching jobs to it.",
+        "When a gateway selects your orchestrator, it is because your combination of capability, pricing, latency, and uptime made you the best option for that specific request.",
+        "The key fields that determine whether you receive AI jobs are: Field What it controls Operator implication Which pipelines you support Declare every pipeline in Your price per pipeline and model Must be below the gateway's GPU specs advertised to the gateway Auto populated by go livepeer Base transcoding price Controls transcoding job eligibility The price filter is a hard gate.",
+        "If your advertised price for a pipeline exceeds the gateway's maximum, you will not receive jobs from that gateway for that pipeline, regardless of how capable your hardware is.",
+        "For the complete list of supported pipelines and their model architectures, see in the Developers section.",
+        "Live video streams in, processed video streams out with sub 100ms latency.",
+        "Comparison Batch AI Real time AI Latency target Seconds per request &lt;100ms per frame Input type Text, image, audio, video files Live video stream (WebRTC) Output type Image, text, audio, video Processed live video stream Runtime containers + ComfyStream Min VRAM 4–24 GB depending on pipeline 24 GB recommended Good for High throughput, varied workloads Streaming AI effects, Cascade pipeline Entry hardware RTX 2060 (8 GB) for LLM; RTX 3090/4090 for diffusion RTX 4090 (24 GB) or better Pricing unit Per pixel, per token, or per ms Per frame AI pipeline types Livepeer's AI worker supports ten pipeline types.",
+        "Each pipeline handles a specific class of inference task, with its own model format, VRAM floor, and pricing unit.",
+        "The most widely used batch AI pipeline on the network.",
+        "Minimum VRAM: 24 GB Pricing unit: Per output pixel Recommended model: Typical hardware: RTX 3090, RTX 4090, A5000 Diffusion models (Stable Diffusion, SDXL variants) run natively on the managed container."
+      ],
+      "matched_claim_families": [
+        "orch-commercial-model-warmth"
+      ]
+    },
+    {
+      "file": "v2/orchestrators/guides/ai-and-job-workloads/batch-ai-setup.mdx",
+      "extracted_claims": [
+        "You earn per unit fees for every successful job.",
+        "This guide covers everything needed to run batch AI pipelines: configuring , choosing and loading models, running the Ollama LLM runner, connecting BYOC external containers, setting pricing, and diagnosing problems.",
+        "Prerequisites Before configuring AI pipelines, ensure: go livepeer is running with the flag enabled NVIDIA Container Toolkit is installed and working ( ) Docker is running and can access your GPUs You have a file or know where you want to create one How the AI worker runs pipelines When go livepeer starts with , it reads and starts Docker containers for each configured pipeline: The standard container image is .",
+        "Except for the pipeline — which uses a separate Ollama based runner — all batch pipelines use this image.",
+        "aiModels.json — full reference is the single file that controls everything about your AI worker: which pipelines you run, which models you load, whether they stay warm in VRAM, and how you price each job.",
+        "Default location: Override location: set with flag at startup Minimal working example This single entry is enough to start earning from the pipeline with a competitive warm model.",
+        "Complete field reference Field Type Required Description string ✅ Pipeline identifier.",
+        "Must exactly match a supported pipeline name.",
+        "Eliminates cold start latency.",
+        "Container must expose a endpoint.",
+        "integer Max concurrent inference tasks from this container.",
+        "must match the HuggingFace model ID exactly, including capitalisation and the organisation prefix."
+      ],
+      "matched_claim_families": [
+        "orch-commercial-model-warmth"
+      ]
+    },
+    {
+      "file": "v2/orchestrators/guides/ai-and-job-workloads/video-transcoding.mdx",
+      "extracted_claims": [
+        "How transcoding works When a broadcaster sends a live stream to a Livepeer gateway, the gateway segments the stream into roughly 2 second chunks and routes each segment to an orchestrator.",
+        "You set your price with the flag; by default is 1, meaning you charge in wei per individual output pixel.",
+        "This charges 500 wei per output pixel.",
+        "Option B: USD pricing (go livepeer 0.8.0+) USD pricing pegs your transcoding fee to a dollar amount and automatically converts to wei via a .",
+        "Add as a suffix to : Tips for USD pricing: supports exponential notation ( ); does not Use to keep as a readable decimal The Chainlink ETH/USD feed on Arbitrum is auto configured for mainnet — no additional setup required Livepeer Studio pegs its to USD, so USD pricing on your node stays in sync with the gateway side automatically Custom currency or non Arbitrum networks: The Chainlink feed can be overridden with .",
+        "Ticket redemption is a gas transaction on Arbitrum — when gas prices rise, the overhead as a percentage of ticket face value rises, which makes tickets less profitable to redeem.",
+        "The auto adjustment compensates: Base price Redemption overhead Advertised price 1000 wei/px 1% 1010 wei/px 1000 wei/px 20% 1200 wei/px 1000 wei/px 50% 1500 wei/px This mechanism keeps your effective earnings stable when Arbitrum gas spikes.",
+        "Checking current market rates: Compare your price to active orchestrators on .",
+        "Filter by active set members and look at advertised price.",
+        "Session limits Your session limit is the maximum number of concurrent transcoding sessions your node accepts.",
+        "The default is 10 sessions.",
+        "Set it via : The right value is the minimum of your hardware capacity and your bandwidth capacity."
+      ],
+      "matched_claim_families": [
+        "orch-consumer-nvenc-session-cap"
+      ]
+    },
+    {
+      "file": "v2/orchestrators/guides/deployment-details/dual-workload-setup.mdx",
+      "extracted_claims": [
+        "Because these two execution paths use separate hardware resources, adding AI capabilities to a running video node requires no changes to your on chain registration, staking, or existing transcoding configuration.",
+        "Dual Mode requires Linux.",
+        "Video only AI only Dual Mode Revenue streams ETH transcoding fees + LPT rewards ETH AI inference fees Both streams simultaneously Pricing config (wei per pixel) per pipeline Both and GPU execution path NVENC/NVDEC hardware blocks CUDA compute cores Both paths, independent queues VRAM requirement Minimal (frame buffers only) 8 24 GB depending on model 16 GB recommended; 8 GB viable for LLM only pipelines Active set Required for video job eligibility Not required for AI job eligibility Required for video; AI routes via capability advertisement OS support Linux, Windows Linux only Linux only Before You Start Confirm these prerequisites before starting: Hardware: NVIDIA GPU with 16 GB VRAM or more.",
+        "8 GB is sufficient for LLM pipelines via the Ollama runner.",
+        "Most diffusion model pipelines require 16 GB or more.",
+        "For video transcoding: Your Arbitrum wallet is funded with ETH for gas, your node is activated via , and you are staked with enough LPT to be eligible for the active set.",
+        "Setup Select the path that matches your current state.",
+        "Model weights must be present on the host machine before go livepeer starts the AI Runner containers.",
+        "For all supported pipelines, model IDs, and VRAM requirements, see .",
+        "Create with at least one pipeline entry.",
+        "Each entry declares a pipeline, model, price, and whether the model stays warm in VRAM between jobs.",
+        "The value above is illustrative — check current per pipeline market rates on before setting your own."
+      ],
+      "matched_claim_families": [
+        "orch-commercial-model-warmth"
+      ]
+    },
+    {
+      "file": "v2/orchestrators/guides/deployment-details/requirements.mdx",
+      "extracted_claims": [
+        "This page covers GPU support policy, session limits by card tier, VRAM requirements by AI pipeline, the minimum system stack, capacity testing, and the checklist to run before activating on the network.",
+        "GPU Vendor Support NVIDIA is the supported GPU vendor for go livepeer.",
+        "AMD and Intel GPUs are not supported for hardware accelerated transcoding or AI inference.",
+        "NVIDIA CUDA is required for both NVENC video transcoding and all AI inference pipelines.",
+        "Driver requirements Verify NVIDIA drivers are installed and current before anything else: If fails or is missing, install NVIDIA drivers for the target OS before proceeding.",
+        "Minimum CUDA version: 12.0.",
+        "Earlier versions are not supported by the AI runner containers.",
+        "NVENC/NVDEC Session Limits NVIDIA consumer GPUs enforce concurrent encoding session limits via NVENC (hardware video encoder) and NVDEC (hardware video decoder).",
+        "Consumer NVIDIA cards (GeForce RTX series) are capped at a small number of concurrent NVENC sessions by default.",
+        "Consumer cards are typically limited to 2 3 concurrent NVENC encode sessions before throttling or failing with errors.",
+        "Check the official NVIDIA matrix for exact limits per generation: GPU tier NVENC session cap Notes GeForce RTX (consumer) 2 3 concurrent sessions Hardware licensing cap; check matrix for exact figure per generation RTX Workstation / Quadro Uncapped Commercial hardware, no artificial limit NVIDIA A series (A100, A4000, A5000) Uncapped Data centre; full concurrent session headroom NVIDIA L series (L4, L40) Uncapped Data centre NVIDIA H series (H100) Uncapped Data centre; highest throughput tier Exact session counts can vary by GPU generation and NVIDIA policy.",
+        "Large VRAM is not required model loading is not involved."
+      ],
+      "matched_claim_families": [
+        "orch-bandwidth-per-stream-planning",
+        "orch-batch-ai-vram-threshold",
+        "orch-business-case-cost-viability",
+        "orch-consumer-nvenc-session-cap",
+        "orch-session-limit-default"
+      ]
+    },
+    {
+      "file": "v2/orchestrators/guides/operator-considerations/business-case.mdx",
+      "extracted_claims": [
+        "Most Orchestrator operators start by thinking about LPT inflation rewards.",
+        "Commercial operators think primarily about ETH service fees.",
+        "Dimension Hobbyist operator Commercial operator Primary income LPT inflation rewards ETH service fees from job processing Revenue lever Total bonded stake Job volume, pricing discipline, uptime Uptime requirement ~95% (reward calls + basic availability) 99%+ (SLA driven, continuous monitoring) Gateway relationship Passive wait to be selected by price and stake Active direct relationships, per Gateway pricing Hardware approach Existing hardware repurposed Dedicated investment, redundancy planned Monitoring Periodic checks, Prometheus optional Automated alerting, SLA dashboards Model loading Load on demand; cold starts acceptable Pre loaded and warm; cold starts are SLA failures Neither model is superior they reflect different operator goals and capabilities.",
+        "Many operators run a hybrid: inflation rewards provide a base, service fees from well served application workloads provide the upside.",
+        "Why Service Fees Scale For commercial operators, ETH service fees not LPT inflation rewards are the primary economic lever.",
+        "The reason is straightforward: fee income scales with workload volume, while inflation rewards scale with stake.",
+        "An Orchestrator with significant staked LPT earns a fixed percentage of the round's inflation regardless of how many jobs it processes.",
+        "For an Orchestrator actively serving a high volume Gateway a streaming platform, an AI product, or a real time video application monthly ETH fee income from job processing can exceed LPT inflation income by a substantial margin.",
+        "Commercial fee income is variable it depends on Gateway demand, job mix, and market pricing conditions.",
+        "Inflation rewards are predictable by stake.",
+        "Most commercial operators treat inflation as a base and fees as the variable upside.",
+        "What Commercial Operation Requires Serving application workloads at commercial scale imposes concrete operational requirements beyond what is needed for passive inflation earning."
+      ],
+      "matched_claim_families": [
+        "orch-active-set-threshold",
+        "orch-bandwidth-per-stream-planning",
+        "orch-batch-ai-vram-threshold",
+        "orch-business-case-cost-viability",
+        "orch-commercial-model-warmth",
+        "orch-pool-vs-solo-prerequisites",
+        "orch-reward-profitability-threshold"
+      ]
+    }
+  ],
+  "verified_claims": [],
+  "conflicted_claims": [
+    {
+      "claim_id": "orch-batch-ai-vram-threshold",
+      "claim_family": "hardware-vram-minimums",
+      "entity": "orchestrator",
+      "canonical_owner": "v2/orchestrators/guides/deployment-details/requirements.mdx",
+      "registry_status": "conflicted",
+      "status": "conflicted",
+      "freshness_class": "review-on-change",
+      "confidence": "low",
+      "summary": "Docs disagree on the practical VRAM minimum for batch AI and real-time AI workloads. Hardware and setup pages should not present conflicting minimums as equally current.",
+      "evidence": [
+        {
+          "type": "repo-file",
+          "ref": "v2/orchestrators/guides/deployment-details/requirements.mdx",
+          "checked_on": "2026-03-16",
+          "ok": true,
+          "matched": true,
+          "summary": "repo evidence matched"
+        },
+        {
+          "type": "repo-file",
+          "ref": "v2/orchestrators/setup/rcs-requirements.mdx",
+          "checked_on": "2026-03-16",
+          "ok": true,
+          "matched": true,
+          "summary": "repo evidence matched"
+        }
+      ],
+      "page_observations": [
+        {
+          "file": "v2/orchestrators/guides/deployment-details/requirements.mdx",
+          "snippets": [
+            "This page covers GPU support policy, session limits by card tier, VRAM requirements by AI pipeline, the minimum system stack, capacity testing, and the checklist to run before activating on the network.",
+            "Large VRAM is not required model loading is not involved.",
+            "Batch AI inference AI inference requires VRAM.",
+            "Full pipeline by pipeline VRAM figures are in ."
+          ],
+          "values": []
+        },
+        {
+          "file": "v2/orchestrators/guides/deployment-details/setup-options.mdx",
+          "snippets": [],
+          "values": []
+        },
+        {
+          "file": "v2/orchestrators/guides/operator-considerations/business-case.mdx",
+          "snippets": [
+            "This requires: Automated monitoring with immediate alerts on node failure Automated restart and recovery Stable, redundant connectivity (not shared home broadband) Consistent power supply (UPS or colocation) Hardware health monitoring (GPU temperatures, VRAM utilisation) Model warm up management For AI inference workloads, cold model starts (loading a model from disk into VRAM on first request) introduce latency that breaks user facing SLAs.",
+            "The practical implication: the VRAM requirements for commercial AI operation are determined by the sum of all models that must be simultaneously loaded, not just the largest single model.",
+            "Prioritise: Pipelines with few available Orchestrators and active demand High VRAM models that exclude commodity GPU competition Cascade (real time AI) pipelines if hardware supports it higher per job value Commercial pricing differs from setting a generic .",
+            "This is the natural next step for video Orchestrators who invest in high VRAM GPUs."
+          ],
+          "values": []
+        },
+        {
+          "file": "v2/orchestrators/setup/rcs-requirements.mdx",
+          "snippets": [
+            "Hardware NVIDIA GPU with NVENC/NVDEC support installed and visible via NVIDIA driver version 525+ (Linux) or 527+ (Windows) CUDA 12.0+ installed (or plan to use the Docker image, which bundles CUDA) CPU: 4+ cores minimum, 8+ recommended RAM: 16 GB minimum, 32 GB recommended Storage: 100 GB SSD minimum (NVMe recommended for AI model weights) For AI inference, VRAM is the primary constraint: 8 GB for LLM only, 16 GB for basic batch AI, 24 GB+ for the full pipeline suite."
+          ],
+          "values": [
+            "16 GB",
+            "24 GB",
+            "8 GB"
+          ]
+        }
+      ],
+      "propagation_queue": [
+        {
+          "file": "v2/orchestrators/guides/deployment-details/requirements.mdx",
+          "page_class": "guide",
+          "role": "canonical-owner",
+          "action": "verify-only",
+          "claim_id": "orch-batch-ai-vram-threshold"
+        },
+        {
+          "file": "v2/orchestrators/guides/deployment-details/setup-options.mdx",
+          "page_class": "guide",
+          "role": "dependent-page",
+          "action": "verify-only",
+          "claim_id": "orch-batch-ai-vram-threshold"
+        },
+        {
+          "file": "v2/orchestrators/guides/operator-considerations/business-case.mdx",
+          "page_class": "guide",
+          "role": "dependent-page",
+          "action": "verify-only",
+          "claim_id": "orch-batch-ai-vram-threshold"
+        },
+        {
+          "file": "v2/orchestrators/setup/rcs-requirements.mdx",
+          "page_class": "setup",
+          "role": "dependent-page",
+          "action": "verify-only",
+          "claim_id": "orch-batch-ai-vram-threshold"
+        }
+      ],
+      "contradictions": [
+        {
+          "claim_family": "hardware-vram-minimums",
+          "claim_id": "orch-batch-ai-vram-threshold",
+          "pages": [
+            {
+              "file": "v2/orchestrators/guides/deployment-details/requirements.mdx",
+              "values": [],
+              "snippet": "This page covers GPU support policy, session limits by card tier, VRAM requirements by AI pipeline, the minimum system stack, capacity testing, and the checklist to run before activating on the network."
+            },
+            {
+              "file": "v2/orchestrators/guides/operator-considerations/business-case.mdx",
+              "values": [],
+              "snippet": "This requires: Automated monitoring with immediate alerts on node failure Automated restart and recovery Stable, redundant connectivity (not shared home broadband) Consistent power supply (UPS or colocation) Hardware health monitoring (GPU temperatures, VRAM utilisation) Model warm up management For AI inference workloads, cold model starts (loading a model from disk into VRAM on first request) introduce latency that breaks user facing SLAs."
+            },
+            {
+              "file": "v2/orchestrators/setup/rcs-requirements.mdx",
+              "values": [
+                "16 GB",
+                "24 GB",
+                "8 GB"
+              ],
+              "snippet": "Hardware NVIDIA GPU with NVENC/NVDEC support installed and visible via NVIDIA driver version 525+ (Linux) or 527+ (Windows) CUDA 12.0+ installed (or plan to use the Docker image, which bundles CUDA) CPU: 4+ cores minimum, 8+ recommended RAM: 16 GB minimum, 32 GB recommended Storage: 100 GB SSD minimum (NVMe recommended for AI model weights) For AI inference, VRAM is the primary constraint: 8 GB for LLM only, 16 GB for basic batch AI, 24 GB+ for the full pipeline suite."
+            }
+          ],
+          "best_known_truth": "Docs disagree on the practical VRAM minimum for batch AI and real-time AI workloads. Hardware and setup pages should not present conflicting minimums as equally current.",
+          "confidence": "low",
+          "recommended_action": "verify-more"
+        }
+      ],
+      "notes": "The current authored pages mention 8 GB, 16 GB, 24 GB, and 24 GB+ depending on context. The runner should surface those differences explicitly."
+    },
+    {
+      "claim_id": "orch-consumer-nvenc-session-cap",
+      "claim_family": "consumer-nvenc-session-cap",
+      "entity": "orchestrator",
+      "canonical_owner": "v2/orchestrators/guides/deployment-details/requirements.mdx",
+      "registry_status": "time-sensitive",
+      "status": "conflicted",
+      "freshness_class": "volatile",
+      "confidence": "low",
+      "summary": "Consumer NVIDIA NVENC session-cap guidance is factual but volatile. Hardware requirement and transcoding guides should stay aligned on whether GeForce-class cards are typically capped at 2-3 concurrent sessions and whether newer generations changed that default.",
+      "evidence": [
+        {
+          "type": "repo-file",
+          "ref": "v2/orchestrators/guides/deployment-details/requirements.mdx",
+          "checked_on": "2026-03-16",
+          "ok": true,
+          "matched": true,
+          "summary": "repo evidence matched"
+        },
+        {
+          "type": "repo-file",
+          "ref": "v2/orchestrators/guides/ai-and-job-workloads/video-transcoding.mdx",
+          "checked_on": "2026-03-16",
+          "ok": true,
+          "matched": true,
+          "summary": "repo evidence matched"
+        }
+      ],
+      "page_observations": [
+        {
+          "file": "v2/orchestrators/guides/deployment-details/requirements.mdx",
+          "snippets": [
+            "Consumer cards are typically limited to 2 3 concurrent NVENC encode sessions before throttling or failing with errors.",
+            "Check the official NVIDIA matrix for exact limits per generation: GPU tier NVENC session cap Notes GeForce RTX (consumer) 2 3 concurrent sessions Hardware licensing cap; check matrix for exact figure per generation RTX Workstation / Quadro Uncapped Commercial hardware, no artificial limit NVIDIA A series (A100, A4000, A5000) Uncapped Data centre; full concurrent session headroom NVIDIA L series (L4, L40) Uncapped Data centre NVIDIA H series (H100) Uncapped Data centre; highest throughput tier Exact session counts can vary by GPU generation and NVIDIA policy."
+          ],
+          "values": [
+            "3 concurrent NVENC encode sessions",
+            "3 concurrent sessions"
+          ]
+        },
+        {
+          "file": "v2/orchestrators/guides/ai-and-job-workloads/job-types.mdx",
+          "snippets": [
+            "Your best options: Transcoding — you can handle video transcoding sessions competitively with any modern NVIDIA GPU; NVENC session caps on consumer cards apply, but can be worked around."
+          ],
+          "values": []
+        },
+        {
+          "file": "v2/orchestrators/guides/ai-and-job-workloads/video-transcoding.mdx",
+          "snippets": [
+            "NVENC session caps on consumer GPUs Consumer NVIDIA GPUs (GTX/RTX series) have a hardware enforced cap on the number of concurrent NVENC encoding sessions.",
+            "GPU tier NVENC session cap Consumer (GTX 10xx, RTX 20xx–40xx) 3–8 concurrent sessions per GPU Professional (RTX A series, Quadro) Unlimited Data centre (A100, H100) Unlimited What happens when you hit the cap: On startup, go livepeer runs a GPU test encode.",
+            "If the NVENC session cap is already reached by other processes, the test fails and the node exits with .",
+            "Workaround — driver patching: The NVENC session cap is enforced in the NVIDIA driver, not the GPU hardware."
+          ],
+          "values": []
+        }
+      ],
+      "propagation_queue": [
+        {
+          "file": "v2/orchestrators/guides/ai-and-job-workloads/job-types.mdx",
+          "page_class": "guide",
+          "role": "dependent-page",
+          "action": "verify-only",
+          "claim_id": "orch-consumer-nvenc-session-cap"
+        },
+        {
+          "file": "v2/orchestrators/guides/ai-and-job-workloads/video-transcoding.mdx",
+          "page_class": "guide",
+          "role": "dependent-page",
+          "action": "verify-only",
+          "claim_id": "orch-consumer-nvenc-session-cap"
+        },
+        {
+          "file": "v2/orchestrators/guides/deployment-details/requirements.mdx",
+          "page_class": "guide",
+          "role": "canonical-owner",
+          "action": "verify-only",
+          "claim_id": "orch-consumer-nvenc-session-cap"
+        }
+      ],
+      "contradictions": [
+        {
+          "claim_family": "consumer-nvenc-session-cap",
+          "claim_id": "orch-consumer-nvenc-session-cap",
+          "pages": [
+            {
+              "file": "v2/orchestrators/guides/deployment-details/requirements.mdx",
+              "values": [
+                "3 concurrent NVENC encode sessions",
+                "3 concurrent sessions"
+              ],
+              "snippet": "Consumer cards are typically limited to 2 3 concurrent NVENC encode sessions before throttling or failing with errors."
+            },
+            {
+              "file": "v2/orchestrators/guides/ai-and-job-workloads/job-types.mdx",
+              "values": [],
+              "snippet": "Your best options: Transcoding — you can handle video transcoding sessions competitively with any modern NVIDIA GPU; NVENC session caps on consumer cards apply, but can be worked around."
+            },
+            {
+              "file": "v2/orchestrators/guides/ai-and-job-workloads/video-transcoding.mdx",
+              "values": [],
+              "snippet": "NVENC session caps on consumer GPUs Consumer NVIDIA GPUs (GTX/RTX series) have a hardware enforced cap on the number of concurrent NVENC encoding sessions."
+            }
+          ],
+          "best_known_truth": "Consumer NVIDIA NVENC session-cap guidance is factual but volatile. Hardware requirement and transcoding guides should stay aligned on whether GeForce-class cards are typically capped at 2-3 concurrent sessions and whether newer generations changed that default.",
+          "confidence": "low",
+          "recommended_action": "verify-more"
+        }
+      ],
+      "notes": "The current docs already carry REVIEW notes for Ada Lovelace uncertainty. The runner should treat these figures as volatile operational claims, not settled constants."
+    },
+    {
+      "claim_id": "orch-active-set-threshold",
+      "claim_family": "stake-threshold",
+      "entity": "orchestrator",
+      "canonical_owner": "v2/orchestrators/guides/operator-considerations/business-case.mdx",
+      "registry_status": "time-sensitive",
+      "status": "conflicted",
+      "freshness_class": "volatile",
+      "confidence": "low",
+      "summary": "Solo transcoding guidance repeatedly states that operators need enough bonded LPT to enter the active set, often phrased as top 100, but that wording is time-sensitive and should not be treated as durable fact without current evidence.",
+      "evidence": [
+        {
+          "type": "official-page",
+          "ref": "https://explorer.livepeer.org/orchestrators",
+          "checked_on": "2026-03-16",
+          "ok": true,
+          "matched": false,
+          "summary": "official page fetched but signal missing"
+        }
+      ],
+      "page_observations": [
+        {
+          "file": "v2/orchestrators/guides/operator-considerations/business-case.mdx",
+          "snippets": [
+            "Practical discipline for commercial capability management: Declare only models that are loaded and warm at startup Remove capability declarations for models that are not being actively served Use to specify exactly which pipeline/model combinations to load on startup Monitor model load times and remove slow start models from the active set Building Gateway relationships Active commercial relationships with Gateways typically develop through: Consistent performance history visible on the Livepeer Explorer Participation in the channel on the Direct outreach to Gateway SPEs and ecosystem partners Demonstrated capability support for pipelines that specific Gateways need Gateways serving AI products actively look for Orchestrators with specific capability profiles."
+          ],
+          "values": [
+            "active set"
+          ]
+        },
+        {
+          "file": "v2/orchestrators/guides/deployment-details/setup-options.mdx",
+          "snippets": [],
+          "values": []
+        },
+        {
+          "file": "v2/orchestrators/setup/rcs-requirements.mdx",
+          "snippets": [
+            "The amount needed to enter the active set (top 100) varies — check for the current threshold."
+          ],
+          "values": [
+            "active set",
+            "top 100"
+          ]
+        }
+      ],
+      "propagation_queue": [
+        {
+          "file": "v2/orchestrators/guides/deployment-details/setup-options.mdx",
+          "page_class": "guide",
+          "role": "dependent-page",
+          "action": "verify-only",
+          "claim_id": "orch-active-set-threshold"
+        },
+        {
+          "file": "v2/orchestrators/guides/operator-considerations/business-case.mdx",
+          "page_class": "guide",
+          "role": "canonical-owner",
+          "action": "verify-only",
+          "claim_id": "orch-active-set-threshold"
+        },
+        {
+          "file": "v2/orchestrators/setup/rcs-requirements.mdx",
+          "page_class": "setup",
+          "role": "dependent-page",
+          "action": "verify-only",
+          "claim_id": "orch-active-set-threshold"
+        }
+      ],
+      "contradictions": [
+        {
+          "claim_family": "stake-threshold",
+          "claim_id": "orch-active-set-threshold",
+          "pages": [
+            {
+              "file": "v2/orchestrators/guides/operator-considerations/business-case.mdx",
+              "values": [
+                "active set"
+              ],
+              "snippet": "Practical discipline for commercial capability management: Declare only models that are loaded and warm at startup Remove capability declarations for models that are not being actively served Use to specify exactly which pipeline/model combinations to load on startup Monitor model load times and remove slow start models from the active set Building Gateway relationships Active commercial relationships with Gateways typically develop through: Consistent performance history visible on the Livepeer Explorer Participation in the channel on the Direct outreach to Gateway SPEs and ecosystem partners Demonstrated capability support for pipelines that specific Gateways need Gateways serving AI products actively look for Orchestrators with specific capability profiles."
+            },
+            {
+              "file": "v2/orchestrators/setup/rcs-requirements.mdx",
+              "values": [
+                "active set",
+                "top 100"
+              ],
+              "snippet": "The amount needed to enter the active set (top 100) varies — check for the current threshold."
+            }
+          ],
+          "best_known_truth": "Solo transcoding guidance repeatedly states that operators need enough bonded LPT to enter the active set, often phrased as top 100, but that wording is time-sensitive and should not be treated as durable fact without current evidence.",
+          "confidence": "low",
+          "recommended_action": "verify-more"
+        }
+      ],
+      "notes": "Use Explorer or protocol-facing sources for current state. Treat 'top 100' wording as volatile until rechecked."
+    },
+    {
+      "claim_id": "orch-pool-vs-solo-prerequisites",
+      "claim_family": "setup-prerequisites",
+      "entity": "orchestrator",
+      "canonical_owner": "v2/orchestrators/guides/deployment-details/setup-options.mdx",
+      "registry_status": "verified",
+      "status": "conflicted",
+      "freshness_class": "review-on-change",
+      "confidence": "low",
+      "summary": "Pool workers and solo operators have different prerequisites. Pages should not imply that LPT, ETH, or public service exposure are universal requirements for every orchestrator entry path.",
+      "evidence": [
+        {
+          "type": "repo-file",
+          "ref": "v2/orchestrators/guides/deployment-details/setup-options.mdx",
+          "checked_on": "2026-03-16",
+          "ok": true,
+          "matched": true,
+          "summary": "repo evidence matched"
+        },
+        {
+          "type": "repo-file",
+          "ref": "v2/orchestrators/guides/deployment-details/join-a-pool.mdx",
+          "checked_on": "2026-03-16",
+          "ok": true,
+          "matched": true,
+          "summary": "repo evidence matched"
+        }
+      ],
+      "page_observations": [
+        {
+          "file": "v2/orchestrators/guides/deployment-details/setup-options.mdx",
+          "snippets": [
+            "At a Glance Alternative What it solves What it requires Guide Pool worker Earn from GPU compute without running an Orchestrator at all no LPT, no on chain management GPU; a pool to join; no stake O T split Separate protocol management from GPU workload processing; scale Transcoder machines independently Two machines; LPT stake; Siphon Keep the keystore on an isolated machine; GPU machine can restart without missing LPT rewards Two machines; LPT stake; Python on secure machine Pool Worker A pool worker does not run an Orchestrator.",
+            "The pool operator handles all on chain operations: staking, reward calling, pricing, Gateway relationships.",
+            "Choosing the Right Alternative Situation Right path No LPT, just a GPU Pool worker not an Orchestrator at all One machine, comfortable with combined setup Standard combined mode see the Setup Guide, not this page Multiple GPU machines under one Orchestrator identity O T split scale Transcoder machines behind a single Orchestrator GPU machine uptime is uncertain; LPT rewards must be protected Siphon reward calling is independent of GPU machine state Keystore must be isolated from the media processing machine Siphon GPU machine never holds the keystore Earn inflation rewards before GPU hardware is ready Siphon (secure machine only) add GPU machine later without re registration Running a pool for external workers O T split as the foundation then see Related Pages Contribute GPU compute to an existing Orchestrator pool no stake, no on chain management."
+          ],
+          "values": [
+            "Pool Worker",
+            "Pool worker",
+            "pool worker"
+          ]
+        },
+        {
+          "file": "v2/orchestrators/guides/deployment-details/setup-options.mdx",
+          "snippets": [
+            "At a Glance Alternative What it solves What it requires Guide Pool worker Earn from GPU compute without running an Orchestrator at all no LPT, no on chain management GPU; a pool to join; no stake O T split Separate protocol management from GPU workload processing; scale Transcoder machines independently Two machines; LPT stake; Siphon Keep the keystore on an isolated machine; GPU machine can restart without missing LPT rewards Two machines; LPT stake; Python on secure machine Pool Worker A pool worker does not run an Orchestrator.",
+            "The pool operator handles all on chain operations: staking, reward calling, pricing, Gateway relationships.",
+            "Choosing the Right Alternative Situation Right path No LPT, just a GPU Pool worker not an Orchestrator at all One machine, comfortable with combined setup Standard combined mode see the Setup Guide, not this page Multiple GPU machines under one Orchestrator identity O T split scale Transcoder machines behind a single Orchestrator GPU machine uptime is uncertain; LPT rewards must be protected Siphon reward calling is independent of GPU machine state Keystore must be isolated from the media processing machine Siphon GPU machine never holds the keystore Earn inflation rewards before GPU hardware is ready Siphon (secure machine only) add GPU machine later without re registration Running a pool for external workers O T split as the foundation then see Related Pages Contribute GPU compute to an existing Orchestrator pool no stake, no on chain management."
+          ],
+          "values": [
+            "Pool Worker",
+            "Pool worker",
+            "pool worker"
+          ]
+        },
+        {
+          "file": "v2/orchestrators/guides/operator-considerations/business-case.mdx",
+          "snippets": [
+            "Pool operators manage the Orchestrator registration, on chain staking, and reward calling for a fleet of GPU workers."
+          ],
+          "values": []
+        },
+        {
+          "file": "v2/orchestrators/setup/rcs-requirements.mdx",
+          "snippets": [
+            "LPT on Arbitrum One — for staking."
+          ],
+          "values": []
+        }
+      ],
+      "propagation_queue": [
+        {
+          "file": "v2/orchestrators/guides/deployment-details/setup-options.mdx",
+          "page_class": "guide",
+          "role": "canonical-owner",
+          "action": "verify-only",
+          "claim_id": "orch-pool-vs-solo-prerequisites"
+        },
+        {
+          "file": "v2/orchestrators/guides/operator-considerations/business-case.mdx",
+          "page_class": "guide",
+          "role": "dependent-page",
+          "action": "verify-only",
+          "claim_id": "orch-pool-vs-solo-prerequisites"
+        },
+        {
+          "file": "v2/orchestrators/setup/rcs-requirements.mdx",
+          "page_class": "setup",
+          "role": "dependent-page",
+          "action": "verify-only",
+          "claim_id": "orch-pool-vs-solo-prerequisites"
+        }
+      ],
+      "contradictions": [
+        {
+          "claim_family": "setup-prerequisites",
+          "claim_id": "orch-pool-vs-solo-prerequisites",
+          "pages": [
+            {
+              "file": "v2/orchestrators/guides/deployment-details/setup-options.mdx",
+              "values": [
+                "Pool Worker",
+                "Pool worker",
+                "pool worker"
+              ],
+              "snippet": "At a Glance Alternative What it solves What it requires Guide Pool worker Earn from GPU compute without running an Orchestrator at all no LPT, no on chain management GPU; a pool to join; no stake O T split Separate protocol management from GPU workload processing; scale Transcoder machines independently Two machines; LPT stake; Siphon Keep the keystore on an isolated machine; GPU machine can restart without missing LPT rewards Two machines; LPT stake; Python on secure machine Pool Worker A pool worker does not run an Orchestrator."
+            },
+            {
+              "file": "v2/orchestrators/guides/deployment-details/setup-options.mdx",
+              "values": [
+                "Pool Worker",
+                "Pool worker",
+                "pool worker"
+              ],
+              "snippet": "At a Glance Alternative What it solves What it requires Guide Pool worker Earn from GPU compute without running an Orchestrator at all no LPT, no on chain management GPU; a pool to join; no stake O T split Separate protocol management from GPU workload processing; scale Transcoder machines independently Two machines; LPT stake; Siphon Keep the keystore on an isolated machine; GPU machine can restart without missing LPT rewards Two machines; LPT stake; Python on secure machine Pool Worker A pool worker does not run an Orchestrator."
+            },
+            {
+              "file": "v2/orchestrators/guides/operator-considerations/business-case.mdx",
+              "values": [],
+              "snippet": "Pool operators manage the Orchestrator registration, on chain staking, and reward calling for a fleet of GPU workers."
+            },
+            {
+              "file": "v2/orchestrators/setup/rcs-requirements.mdx",
+              "values": [],
+              "snippet": "LPT on Arbitrum One — for staking."
+            }
+          ],
+          "best_known_truth": "Pool workers and solo operators have different prerequisites. Pages should not imply that LPT, ETH, or public service exposure are universal requirements for every orchestrator entry path.",
+          "confidence": "low",
+          "recommended_action": "verify-more"
+        }
+      ],
+      "notes": "This is a durable claim family but still needs contradiction checks against setup-facing pages."
+    },
+    {
+      "claim_id": "orch-ai-routing-capability-based",
+      "claim_family": "ai-routing-mechanics",
+      "entity": "orchestrator",
+      "canonical_owner": "v2/orchestrators/guides/ai-and-job-workloads/job-types.mdx",
+      "registry_status": "verified",
+      "status": "conflicted",
+      "freshness_class": "review-on-change",
+      "confidence": "low",
+      "summary": "AI jobs are routed primarily by capability match and price ceilings rather than by stake weight. Docs should not collapse AI routing into the same rules as transcoding routing.",
+      "evidence": [
+        {
+          "type": "repo-file",
+          "ref": "v2/orchestrators/guides/ai-and-job-workloads/job-types.mdx",
+          "checked_on": "2026-03-16",
+          "ok": true,
+          "matched": true,
+          "summary": "repo evidence matched"
+        },
+        {
+          "type": "repo-file",
+          "ref": "v2/orchestrators/guides/deployment-details/dual-workload-setup.mdx",
+          "checked_on": "2026-03-16",
+          "ok": true,
+          "matched": true,
+          "summary": "repo evidence matched"
+        }
+      ],
+      "page_observations": [
+        {
+          "file": "v2/orchestrators/guides/ai-and-job-workloads/job-types.mdx",
+          "snippets": [
+            "Batch AI inference AI jobs route on capability match + price ceiling.",
+            "Stake plays a much smaller role.",
+            "This matters for operators: a new orchestrator with 24 GB VRAM and correctly configured AI pipelines can compete for AI jobs immediately, regardless of stake.",
+            "LLM inference Routes the same way as batch AI — capability match and price — but the capability check is against a specific Ollama model ID rather than a diffusion pipeline."
+          ],
+          "values": [
+            "Stake plays a much smaller role",
+            "capability match"
+          ]
+        },
+        {
+          "file": "v2/orchestrators/guides/deployment-details/setup-options.mdx",
+          "snippets": [],
+          "values": []
+        }
+      ],
+      "propagation_queue": [
+        {
+          "file": "v2/orchestrators/guides/ai-and-job-workloads/job-types.mdx",
+          "page_class": "guide",
+          "role": "canonical-owner",
+          "action": "verify-only",
+          "claim_id": "orch-ai-routing-capability-based"
+        },
+        {
+          "file": "v2/orchestrators/guides/deployment-details/setup-options.mdx",
+          "page_class": "guide",
+          "role": "dependent-page",
+          "action": "verify-only",
+          "claim_id": "orch-ai-routing-capability-based"
+        }
+      ],
+      "contradictions": [
+        {
+          "claim_family": "ai-routing-mechanics",
+          "claim_id": "orch-ai-routing-capability-based",
+          "pages": [
+            {
+              "file": "v2/orchestrators/guides/ai-and-job-workloads/job-types.mdx",
+              "values": [
+                "Stake plays a much smaller role",
+                "capability match"
+              ],
+              "snippet": "Batch AI inference AI jobs route on capability match + price ceiling."
+            }
+          ],
+          "best_known_truth": "AI jobs are routed primarily by capability match and price ceilings rather than by stake weight. Docs should not collapse AI routing into the same rules as transcoding routing.",
+          "confidence": "low",
+          "recommended_action": "verify-more"
+        }
+      ],
+      "notes": "This family is high-value because setup pages frequently mix stake-sensitive transcoding guidance with AI inference guidance."
+    },
+    {
+      "claim_id": "orch-siphon-github-current",
+      "claim_family": "community-tooling-status",
+      "entity": "orchestrator",
+      "canonical_owner": "v2/orchestrators/guides/deployment-details/setup-options.mdx",
+      "registry_status": "verified",
+      "status": "conflicted",
+      "freshness_class": "review-periodic",
+      "confidence": "low",
+      "summary": "Split-setup guidance depends on OrchestratorSiphon still being an active community-maintained project. That claim should be checked against the current GitHub repository, not just repeated in docs.",
+      "evidence": [
+        {
+          "type": "github-repo",
+          "ref": "https://github.com/Stronk-Tech/OrchestratorSiphon",
+          "checked_on": "2026-03-16",
+          "ok": true,
+          "matched": true,
+          "summary": "GitHub evidence matched"
+        }
+      ],
+      "page_observations": [
+        {
+          "file": "v2/orchestrators/guides/deployment-details/setup-options.mdx",
+          "snippets": [
+            "At a Glance Alternative What it solves What it requires Guide Pool worker Earn from GPU compute without running an Orchestrator at all no LPT, no on chain management GPU; a pool to join; no stake O T split Separate protocol management from GPU workload processing; scale Transcoder machines independently Two machines; LPT stake; Siphon Keep the keystore on an isolated machine; GPU machine can restart without missing LPT rewards Two machines; LPT stake; Python on secure machine Pool Worker A pool worker does not run an Orchestrator.",
+            "Siphon The Siphon setup also uses a secure machine and a GPU machine but uses a different tool on the secure side.",
+            "Instead of running , the secure machine runs OrchestratorSiphon: a lightweight Python tool that handles only on chain operations reward calling, fee withdrawal, governance voting, service URI updates.",
+            "With Siphon, the secure machine calls rewards independently of whether the GPU machine is running."
+          ],
+          "values": [
+            "OrchestratorSiphon",
+            "Siphon"
+          ]
+        },
+        {
+          "file": "v2/orchestrators/guides/deployment-details/setup-options.mdx",
+          "snippets": [
+            "At a Glance Alternative What it solves What it requires Guide Pool worker Earn from GPU compute without running an Orchestrator at all no LPT, no on chain management GPU; a pool to join; no stake O T split Separate protocol management from GPU workload processing; scale Transcoder machines independently Two machines; LPT stake; Siphon Keep the keystore on an isolated machine; GPU machine can restart without missing LPT rewards Two machines; LPT stake; Python on secure machine Pool Worker A pool worker does not run an Orchestrator.",
+            "Siphon The Siphon setup also uses a secure machine and a GPU machine but uses a different tool on the secure side.",
+            "Instead of running , the secure machine runs OrchestratorSiphon: a lightweight Python tool that handles only on chain operations reward calling, fee withdrawal, governance voting, service URI updates.",
+            "With Siphon, the secure machine calls rewards independently of whether the GPU machine is running."
+          ],
+          "values": [
+            "OrchestratorSiphon",
+            "Siphon"
+          ]
+        }
+      ],
+      "propagation_queue": [
+        {
+          "file": "v2/orchestrators/guides/deployment-details/setup-options.mdx",
+          "page_class": "guide",
+          "role": "canonical-owner",
+          "action": "verify-only",
+          "claim_id": "orch-siphon-github-current"
+        }
+      ],
+      "contradictions": [
+        {
+          "claim_family": "community-tooling-status",
+          "claim_id": "orch-siphon-github-current",
+          "pages": [
+            {
+              "file": "v2/orchestrators/guides/deployment-details/setup-options.mdx",
+              "values": [
+                "OrchestratorSiphon",
+                "Siphon"
+              ],
+              "snippet": "At a Glance Alternative What it solves What it requires Guide Pool worker Earn from GPU compute without running an Orchestrator at all no LPT, no on chain management GPU; a pool to join; no stake O T split Separate protocol management from GPU workload processing; scale Transcoder machines independently Two machines; LPT stake; Siphon Keep the keystore on an isolated machine; GPU machine can restart without missing LPT rewards Two machines; LPT stake; Python on secure machine Pool Worker A pool worker does not run an Orchestrator."
+            },
+            {
+              "file": "v2/orchestrators/guides/deployment-details/setup-options.mdx",
+              "values": [
+                "OrchestratorSiphon",
+                "Siphon"
+              ],
+              "snippet": "At a Glance Alternative What it solves What it requires Guide Pool worker Earn from GPU compute without running an Orchestrator at all no LPT, no on chain management GPU; a pool to join; no stake O T split Separate protocol management from GPU workload processing; scale Transcoder machines independently Two machines; LPT stake; Siphon Keep the keystore on an isolated machine; GPU machine can restart without missing LPT rewards Two machines; LPT stake; Python on secure machine Pool Worker A pool worker does not run an Orchestrator."
+            }
+          ],
+          "best_known_truth": "Split-setup guidance depends on OrchestratorSiphon still being an active community-maintained project. That claim should be checked against the current GitHub repository, not just repeated in docs.",
+          "confidence": "low",
+          "recommended_action": "verify-more"
+        }
+      ],
+      "notes": "Use GitHub repository metadata to confirm the project still exists and is publicly accessible."
+    },
+    {
+      "claim_id": "orch-siphon-reward-isolation",
+      "claim_family": "split-setup-reward-safety",
+      "entity": "orchestrator",
+      "canonical_owner": "v2/orchestrators/guides/deployment-details/siphon-setup.mdx",
+      "registry_status": "verified",
+      "status": "conflicted",
+      "freshness_class": "review-periodic",
+      "confidence": "low",
+      "summary": "A split setup with OrchestratorSiphon isolates the keystore from the GPU machine and keeps reward calling independent of GPU uptime. Docs should keep that claim aligned across setup-path pages.",
+      "evidence": [
+        {
+          "type": "repo-file",
+          "ref": "v2/orchestrators/guides/deployment-details/siphon-setup.mdx",
+          "checked_on": "2026-03-16",
+          "ok": true,
+          "matched": true,
+          "summary": "repo evidence matched"
+        },
+        {
+          "type": "github-repo",
+          "ref": "https://github.com/Stronk-Tech/OrchestratorSiphon",
+          "checked_on": "2026-03-16",
+          "ok": true,
+          "matched": true,
+          "summary": "GitHub evidence matched"
+        }
+      ],
+      "page_observations": [
+        {
+          "file": "v2/orchestrators/guides/deployment-details/siphon-setup.mdx",
+          "snippets": [
+            "If the GPU machine reboots mid round, that round's LPT inflation reward is permanently lost and missed rewards compound over time.",
+            "The Siphon split setup solves both.",
+            "OrchestratorSiphon runs on a small, secure machine and handles all on chain actions: reward calling, fee withdrawal, governance voting, and service URI updates.",
+            "The GPU machine can restart, be replaced, or go offline for maintenance without interrupting reward claims."
+          ],
+          "values": [
+            "GPU machine can restart",
+            "reward",
+            "reward calling"
+          ]
+        },
+        {
+          "file": "v2/orchestrators/guides/deployment-details/setup-options.mdx",
+          "snippets": [
+            "At a Glance Alternative What it solves What it requires Guide Pool worker Earn from GPU compute without running an Orchestrator at all no LPT, no on chain management GPU; a pool to join; no stake O T split Separate protocol management from GPU workload processing; scale Transcoder machines independently Two machines; LPT stake; Siphon Keep the keystore on an isolated machine; GPU machine can restart without missing LPT rewards Two machines; LPT stake; Python on secure machine Pool Worker A pool worker does not run an Orchestrator.",
+            "The pool operator handles all on chain operations: staking, reward calling, pricing, Gateway relationships.",
+            "The Orchestrator process protocol, routing, reward calling, keystore runs on one machine.",
+            "Instead of running , the secure machine runs OrchestratorSiphon: a lightweight Python tool that handles only on chain operations reward calling, fee withdrawal, governance voting, service URI updates."
+          ],
+          "values": [
+            "GPU machine can restart",
+            "reward calling"
+          ]
+        }
+      ],
+      "propagation_queue": [
+        {
+          "file": "v2/orchestrators/guides/deployment-details/setup-options.mdx",
+          "page_class": "guide",
+          "role": "dependent-page",
+          "action": "verify-only",
+          "claim_id": "orch-siphon-reward-isolation"
+        },
+        {
+          "file": "v2/orchestrators/guides/deployment-details/siphon-setup.mdx",
+          "page_class": "guide",
+          "role": "canonical-owner",
+          "action": "verify-only",
+          "claim_id": "orch-siphon-reward-isolation"
+        }
+      ],
+      "contradictions": [
+        {
+          "claim_family": "split-setup-reward-safety",
+          "claim_id": "orch-siphon-reward-isolation",
+          "pages": [
+            {
+              "file": "v2/orchestrators/guides/deployment-details/siphon-setup.mdx",
+              "values": [
+                "GPU machine can restart",
+                "reward",
+                "reward calling"
+              ],
+              "snippet": "If the GPU machine reboots mid round, that round's LPT inflation reward is permanently lost and missed rewards compound over time."
+            },
+            {
+              "file": "v2/orchestrators/guides/deployment-details/setup-options.mdx",
+              "values": [
+                "GPU machine can restart",
+                "reward calling"
+              ],
+              "snippet": "At a Glance Alternative What it solves What it requires Guide Pool worker Earn from GPU compute without running an Orchestrator at all no LPT, no on chain management GPU; a pool to join; no stake O T split Separate protocol management from GPU workload processing; scale Transcoder machines independently Two machines; LPT stake; Siphon Keep the keystore on an isolated machine; GPU machine can restart without missing LPT rewards Two machines; LPT stake; Python on secure machine Pool Worker A pool worker does not run an Orchestrator."
+            }
+          ],
+          "best_known_truth": "A split setup with OrchestratorSiphon isolates the keystore from the GPU machine and keeps reward calling independent of GPU uptime. Docs should keep that claim aligned across setup-path pages.",
+          "confidence": "low",
+          "recommended_action": "verify-more"
+        }
+      ],
+      "notes": "This family is partly repo-doc backed and partly GitHub backed because the live project status matters alongside the docs explanation."
+    }
+  ],
+  "time_sensitive_claims": [
+    {
+      "claim_id": "orch-commercial-model-warmth",
+      "claim_family": "commercial-model-warmth",
+      "entity": "orchestrator",
+      "canonical_owner": "v2/orchestrators/guides/operator-considerations/business-case.mdx",
+      "registry_status": "time-sensitive",
+      "status": "time-sensitive",
+      "freshness_class": "review-on-change",
+      "confidence": "medium",
+      "summary": "Commercial AI operator guidance should keep warm-model, pre-loaded startup, and cold-start SLA language aligned across setup and business-case pages. These claims describe real operational expectations, but they remain experimental and workload-sensitive.",
+      "evidence": [
+        {
+          "type": "repo-file",
+          "ref": "v2/orchestrators/guides/operator-considerations/business-case.mdx",
+          "checked_on": "2026-03-16",
+          "ok": true,
+          "matched": true,
+          "summary": "repo evidence matched"
+        },
+        {
+          "type": "repo-file",
+          "ref": "v2/orchestrators/guides/deployment-details/dual-workload-setup.mdx",
+          "checked_on": "2026-03-16",
+          "ok": true,
+          "matched": true,
+          "summary": "repo evidence matched"
+        },
+        {
+          "type": "repo-file",
+          "ref": "v2/orchestrators/guides/ai-and-job-workloads/batch-ai-setup.mdx",
+          "checked_on": "2026-03-16",
+          "ok": true,
+          "matched": true,
+          "summary": "repo evidence matched"
+        }
+      ],
+      "page_observations": [
+        {
+          "file": "v2/orchestrators/guides/operator-considerations/business-case.mdx",
+          "snippets": [
+            "Dimension Hobbyist operator Commercial operator Primary income LPT inflation rewards ETH service fees from job processing Revenue lever Total bonded stake Job volume, pricing discipline, uptime Uptime requirement ~95% (reward calls + basic availability) 99%+ (SLA driven, continuous monitoring) Gateway relationship Passive wait to be selected by price and stake Active direct relationships, per Gateway pricing Hardware approach Existing hardware repurposed Dedicated investment, redundancy planned Monitoring Periodic checks, Prometheus optional Automated alerting, SLA dashboards Model loading Load on demand; cold starts acceptable Pre loaded and warm; cold starts are SLA failures Neither model is superior they reflect different operator goals and capabilities.",
+            "Commercial AI Orchestrators pre load all advertised models at startup and keep them warm.",
+            "Practical discipline for commercial capability management: Declare only models that are loaded and warm at startup Remove capability declarations for models that are not being actively served Use to specify exactly which pipeline/model combinations to load on startup Monitor model load times and remove slow start models from the active set Building Gateway relationships Active commercial relationships with Gateways typically develop through: Consistent performance history visible on the Livepeer Explorer Participation in the channel on the Direct outreach to Gateway SPEs and ecosystem partners Demonstrated capability support for pipelines that specific Gateways need Gateways serving AI products actively look for Orchestrators with specific capability profiles."
+          ],
+          "values": []
+        },
+        {
+          "file": "v2/orchestrators/guides/ai-and-job-workloads/ai-workloads-guide.mdx",
+          "snippets": [],
+          "values": []
+        },
+        {
+          "file": "v2/orchestrators/guides/ai-and-job-workloads/batch-ai-setup.mdx",
+          "snippets": [
+            "Eliminates cold start latency."
+          ],
+          "values": []
+        },
+        {
+          "file": "v2/orchestrators/guides/deployment-details/dual-workload-setup.mdx",
+          "snippets": [],
+          "values": []
+        }
+      ],
+      "propagation_queue": [
+        {
+          "file": "v2/orchestrators/guides/ai-and-job-workloads/ai-workloads-guide.mdx",
+          "page_class": "guide",
+          "role": "dependent-page",
+          "action": "verify-only",
+          "claim_id": "orch-commercial-model-warmth"
+        },
+        {
+          "file": "v2/orchestrators/guides/ai-and-job-workloads/batch-ai-setup.mdx",
+          "page_class": "guide",
+          "role": "dependent-page",
+          "action": "verify-only",
+          "claim_id": "orch-commercial-model-warmth"
+        },
+        {
+          "file": "v2/orchestrators/guides/deployment-details/dual-workload-setup.mdx",
+          "page_class": "guide",
+          "role": "dependent-page",
+          "action": "verify-only",
+          "claim_id": "orch-commercial-model-warmth"
+        },
+        {
+          "file": "v2/orchestrators/guides/operator-considerations/business-case.mdx",
+          "page_class": "guide",
+          "role": "canonical-owner",
+          "action": "verify-only",
+          "claim_id": "orch-commercial-model-warmth"
+        }
+      ],
+      "contradictions": [],
+      "notes": "This family tracks whether docs consistently present warm models as a commercial latency/SLA requirement rather than a generic optimisation tip."
+    },
+    {
+      "claim_id": "orch-bandwidth-per-stream-planning",
+      "claim_family": "transcoding-bandwidth-planning",
+      "entity": "orchestrator",
+      "canonical_owner": "v2/orchestrators/setup/configure.mdx",
+      "registry_status": "time-sensitive",
+      "status": "time-sensitive",
+      "freshness_class": "review-periodic",
+      "confidence": "medium",
+      "summary": "Bandwidth planning for transcoding is currently presented as an approximate planning rule rather than a single durable network constant. Pages should make the source-resolution assumption and rendition-set basis explicit when quoting per-stream bandwidth.",
+      "evidence": [
+        {
+          "type": "repo-file",
+          "ref": "v2/orchestrators/setup/configure.mdx",
+          "checked_on": "2026-03-16",
+          "ok": true,
+          "matched": true,
+          "summary": "repo evidence matched"
+        },
+        {
+          "type": "repo-file",
+          "ref": "v2/orchestrators/guides/deployment-details/requirements.mdx",
+          "checked_on": "2026-03-16",
+          "ok": true,
+          "matched": true,
+          "summary": "repo evidence matched"
+        }
+      ],
+      "page_observations": [
+        {
+          "file": "v2/orchestrators/setup/configure.mdx",
+          "snippets": [],
+          "values": []
+        },
+        {
+          "file": "v2/orchestrators/guides/deployment-details/requirements.mdx",
+          "snippets": [],
+          "values": []
+        },
+        {
+          "file": "v2/orchestrators/guides/operator-considerations/business-case.mdx",
+          "snippets": [],
+          "values": []
+        }
+      ],
+      "propagation_queue": [
+        {
+          "file": "v2/orchestrators/guides/deployment-details/requirements.mdx",
+          "page_class": "guide",
+          "role": "dependent-page",
+          "action": "verify-only",
+          "claim_id": "orch-bandwidth-per-stream-planning"
+        },
+        {
+          "file": "v2/orchestrators/guides/operator-considerations/business-case.mdx",
+          "page_class": "guide",
+          "role": "dependent-page",
+          "action": "verify-only",
+          "claim_id": "orch-bandwidth-per-stream-planning"
+        },
+        {
+          "file": "v2/orchestrators/setup/configure.mdx",
+          "page_class": "setup",
+          "role": "canonical-owner",
+          "action": "verify-only",
+          "claim_id": "orch-bandwidth-per-stream-planning"
+        }
+      ],
+      "contradictions": [],
+      "notes": "Current docs mix four-rendition benchmark data with planning guidance that assumes higher source bandwidth. Keep this as approximation-first wording, not a hard constant."
+    },
+    {
+      "claim_id": "orch-business-case-cost-viability",
+      "claim_family": "business-case-viability",
+      "entity": "orchestrator",
+      "canonical_owner": "v2/orchestrators/guides/operator-considerations/business-case.mdx",
+      "registry_status": "time-sensitive",
+      "status": "time-sensitive",
+      "freshness_class": "volatile",
+      "confidence": "medium",
+      "summary": "Business-case guidance should explicitly stay approximate and local-context dependent. Payback, electricity cost, and 'worth it' framing are useful, but they should not be presented as portable constants across operators, geographies, or market conditions.",
+      "evidence": [
+        {
+          "type": "repo-file",
+          "ref": "v2/orchestrators/guides/operator-considerations/business-case.mdx",
+          "checked_on": "2026-03-16",
+          "ok": true,
+          "matched": true,
+          "summary": "repo evidence matched"
+        },
+        {
+          "type": "repo-file",
+          "ref": "v2/orchestrators/guides/deployment-details/requirements.mdx",
+          "checked_on": "2026-03-16",
+          "ok": true,
+          "matched": true,
+          "summary": "repo evidence matched"
+        }
+      ],
+      "page_observations": [
+        {
+          "file": "v2/orchestrators/guides/operator-considerations/business-case.mdx",
+          "snippets": [],
+          "values": []
+        },
+        {
+          "file": "v2/orchestrators/guides/deployment-details/requirements.mdx",
+          "snippets": [],
+          "values": []
+        }
+      ],
+      "propagation_queue": [
+        {
+          "file": "v2/orchestrators/guides/deployment-details/requirements.mdx",
+          "page_class": "guide",
+          "role": "dependent-page",
+          "action": "verify-only",
+          "claim_id": "orch-business-case-cost-viability"
+        },
+        {
+          "file": "v2/orchestrators/guides/operator-considerations/business-case.mdx",
+          "page_class": "guide",
+          "role": "canonical-owner",
+          "action": "verify-only",
+          "claim_id": "orch-business-case-cost-viability"
+        }
+      ],
+      "contradictions": [],
+      "notes": "This family is about keeping 'worth it' or break-even style guidance honest and local to the operator's hardware, energy, and stake context."
+    },
+    {
+      "claim_id": "orch-session-limit-default",
+      "claim_family": "transcoding-session-cap",
+      "entity": "orchestrator",
+      "canonical_owner": "v2/orchestrators/setup/configure.mdx",
+      "registry_status": "time-sensitive",
+      "status": "time-sensitive",
+      "freshness_class": "review-on-change",
+      "confidence": "medium",
+      "summary": "The default session limit and overload behavior are operational facts that multiple setup and hardware pages depend on. When docs state the default cap or the error condition, they should stay aligned with current go-livepeer behavior.",
+      "evidence": [
+        {
+          "type": "repo-file",
+          "ref": "v2/orchestrators/setup/configure.mdx",
+          "checked_on": "2026-03-16",
+          "ok": true,
+          "matched": true,
+          "summary": "repo evidence matched"
+        }
+      ],
+      "page_observations": [
+        {
+          "file": "v2/orchestrators/setup/configure.mdx",
+          "snippets": [
+            "The hardware session limit number from the test in ."
+          ],
+          "values": []
+        },
+        {
+          "file": "v2/orchestrators/guides/deployment-details/requirements.mdx",
+          "snippets": [
+            "This page covers GPU support policy, session limits by card tier, VRAM requirements by AI pipeline, the minimum system stack, capacity testing, and the checklist to run before activating on the network.",
+            "NVENC/NVDEC Session Limits NVIDIA consumer GPUs enforce concurrent encoding session limits via NVENC (hardware video encoder) and NVDEC (hardware video decoder).",
+            "Run the scaling test above to find the hardware session limit."
+          ],
+          "values": []
+        }
+      ],
+      "propagation_queue": [
+        {
+          "file": "v2/orchestrators/guides/deployment-details/requirements.mdx",
+          "page_class": "guide",
+          "role": "dependent-page",
+          "action": "verify-only",
+          "claim_id": "orch-session-limit-default"
+        },
+        {
+          "file": "v2/orchestrators/setup/configure.mdx",
+          "page_class": "setup",
+          "role": "canonical-owner",
+          "action": "verify-only",
+          "claim_id": "orch-session-limit-default"
+        }
+      ],
+      "contradictions": [],
+      "notes": "The current page still carries a REVIEW note on OrchestratorCapped. Treat both the default value and error-name wording as review-on-change operational claims."
+    },
+    {
+      "claim_id": "orch-reward-profitability-threshold",
+      "claim_family": "reward-profitability",
+      "entity": "orchestrator",
+      "canonical_owner": "v2/orchestrators/guides/staking-and-rewards/rewards-and-fees.mdx",
+      "registry_status": "time-sensitive",
+      "status": "time-sensitive",
+      "freshness_class": "volatile",
+      "confidence": "medium",
+      "summary": "Reward-call profitability guidance should remain explicitly time-sensitive because gas cost, ETH price, and LPT price move. Docs must not present rough thresholds as durable constants.",
+      "evidence": [
+        {
+          "type": "repo-file",
+          "ref": "v2/orchestrators/guides/staking-and-rewards/rewards-and-fees.mdx",
+          "checked_on": "2026-03-16",
+          "ok": true,
+          "matched": true,
+          "summary": "repo evidence matched"
+        }
+      ],
+      "page_observations": [
+        {
+          "file": "v2/orchestrators/guides/staking-and-rewards/rewards-and-fees.mdx",
+          "snippets": [
+            "This page covers the operational mechanics of how LPT rewards flow, how to call reliably, the economics of when calling reward is profitable, and how ETH fees move from job to wallet.",
+            "Calling Reward() — your options Option 1: Automatic (default, recommended) By default, go livepeer automatically calls at the start of each new round.",
+            "Option 2: Disable automatic, call manually Use this approach when you are newly activated with very low stake, and want to evaluate whether the gas cost exceeds the LPT value before committing to automatic calling.",
+            "Step 1: Disable automatic reward calls Step 2: Estimate whether calling is profitable this round Gather three inputs: 1."
+          ],
+          "values": []
+        },
+        {
+          "file": "v2/orchestrators/guides/operator-considerations/business-case.mdx",
+          "snippets": [],
+          "values": []
+        }
+      ],
+      "propagation_queue": [
+        {
+          "file": "v2/orchestrators/guides/operator-considerations/business-case.mdx",
+          "page_class": "guide",
+          "role": "dependent-page",
+          "action": "verify-only",
+          "claim_id": "orch-reward-profitability-threshold"
+        },
+        {
+          "file": "v2/orchestrators/guides/staking-and-rewards/rewards-and-fees.mdx",
+          "page_class": "guide",
+          "role": "canonical-owner",
+          "action": "verify-only",
+          "claim_id": "orch-reward-profitability-threshold"
+        }
+      ],
+      "contradictions": [],
+      "notes": "Surface rough thresholds as review-sensitive even when the docs provide a range."
+    }
+  ],
+  "unverified_or_historical_claims": [],
+  "cross_page_contradictions": [
+    {
+      "claim_family": "hardware-vram-minimums",
+      "claim_id": "orch-batch-ai-vram-threshold",
+      "pages": [
+        {
+          "file": "v2/orchestrators/guides/deployment-details/requirements.mdx",
+          "values": [],
+          "snippet": "This page covers GPU support policy, session limits by card tier, VRAM requirements by AI pipeline, the minimum system stack, capacity testing, and the checklist to run before activating on the network."
+        },
+        {
+          "file": "v2/orchestrators/guides/operator-considerations/business-case.mdx",
+          "values": [],
+          "snippet": "This requires: Automated monitoring with immediate alerts on node failure Automated restart and recovery Stable, redundant connectivity (not shared home broadband) Consistent power supply (UPS or colocation) Hardware health monitoring (GPU temperatures, VRAM utilisation) Model warm up management For AI inference workloads, cold model starts (loading a model from disk into VRAM on first request) introduce latency that breaks user facing SLAs."
+        },
+        {
+          "file": "v2/orchestrators/setup/rcs-requirements.mdx",
+          "values": [
+            "16 GB",
+            "24 GB",
+            "8 GB"
+          ],
+          "snippet": "Hardware NVIDIA GPU with NVENC/NVDEC support installed and visible via NVIDIA driver version 525+ (Linux) or 527+ (Windows) CUDA 12.0+ installed (or plan to use the Docker image, which bundles CUDA) CPU: 4+ cores minimum, 8+ recommended RAM: 16 GB minimum, 32 GB recommended Storage: 100 GB SSD minimum (NVMe recommended for AI model weights) For AI inference, VRAM is the primary constraint: 8 GB for LLM only, 16 GB for basic batch AI, 24 GB+ for the full pipeline suite."
+        }
+      ],
+      "best_known_truth": "Docs disagree on the practical VRAM minimum for batch AI and real-time AI workloads. Hardware and setup pages should not present conflicting minimums as equally current.",
+      "confidence": "low",
+      "recommended_action": "verify-more"
+    },
+    {
+      "claim_family": "consumer-nvenc-session-cap",
+      "claim_id": "orch-consumer-nvenc-session-cap",
+      "pages": [
+        {
+          "file": "v2/orchestrators/guides/deployment-details/requirements.mdx",
+          "values": [
+            "3 concurrent NVENC encode sessions",
+            "3 concurrent sessions"
+          ],
+          "snippet": "Consumer cards are typically limited to 2 3 concurrent NVENC encode sessions before throttling or failing with errors."
+        },
+        {
+          "file": "v2/orchestrators/guides/ai-and-job-workloads/job-types.mdx",
+          "values": [],
+          "snippet": "Your best options: Transcoding — you can handle video transcoding sessions competitively with any modern NVIDIA GPU; NVENC session caps on consumer cards apply, but can be worked around."
+        },
+        {
+          "file": "v2/orchestrators/guides/ai-and-job-workloads/video-transcoding.mdx",
+          "values": [],
+          "snippet": "NVENC session caps on consumer GPUs Consumer NVIDIA GPUs (GTX/RTX series) have a hardware enforced cap on the number of concurrent NVENC encoding sessions."
+        }
+      ],
+      "best_known_truth": "Consumer NVIDIA NVENC session-cap guidance is factual but volatile. Hardware requirement and transcoding guides should stay aligned on whether GeForce-class cards are typically capped at 2-3 concurrent sessions and whether newer generations changed that default.",
+      "confidence": "low",
+      "recommended_action": "verify-more"
+    },
+    {
+      "claim_family": "stake-threshold",
+      "claim_id": "orch-active-set-threshold",
+      "pages": [
+        {
+          "file": "v2/orchestrators/guides/operator-considerations/business-case.mdx",
+          "values": [
+            "active set"
+          ],
+          "snippet": "Practical discipline for commercial capability management: Declare only models that are loaded and warm at startup Remove capability declarations for models that are not being actively served Use to specify exactly which pipeline/model combinations to load on startup Monitor model load times and remove slow start models from the active set Building Gateway relationships Active commercial relationships with Gateways typically develop through: Consistent performance history visible on the Livepeer Explorer Participation in the channel on the Direct outreach to Gateway SPEs and ecosystem partners Demonstrated capability support for pipelines that specific Gateways need Gateways serving AI products actively look for Orchestrators with specific capability profiles."
+        },
+        {
+          "file": "v2/orchestrators/setup/rcs-requirements.mdx",
+          "values": [
+            "active set",
+            "top 100"
+          ],
+          "snippet": "The amount needed to enter the active set (top 100) varies — check for the current threshold."
+        }
+      ],
+      "best_known_truth": "Solo transcoding guidance repeatedly states that operators need enough bonded LPT to enter the active set, often phrased as top 100, but that wording is time-sensitive and should not be treated as durable fact without current evidence.",
+      "confidence": "low",
+      "recommended_action": "verify-more"
+    },
+    {
+      "claim_family": "setup-prerequisites",
+      "claim_id": "orch-pool-vs-solo-prerequisites",
+      "pages": [
+        {
+          "file": "v2/orchestrators/guides/deployment-details/setup-options.mdx",
+          "values": [
+            "Pool Worker",
+            "Pool worker",
+            "pool worker"
+          ],
+          "snippet": "At a Glance Alternative What it solves What it requires Guide Pool worker Earn from GPU compute without running an Orchestrator at all no LPT, no on chain management GPU; a pool to join; no stake O T split Separate protocol management from GPU workload processing; scale Transcoder machines independently Two machines; LPT stake; Siphon Keep the keystore on an isolated machine; GPU machine can restart without missing LPT rewards Two machines; LPT stake; Python on secure machine Pool Worker A pool worker does not run an Orchestrator."
+        },
+        {
+          "file": "v2/orchestrators/guides/deployment-details/setup-options.mdx",
+          "values": [
+            "Pool Worker",
+            "Pool worker",
+            "pool worker"
+          ],
+          "snippet": "At a Glance Alternative What it solves What it requires Guide Pool worker Earn from GPU compute without running an Orchestrator at all no LPT, no on chain management GPU; a pool to join; no stake O T split Separate protocol management from GPU workload processing; scale Transcoder machines independently Two machines; LPT stake; Siphon Keep the keystore on an isolated machine; GPU machine can restart without missing LPT rewards Two machines; LPT stake; Python on secure machine Pool Worker A pool worker does not run an Orchestrator."
+        },
+        {
+          "file": "v2/orchestrators/guides/operator-considerations/business-case.mdx",
+          "values": [],
+          "snippet": "Pool operators manage the Orchestrator registration, on chain staking, and reward calling for a fleet of GPU workers."
+        },
+        {
+          "file": "v2/orchestrators/setup/rcs-requirements.mdx",
+          "values": [],
+          "snippet": "LPT on Arbitrum One — for staking."
+        }
+      ],
+      "best_known_truth": "Pool workers and solo operators have different prerequisites. Pages should not imply that LPT, ETH, or public service exposure are universal requirements for every orchestrator entry path.",
+      "confidence": "low",
+      "recommended_action": "verify-more"
+    },
+    {
+      "claim_family": "ai-routing-mechanics",
+      "claim_id": "orch-ai-routing-capability-based",
+      "pages": [
+        {
+          "file": "v2/orchestrators/guides/ai-and-job-workloads/job-types.mdx",
+          "values": [
+            "Stake plays a much smaller role",
+            "capability match"
+          ],
+          "snippet": "Batch AI inference AI jobs route on capability match + price ceiling."
+        }
+      ],
+      "best_known_truth": "AI jobs are routed primarily by capability match and price ceilings rather than by stake weight. Docs should not collapse AI routing into the same rules as transcoding routing.",
+      "confidence": "low",
+      "recommended_action": "verify-more"
+    },
+    {
+      "claim_family": "community-tooling-status",
+      "claim_id": "orch-siphon-github-current",
+      "pages": [
+        {
+          "file": "v2/orchestrators/guides/deployment-details/setup-options.mdx",
+          "values": [
+            "OrchestratorSiphon",
+            "Siphon"
+          ],
+          "snippet": "At a Glance Alternative What it solves What it requires Guide Pool worker Earn from GPU compute without running an Orchestrator at all no LPT, no on chain management GPU; a pool to join; no stake O T split Separate protocol management from GPU workload processing; scale Transcoder machines independently Two machines; LPT stake; Siphon Keep the keystore on an isolated machine; GPU machine can restart without missing LPT rewards Two machines; LPT stake; Python on secure machine Pool Worker A pool worker does not run an Orchestrator."
+        },
+        {
+          "file": "v2/orchestrators/guides/deployment-details/setup-options.mdx",
+          "values": [
+            "OrchestratorSiphon",
+            "Siphon"
+          ],
+          "snippet": "At a Glance Alternative What it solves What it requires Guide Pool worker Earn from GPU compute without running an Orchestrator at all no LPT, no on chain management GPU; a pool to join; no stake O T split Separate protocol management from GPU workload processing; scale Transcoder machines independently Two machines; LPT stake; Siphon Keep the keystore on an isolated machine; GPU machine can restart without missing LPT rewards Two machines; LPT stake; Python on secure machine Pool Worker A pool worker does not run an Orchestrator."
+        }
+      ],
+      "best_known_truth": "Split-setup guidance depends on OrchestratorSiphon still being an active community-maintained project. That claim should be checked against the current GitHub repository, not just repeated in docs.",
+      "confidence": "low",
+      "recommended_action": "verify-more"
+    },
+    {
+      "claim_family": "split-setup-reward-safety",
+      "claim_id": "orch-siphon-reward-isolation",
+      "pages": [
+        {
+          "file": "v2/orchestrators/guides/deployment-details/siphon-setup.mdx",
+          "values": [
+            "GPU machine can restart",
+            "reward",
+            "reward calling"
+          ],
+          "snippet": "If the GPU machine reboots mid round, that round's LPT inflation reward is permanently lost and missed rewards compound over time."
+        },
+        {
+          "file": "v2/orchestrators/guides/deployment-details/setup-options.mdx",
+          "values": [
+            "GPU machine can restart",
+            "reward calling"
+          ],
+          "snippet": "At a Glance Alternative What it solves What it requires Guide Pool worker Earn from GPU compute without running an Orchestrator at all no LPT, no on chain management GPU; a pool to join; no stake O T split Separate protocol management from GPU workload processing; scale Transcoder machines independently Two machines; LPT stake; Siphon Keep the keystore on an isolated machine; GPU machine can restart without missing LPT rewards Two machines; LPT stake; Python on secure machine Pool Worker A pool worker does not run an Orchestrator."
+        }
+      ],
+      "best_known_truth": "A split setup with OrchestratorSiphon isolates the keystore from the GPU machine and keeps reward calling independent of GPU uptime. Docs should keep that claim aligned across setup-path pages.",
+      "confidence": "low",
+      "recommended_action": "verify-more"
+    }
+  ],
+  "propagation_queue": [
+    {
+      "file": "v2/orchestrators/guides/ai-and-job-workloads/ai-workloads-guide.mdx",
+      "page_class": "guide",
+      "role": "dependent-page",
+      "action": "verify-only",
+      "claim_id": "orch-commercial-model-warmth"
+    },
+    {
+      "file": "v2/orchestrators/guides/ai-and-job-workloads/batch-ai-setup.mdx",
+      "page_class": "guide",
+      "role": "dependent-page",
+      "action": "verify-only",
+      "claim_id": "orch-commercial-model-warmth"
+    },
+    {
+      "file": "v2/orchestrators/guides/ai-and-job-workloads/job-types.mdx",
+      "page_class": "guide",
+      "role": "canonical-owner",
+      "action": "verify-only",
+      "claim_id": "orch-ai-routing-capability-based"
+    },
+    {
+      "file": "v2/orchestrators/guides/ai-and-job-workloads/job-types.mdx",
+      "page_class": "guide",
+      "role": "dependent-page",
+      "action": "verify-only",
+      "claim_id": "orch-consumer-nvenc-session-cap"
+    },
+    {
+      "file": "v2/orchestrators/guides/ai-and-job-workloads/video-transcoding.mdx",
+      "page_class": "guide",
+      "role": "dependent-page",
+      "action": "verify-only",
+      "claim_id": "orch-consumer-nvenc-session-cap"
+    },
+    {
+      "file": "v2/orchestrators/guides/deployment-details/dual-workload-setup.mdx",
+      "page_class": "guide",
+      "role": "dependent-page",
+      "action": "verify-only",
+      "claim_id": "orch-commercial-model-warmth"
+    },
+    {
+      "file": "v2/orchestrators/guides/deployment-details/requirements.mdx",
+      "page_class": "guide",
+      "role": "dependent-page",
+      "action": "verify-only",
+      "claim_id": "orch-bandwidth-per-stream-planning"
+    },
+    {
+      "file": "v2/orchestrators/guides/deployment-details/requirements.mdx",
+      "page_class": "guide",
+      "role": "canonical-owner",
+      "action": "verify-only",
+      "claim_id": "orch-batch-ai-vram-threshold"
+    },
+    {
+      "file": "v2/orchestrators/guides/deployment-details/requirements.mdx",
+      "page_class": "guide",
+      "role": "dependent-page",
+      "action": "verify-only",
+      "claim_id": "orch-business-case-cost-viability"
+    },
+    {
+      "file": "v2/orchestrators/guides/deployment-details/requirements.mdx",
+      "page_class": "guide",
+      "role": "canonical-owner",
+      "action": "verify-only",
+      "claim_id": "orch-consumer-nvenc-session-cap"
+    },
+    {
+      "file": "v2/orchestrators/guides/deployment-details/requirements.mdx",
+      "page_class": "guide",
+      "role": "dependent-page",
+      "action": "verify-only",
+      "claim_id": "orch-session-limit-default"
+    },
+    {
+      "file": "v2/orchestrators/guides/deployment-details/setup-options.mdx",
+      "page_class": "guide",
+      "role": "dependent-page",
+      "action": "verify-only",
+      "claim_id": "orch-active-set-threshold"
+    },
+    {
+      "file": "v2/orchestrators/guides/deployment-details/setup-options.mdx",
+      "page_class": "guide",
+      "role": "dependent-page",
+      "action": "verify-only",
+      "claim_id": "orch-ai-routing-capability-based"
+    },
+    {
+      "file": "v2/orchestrators/guides/deployment-details/setup-options.mdx",
+      "page_class": "guide",
+      "role": "dependent-page",
+      "action": "verify-only",
+      "claim_id": "orch-batch-ai-vram-threshold"
+    },
+    {
+      "file": "v2/orchestrators/guides/deployment-details/setup-options.mdx",
+      "page_class": "guide",
+      "role": "canonical-owner",
+      "action": "verify-only",
+      "claim_id": "orch-pool-vs-solo-prerequisites"
+    },
+    {
+      "file": "v2/orchestrators/guides/deployment-details/setup-options.mdx",
+      "page_class": "guide",
+      "role": "canonical-owner",
+      "action": "verify-only",
+      "claim_id": "orch-siphon-github-current"
+    },
+    {
+      "file": "v2/orchestrators/guides/deployment-details/setup-options.mdx",
+      "page_class": "guide",
+      "role": "dependent-page",
+      "action": "verify-only",
+      "claim_id": "orch-siphon-reward-isolation"
+    },
+    {
+      "file": "v2/orchestrators/guides/deployment-details/siphon-setup.mdx",
+      "page_class": "guide",
+      "role": "canonical-owner",
+      "action": "verify-only",
+      "claim_id": "orch-siphon-reward-isolation"
+    },
+    {
+      "file": "v2/orchestrators/guides/operator-considerations/business-case.mdx",
+      "page_class": "guide",
+      "role": "canonical-owner",
+      "action": "verify-only",
+      "claim_id": "orch-active-set-threshold"
+    },
+    {
+      "file": "v2/orchestrators/guides/operator-considerations/business-case.mdx",
+      "page_class": "guide",
+      "role": "dependent-page",
+      "action": "verify-only",
+      "claim_id": "orch-bandwidth-per-stream-planning"
+    },
+    {
+      "file": "v2/orchestrators/guides/operator-considerations/business-case.mdx",
+      "page_class": "guide",
+      "role": "dependent-page",
+      "action": "verify-only",
+      "claim_id": "orch-batch-ai-vram-threshold"
+    },
+    {
+      "file": "v2/orchestrators/guides/operator-considerations/business-case.mdx",
+      "page_class": "guide",
+      "role": "canonical-owner",
+      "action": "verify-only",
+      "claim_id": "orch-business-case-cost-viability"
+    },
+    {
+      "file": "v2/orchestrators/guides/operator-considerations/business-case.mdx",
+      "page_class": "guide",
+      "role": "canonical-owner",
+      "action": "verify-only",
+      "claim_id": "orch-commercial-model-warmth"
+    },
+    {
+      "file": "v2/orchestrators/guides/operator-considerations/business-case.mdx",
+      "page_class": "guide",
+      "role": "dependent-page",
+      "action": "verify-only",
+      "claim_id": "orch-pool-vs-solo-prerequisites"
+    },
+    {
+      "file": "v2/orchestrators/guides/operator-considerations/business-case.mdx",
+      "page_class": "guide",
+      "role": "dependent-page",
+      "action": "verify-only",
+      "claim_id": "orch-reward-profitability-threshold"
+    },
+    {
+      "file": "v2/orchestrators/guides/staking-and-rewards/rewards-and-fees.mdx",
+      "page_class": "guide",
+      "role": "canonical-owner",
+      "action": "verify-only",
+      "claim_id": "orch-reward-profitability-threshold"
+    },
+    {
+      "file": "v2/orchestrators/setup/configure.mdx",
+      "page_class": "setup",
+      "role": "canonical-owner",
+      "action": "verify-only",
+      "claim_id": "orch-bandwidth-per-stream-planning"
+    },
+    {
+      "file": "v2/orchestrators/setup/configure.mdx",
+      "page_class": "setup",
+      "role": "canonical-owner",
+      "action": "verify-only",
+      "claim_id": "orch-session-limit-default"
+    },
+    {
+      "file": "v2/orchestrators/setup/rcs-requirements.mdx",
+      "page_class": "setup",
+      "role": "dependent-page",
+      "action": "verify-only",
+      "claim_id": "orch-active-set-threshold"
+    },
+    {
+      "file": "v2/orchestrators/setup/rcs-requirements.mdx",
+      "page_class": "setup",
+      "role": "dependent-page",
+      "action": "verify-only",
+      "claim_id": "orch-batch-ai-vram-threshold"
+    },
+    {
+      "file": "v2/orchestrators/setup/rcs-requirements.mdx",
+      "page_class": "setup",
+      "role": "dependent-page",
+      "action": "verify-only",
+      "claim_id": "orch-pool-vs-solo-prerequisites"
+    }
+  ],
+  "evidence_sources": [
+    {
+      "claim_id": "orch-batch-ai-vram-threshold",
+      "type": "repo-file",
+      "ref": "v2/orchestrators/guides/deployment-details/requirements.mdx",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "repo evidence matched"
+    },
+    {
+      "claim_id": "orch-batch-ai-vram-threshold",
+      "type": "repo-file",
+      "ref": "v2/orchestrators/setup/rcs-requirements.mdx",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "repo evidence matched"
+    },
+    {
+      "claim_id": "orch-commercial-model-warmth",
+      "type": "repo-file",
+      "ref": "v2/orchestrators/guides/operator-considerations/business-case.mdx",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "repo evidence matched"
+    },
+    {
+      "claim_id": "orch-commercial-model-warmth",
+      "type": "repo-file",
+      "ref": "v2/orchestrators/guides/deployment-details/dual-workload-setup.mdx",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "repo evidence matched"
+    },
+    {
+      "claim_id": "orch-commercial-model-warmth",
+      "type": "repo-file",
+      "ref": "v2/orchestrators/guides/ai-and-job-workloads/batch-ai-setup.mdx",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "repo evidence matched"
+    },
+    {
+      "claim_id": "orch-consumer-nvenc-session-cap",
+      "type": "repo-file",
+      "ref": "v2/orchestrators/guides/deployment-details/requirements.mdx",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "repo evidence matched"
+    },
+    {
+      "claim_id": "orch-consumer-nvenc-session-cap",
+      "type": "repo-file",
+      "ref": "v2/orchestrators/guides/ai-and-job-workloads/video-transcoding.mdx",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "repo evidence matched"
+    },
+    {
+      "claim_id": "orch-active-set-threshold",
+      "type": "official-page",
+      "ref": "https://explorer.livepeer.org/orchestrators",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": false,
+      "summary": "official page fetched but signal missing"
+    },
+    {
+      "claim_id": "orch-pool-vs-solo-prerequisites",
+      "type": "repo-file",
+      "ref": "v2/orchestrators/guides/deployment-details/setup-options.mdx",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "repo evidence matched"
+    },
+    {
+      "claim_id": "orch-pool-vs-solo-prerequisites",
+      "type": "repo-file",
+      "ref": "v2/orchestrators/guides/deployment-details/join-a-pool.mdx",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "repo evidence matched"
+    },
+    {
+      "claim_id": "orch-bandwidth-per-stream-planning",
+      "type": "repo-file",
+      "ref": "v2/orchestrators/setup/configure.mdx",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "repo evidence matched"
+    },
+    {
+      "claim_id": "orch-bandwidth-per-stream-planning",
+      "type": "repo-file",
+      "ref": "v2/orchestrators/guides/deployment-details/requirements.mdx",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "repo evidence matched"
+    },
+    {
+      "claim_id": "orch-business-case-cost-viability",
+      "type": "repo-file",
+      "ref": "v2/orchestrators/guides/operator-considerations/business-case.mdx",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "repo evidence matched"
+    },
+    {
+      "claim_id": "orch-business-case-cost-viability",
+      "type": "repo-file",
+      "ref": "v2/orchestrators/guides/deployment-details/requirements.mdx",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "repo evidence matched"
+    },
+    {
+      "claim_id": "orch-session-limit-default",
+      "type": "repo-file",
+      "ref": "v2/orchestrators/setup/configure.mdx",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "repo evidence matched"
+    },
+    {
+      "claim_id": "orch-reward-profitability-threshold",
+      "type": "repo-file",
+      "ref": "v2/orchestrators/guides/staking-and-rewards/rewards-and-fees.mdx",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "repo evidence matched"
+    },
+    {
+      "claim_id": "orch-ai-routing-capability-based",
+      "type": "repo-file",
+      "ref": "v2/orchestrators/guides/ai-and-job-workloads/job-types.mdx",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "repo evidence matched"
+    },
+    {
+      "claim_id": "orch-ai-routing-capability-based",
+      "type": "repo-file",
+      "ref": "v2/orchestrators/guides/deployment-details/dual-workload-setup.mdx",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "repo evidence matched"
+    },
+    {
+      "claim_id": "orch-siphon-github-current",
+      "type": "github-repo",
+      "ref": "https://github.com/Stronk-Tech/OrchestratorSiphon",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "GitHub evidence matched"
+    },
+    {
+      "claim_id": "orch-siphon-reward-isolation",
+      "type": "repo-file",
+      "ref": "v2/orchestrators/guides/deployment-details/siphon-setup.mdx",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "repo evidence matched"
+    },
+    {
+      "claim_id": "orch-siphon-reward-isolation",
+      "type": "github-repo",
+      "ref": "https://github.com/Stronk-Tech/OrchestratorSiphon",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "GitHub evidence matched"
+    }
+  ],
+  "validation": {
+    "target_files": 6,
+    "claim_families": 9,
+    "contradictions": 7,
+    "evidence_sources": 21
+  }
+}

--- a/tasks/reports/repo-ops/2026-03-16-page-content-research-pilot-orchestrator-sla-session-cap.md
+++ b/tasks/reports/repo-ops/2026-03-16-page-content-research-pilot-orchestrator-sla-session-cap.md
@@ -1,0 +1,242 @@
+# Docs Page Research Report
+
+## Scope
+
+- `v2/orchestrators/guides/ai-and-job-workloads/ai-workloads-guide.mdx`
+- `v2/orchestrators/guides/ai-and-job-workloads/batch-ai-setup.mdx`
+- `v2/orchestrators/guides/ai-and-job-workloads/video-transcoding.mdx`
+- `v2/orchestrators/guides/deployment-details/dual-workload-setup.mdx`
+- `v2/orchestrators/guides/deployment-details/requirements.mdx`
+- `v2/orchestrators/guides/operator-considerations/business-case.mdx`
+
+## Claims Reviewed
+
+- `v2/orchestrators/guides/ai-and-job-workloads/ai-workloads-guide.mdx`
+  - claim families: `orch-commercial-model-warmth`
+  - extracted: Livepeer's AI subnet launched in Q3 2024 and has grown to become the primary source of new fee revenue for orchestrators.
+  - extracted: AI pipelines run alongside your existing node using dedicated AI Runner containers.
+  - extracted: Your orchestrator advertises capabilities — which pipelines it supports and at what price — and gateways route matching jobs to it.
+  - extracted: When a gateway selects your orchestrator, it is because your combination of capability, pricing, latency, and uptime made you the best option for that specific request.
+- `v2/orchestrators/guides/ai-and-job-workloads/batch-ai-setup.mdx`
+  - claim families: `orch-commercial-model-warmth`
+  - extracted: You earn per unit fees for every successful job.
+  - extracted: This guide covers everything needed to run batch AI pipelines: configuring , choosing and loading models, running the Ollama LLM runner, connecting BYOC external containers, setting pricing, and diagnosing problems.
+  - extracted: Prerequisites Before configuring AI pipelines, ensure: go livepeer is running with the flag enabled NVIDIA Container Toolkit is installed and working ( ) Docker is running and can access your GPUs You have a file or know where you want to create one How the AI worker runs pipelines When go livepeer starts with , it reads and starts Docker containers for each configured pipeline: The standard container image is .
+  - extracted: Except for the pipeline — which uses a separate Ollama based runner — all batch pipelines use this image.
+- `v2/orchestrators/guides/ai-and-job-workloads/video-transcoding.mdx`
+  - claim families: `orch-consumer-nvenc-session-cap`
+  - extracted: How transcoding works When a broadcaster sends a live stream to a Livepeer gateway, the gateway segments the stream into roughly 2 second chunks and routes each segment to an orchestrator.
+  - extracted: You set your price with the flag; by default is 1, meaning you charge in wei per individual output pixel.
+  - extracted: This charges 500 wei per output pixel.
+  - extracted: Option B: USD pricing (go livepeer 0.8.0+) USD pricing pegs your transcoding fee to a dollar amount and automatically converts to wei via a .
+- `v2/orchestrators/guides/deployment-details/dual-workload-setup.mdx`
+  - claim families: `orch-commercial-model-warmth`
+  - extracted: Because these two execution paths use separate hardware resources, adding AI capabilities to a running video node requires no changes to your on chain registration, staking, or existing transcoding configuration.
+  - extracted: Dual Mode requires Linux.
+  - extracted: Video only AI only Dual Mode Revenue streams ETH transcoding fees + LPT rewards ETH AI inference fees Both streams simultaneously Pricing config (wei per pixel) per pipeline Both and GPU execution path NVENC/NVDEC hardware blocks CUDA compute cores Both paths, independent queues VRAM requirement Minimal (frame buffers only) 8 24 GB depending on model 16 GB recommended; 8 GB viable for LLM only pipelines Active set Required for video job eligibility Not required for AI job eligibility Required for video; AI routes via capability advertisement OS support Linux, Windows Linux only Linux only Before You Start Confirm these prerequisites before starting: Hardware: NVIDIA GPU with 16 GB VRAM or more.
+  - extracted: 8 GB is sufficient for LLM pipelines via the Ollama runner.
+- `v2/orchestrators/guides/deployment-details/requirements.mdx`
+  - claim families: `orch-bandwidth-per-stream-planning`, `orch-batch-ai-vram-threshold`, `orch-business-case-cost-viability`, `orch-consumer-nvenc-session-cap`, `orch-session-limit-default`
+  - extracted: This page covers GPU support policy, session limits by card tier, VRAM requirements by AI pipeline, the minimum system stack, capacity testing, and the checklist to run before activating on the network.
+  - extracted: GPU Vendor Support NVIDIA is the supported GPU vendor for go livepeer.
+  - extracted: AMD and Intel GPUs are not supported for hardware accelerated transcoding or AI inference.
+  - extracted: NVIDIA CUDA is required for both NVENC video transcoding and all AI inference pipelines.
+- `v2/orchestrators/guides/operator-considerations/business-case.mdx`
+  - claim families: `orch-active-set-threshold`, `orch-bandwidth-per-stream-planning`, `orch-batch-ai-vram-threshold`, `orch-business-case-cost-viability`, `orch-commercial-model-warmth`, `orch-pool-vs-solo-prerequisites`, `orch-reward-profitability-threshold`
+  - extracted: Most Orchestrator operators start by thinking about LPT inflation rewards.
+  - extracted: Commercial operators think primarily about ETH service fees.
+  - extracted: Dimension Hobbyist operator Commercial operator Primary income LPT inflation rewards ETH service fees from job processing Revenue lever Total bonded stake Job volume, pricing discipline, uptime Uptime requirement ~95% (reward calls + basic availability) 99%+ (SLA driven, continuous monitoring) Gateway relationship Passive wait to be selected by price and stake Active direct relationships, per Gateway pricing Hardware approach Existing hardware repurposed Dedicated investment, redundancy planned Monitoring Periodic checks, Prometheus optional Automated alerting, SLA dashboards Model loading Load on demand; cold starts acceptable Pre loaded and warm; cold starts are SLA failures Neither model is superior they reflect different operator goals and capabilities.
+  - extracted: Many operators run a hybrid: inflation rewards provide a base, service fees from well served application workloads provide the upside.
+
+## Verified Claims
+
+- None
+
+## Conflicted Claims
+
+- `orch-batch-ai-vram-threshold` (conflicted, low)
+  - owner: `v2/orchestrators/guides/deployment-details/requirements.mdx`
+  - summary: Docs disagree on the practical VRAM minimum for batch AI and real-time AI workloads. Hardware and setup pages should not present conflicting minimums as equally current.
+- `orch-consumer-nvenc-session-cap` (conflicted, low)
+  - owner: `v2/orchestrators/guides/deployment-details/requirements.mdx`
+  - summary: Consumer NVIDIA NVENC session-cap guidance is factual but volatile. Hardware requirement and transcoding guides should stay aligned on whether GeForce-class cards are typically capped at 2-3 concurrent sessions and whether newer generations changed that default.
+- `orch-active-set-threshold` (conflicted, low)
+  - owner: `v2/orchestrators/guides/operator-considerations/business-case.mdx`
+  - summary: Solo transcoding guidance repeatedly states that operators need enough bonded LPT to enter the active set, often phrased as top 100, but that wording is time-sensitive and should not be treated as durable fact without current evidence.
+- `orch-pool-vs-solo-prerequisites` (conflicted, low)
+  - owner: `v2/orchestrators/guides/deployment-details/setup-options.mdx`
+  - summary: Pool workers and solo operators have different prerequisites. Pages should not imply that LPT, ETH, or public service exposure are universal requirements for every orchestrator entry path.
+- `orch-ai-routing-capability-based` (conflicted, low)
+  - owner: `v2/orchestrators/guides/ai-and-job-workloads/job-types.mdx`
+  - summary: AI jobs are routed primarily by capability match and price ceilings rather than by stake weight. Docs should not collapse AI routing into the same rules as transcoding routing.
+- `orch-siphon-github-current` (conflicted, low)
+  - owner: `v2/orchestrators/guides/deployment-details/setup-options.mdx`
+  - summary: Split-setup guidance depends on OrchestratorSiphon still being an active community-maintained project. That claim should be checked against the current GitHub repository, not just repeated in docs.
+- `orch-siphon-reward-isolation` (conflicted, low)
+  - owner: `v2/orchestrators/guides/deployment-details/siphon-setup.mdx`
+  - summary: A split setup with OrchestratorSiphon isolates the keystore from the GPU machine and keeps reward calling independent of GPU uptime. Docs should keep that claim aligned across setup-path pages.
+
+## Time-Sensitive Claims
+
+- `orch-commercial-model-warmth` (time-sensitive, medium)
+  - owner: `v2/orchestrators/guides/operator-considerations/business-case.mdx`
+  - summary: Commercial AI operator guidance should keep warm-model, pre-loaded startup, and cold-start SLA language aligned across setup and business-case pages. These claims describe real operational expectations, but they remain experimental and workload-sensitive.
+- `orch-bandwidth-per-stream-planning` (time-sensitive, medium)
+  - owner: `v2/orchestrators/setup/configure.mdx`
+  - summary: Bandwidth planning for transcoding is currently presented as an approximate planning rule rather than a single durable network constant. Pages should make the source-resolution assumption and rendition-set basis explicit when quoting per-stream bandwidth.
+- `orch-business-case-cost-viability` (time-sensitive, medium)
+  - owner: `v2/orchestrators/guides/operator-considerations/business-case.mdx`
+  - summary: Business-case guidance should explicitly stay approximate and local-context dependent. Payback, electricity cost, and 'worth it' framing are useful, but they should not be presented as portable constants across operators, geographies, or market conditions.
+- `orch-session-limit-default` (time-sensitive, medium)
+  - owner: `v2/orchestrators/setup/configure.mdx`
+  - summary: The default session limit and overload behavior are operational facts that multiple setup and hardware pages depend on. When docs state the default cap or the error condition, they should stay aligned with current go-livepeer behavior.
+- `orch-reward-profitability-threshold` (time-sensitive, medium)
+  - owner: `v2/orchestrators/guides/staking-and-rewards/rewards-and-fees.mdx`
+  - summary: Reward-call profitability guidance should remain explicitly time-sensitive because gas cost, ETH price, and LPT price move. Docs must not present rough thresholds as durable constants.
+
+## Unverified / Historical Claims
+
+- None
+
+## Cross-Page Contradictions
+
+- `orch-batch-ai-vram-threshold` (hardware-vram-minimums)
+  - action: verify-more
+  - `v2/orchestrators/guides/deployment-details/requirements.mdx`: This page covers GPU support policy, session limits by card tier, VRAM requirements by AI pipeline, the minimum system stack, capacity testing, and the checklist to run before activating on the network.
+  - `v2/orchestrators/guides/operator-considerations/business-case.mdx`: This requires: Automated monitoring with immediate alerts on node failure Automated restart and recovery Stable, redundant connectivity (not shared home broadband) Consistent power supply (UPS or colocation) Hardware health monitoring (GPU temperatures, VRAM utilisation) Model warm up management For AI inference workloads, cold model starts (loading a model from disk into VRAM on first request) introduce latency that breaks user facing SLAs.
+  - `v2/orchestrators/setup/rcs-requirements.mdx`: 16 GB, 24 GB, 8 GB
+- `orch-consumer-nvenc-session-cap` (consumer-nvenc-session-cap)
+  - action: verify-more
+  - `v2/orchestrators/guides/deployment-details/requirements.mdx`: 3 concurrent NVENC encode sessions, 3 concurrent sessions
+  - `v2/orchestrators/guides/ai-and-job-workloads/job-types.mdx`: Your best options: Transcoding — you can handle video transcoding sessions competitively with any modern NVIDIA GPU; NVENC session caps on consumer cards apply, but can be worked around.
+  - `v2/orchestrators/guides/ai-and-job-workloads/video-transcoding.mdx`: NVENC session caps on consumer GPUs Consumer NVIDIA GPUs (GTX/RTX series) have a hardware enforced cap on the number of concurrent NVENC encoding sessions.
+- `orch-active-set-threshold` (stake-threshold)
+  - action: verify-more
+  - `v2/orchestrators/guides/operator-considerations/business-case.mdx`: active set
+  - `v2/orchestrators/setup/rcs-requirements.mdx`: active set, top 100
+- `orch-pool-vs-solo-prerequisites` (setup-prerequisites)
+  - action: verify-more
+  - `v2/orchestrators/guides/deployment-details/setup-options.mdx`: Pool Worker, Pool worker, pool worker
+  - `v2/orchestrators/guides/deployment-details/setup-options.mdx`: Pool Worker, Pool worker, pool worker
+  - `v2/orchestrators/guides/operator-considerations/business-case.mdx`: Pool operators manage the Orchestrator registration, on chain staking, and reward calling for a fleet of GPU workers.
+  - `v2/orchestrators/setup/rcs-requirements.mdx`: LPT on Arbitrum One — for staking.
+- `orch-ai-routing-capability-based` (ai-routing-mechanics)
+  - action: verify-more
+  - `v2/orchestrators/guides/ai-and-job-workloads/job-types.mdx`: Stake plays a much smaller role, capability match
+- `orch-siphon-github-current` (community-tooling-status)
+  - action: verify-more
+  - `v2/orchestrators/guides/deployment-details/setup-options.mdx`: OrchestratorSiphon, Siphon
+  - `v2/orchestrators/guides/deployment-details/setup-options.mdx`: OrchestratorSiphon, Siphon
+- `orch-siphon-reward-isolation` (split-setup-reward-safety)
+  - action: verify-more
+  - `v2/orchestrators/guides/deployment-details/siphon-setup.mdx`: GPU machine can restart, reward, reward calling
+  - `v2/orchestrators/guides/deployment-details/setup-options.mdx`: GPU machine can restart, reward calling
+
+## Propagation Queue
+
+| File | Class | Role | Action | Claim |
+|---|---|---|---|---|
+| `v2/orchestrators/guides/ai-and-job-workloads/ai-workloads-guide.mdx` | guide | dependent-page | verify-only | `orch-commercial-model-warmth` |
+| `v2/orchestrators/guides/ai-and-job-workloads/batch-ai-setup.mdx` | guide | dependent-page | verify-only | `orch-commercial-model-warmth` |
+| `v2/orchestrators/guides/ai-and-job-workloads/job-types.mdx` | guide | canonical-owner | verify-only | `orch-ai-routing-capability-based` |
+| `v2/orchestrators/guides/ai-and-job-workloads/job-types.mdx` | guide | dependent-page | verify-only | `orch-consumer-nvenc-session-cap` |
+| `v2/orchestrators/guides/ai-and-job-workloads/video-transcoding.mdx` | guide | dependent-page | verify-only | `orch-consumer-nvenc-session-cap` |
+| `v2/orchestrators/guides/deployment-details/dual-workload-setup.mdx` | guide | dependent-page | verify-only | `orch-commercial-model-warmth` |
+| `v2/orchestrators/guides/deployment-details/requirements.mdx` | guide | dependent-page | verify-only | `orch-bandwidth-per-stream-planning` |
+| `v2/orchestrators/guides/deployment-details/requirements.mdx` | guide | canonical-owner | verify-only | `orch-batch-ai-vram-threshold` |
+| `v2/orchestrators/guides/deployment-details/requirements.mdx` | guide | dependent-page | verify-only | `orch-business-case-cost-viability` |
+| `v2/orchestrators/guides/deployment-details/requirements.mdx` | guide | canonical-owner | verify-only | `orch-consumer-nvenc-session-cap` |
+| `v2/orchestrators/guides/deployment-details/requirements.mdx` | guide | dependent-page | verify-only | `orch-session-limit-default` |
+| `v2/orchestrators/guides/deployment-details/setup-options.mdx` | guide | dependent-page | verify-only | `orch-active-set-threshold` |
+| `v2/orchestrators/guides/deployment-details/setup-options.mdx` | guide | dependent-page | verify-only | `orch-ai-routing-capability-based` |
+| `v2/orchestrators/guides/deployment-details/setup-options.mdx` | guide | dependent-page | verify-only | `orch-batch-ai-vram-threshold` |
+| `v2/orchestrators/guides/deployment-details/setup-options.mdx` | guide | canonical-owner | verify-only | `orch-pool-vs-solo-prerequisites` |
+| `v2/orchestrators/guides/deployment-details/setup-options.mdx` | guide | canonical-owner | verify-only | `orch-siphon-github-current` |
+| `v2/orchestrators/guides/deployment-details/setup-options.mdx` | guide | dependent-page | verify-only | `orch-siphon-reward-isolation` |
+| `v2/orchestrators/guides/deployment-details/siphon-setup.mdx` | guide | canonical-owner | verify-only | `orch-siphon-reward-isolation` |
+| `v2/orchestrators/guides/operator-considerations/business-case.mdx` | guide | canonical-owner | verify-only | `orch-active-set-threshold` |
+| `v2/orchestrators/guides/operator-considerations/business-case.mdx` | guide | dependent-page | verify-only | `orch-bandwidth-per-stream-planning` |
+| `v2/orchestrators/guides/operator-considerations/business-case.mdx` | guide | dependent-page | verify-only | `orch-batch-ai-vram-threshold` |
+| `v2/orchestrators/guides/operator-considerations/business-case.mdx` | guide | canonical-owner | verify-only | `orch-business-case-cost-viability` |
+| `v2/orchestrators/guides/operator-considerations/business-case.mdx` | guide | canonical-owner | verify-only | `orch-commercial-model-warmth` |
+| `v2/orchestrators/guides/operator-considerations/business-case.mdx` | guide | dependent-page | verify-only | `orch-pool-vs-solo-prerequisites` |
+| `v2/orchestrators/guides/operator-considerations/business-case.mdx` | guide | dependent-page | verify-only | `orch-reward-profitability-threshold` |
+| `v2/orchestrators/guides/staking-and-rewards/rewards-and-fees.mdx` | guide | canonical-owner | verify-only | `orch-reward-profitability-threshold` |
+| `v2/orchestrators/setup/configure.mdx` | setup | canonical-owner | verify-only | `orch-bandwidth-per-stream-planning` |
+| `v2/orchestrators/setup/configure.mdx` | setup | canonical-owner | verify-only | `orch-session-limit-default` |
+| `v2/orchestrators/setup/rcs-requirements.mdx` | setup | dependent-page | verify-only | `orch-active-set-threshold` |
+| `v2/orchestrators/setup/rcs-requirements.mdx` | setup | dependent-page | verify-only | `orch-batch-ai-vram-threshold` |
+| `v2/orchestrators/setup/rcs-requirements.mdx` | setup | dependent-page | verify-only | `orch-pool-vs-solo-prerequisites` |
+
+## Evidence Sources
+
+- `orch-batch-ai-vram-threshold` → repo-file: v2/orchestrators/guides/deployment-details/requirements.mdx
+  - checked: 2026-03-16
+  - result: repo evidence matched
+- `orch-batch-ai-vram-threshold` → repo-file: v2/orchestrators/setup/rcs-requirements.mdx
+  - checked: 2026-03-16
+  - result: repo evidence matched
+- `orch-commercial-model-warmth` → repo-file: v2/orchestrators/guides/operator-considerations/business-case.mdx
+  - checked: 2026-03-16
+  - result: repo evidence matched
+- `orch-commercial-model-warmth` → repo-file: v2/orchestrators/guides/deployment-details/dual-workload-setup.mdx
+  - checked: 2026-03-16
+  - result: repo evidence matched
+- `orch-commercial-model-warmth` → repo-file: v2/orchestrators/guides/ai-and-job-workloads/batch-ai-setup.mdx
+  - checked: 2026-03-16
+  - result: repo evidence matched
+- `orch-consumer-nvenc-session-cap` → repo-file: v2/orchestrators/guides/deployment-details/requirements.mdx
+  - checked: 2026-03-16
+  - result: repo evidence matched
+- `orch-consumer-nvenc-session-cap` → repo-file: v2/orchestrators/guides/ai-and-job-workloads/video-transcoding.mdx
+  - checked: 2026-03-16
+  - result: repo evidence matched
+- `orch-active-set-threshold` → official-page: https://explorer.livepeer.org/orchestrators
+  - checked: 2026-03-16
+  - result: official page fetched but signal missing
+- `orch-pool-vs-solo-prerequisites` → repo-file: v2/orchestrators/guides/deployment-details/setup-options.mdx
+  - checked: 2026-03-16
+  - result: repo evidence matched
+- `orch-pool-vs-solo-prerequisites` → repo-file: v2/orchestrators/guides/deployment-details/join-a-pool.mdx
+  - checked: 2026-03-16
+  - result: repo evidence matched
+- `orch-bandwidth-per-stream-planning` → repo-file: v2/orchestrators/setup/configure.mdx
+  - checked: 2026-03-16
+  - result: repo evidence matched
+- `orch-bandwidth-per-stream-planning` → repo-file: v2/orchestrators/guides/deployment-details/requirements.mdx
+  - checked: 2026-03-16
+  - result: repo evidence matched
+- `orch-business-case-cost-viability` → repo-file: v2/orchestrators/guides/operator-considerations/business-case.mdx
+  - checked: 2026-03-16
+  - result: repo evidence matched
+- `orch-business-case-cost-viability` → repo-file: v2/orchestrators/guides/deployment-details/requirements.mdx
+  - checked: 2026-03-16
+  - result: repo evidence matched
+- `orch-session-limit-default` → repo-file: v2/orchestrators/setup/configure.mdx
+  - checked: 2026-03-16
+  - result: repo evidence matched
+- `orch-reward-profitability-threshold` → repo-file: v2/orchestrators/guides/staking-and-rewards/rewards-and-fees.mdx
+  - checked: 2026-03-16
+  - result: repo evidence matched
+- `orch-ai-routing-capability-based` → repo-file: v2/orchestrators/guides/ai-and-job-workloads/job-types.mdx
+  - checked: 2026-03-16
+  - result: repo evidence matched
+- `orch-ai-routing-capability-based` → repo-file: v2/orchestrators/guides/deployment-details/dual-workload-setup.mdx
+  - checked: 2026-03-16
+  - result: repo evidence matched
+- `orch-siphon-github-current` → github-repo: https://github.com/Stronk-Tech/OrchestratorSiphon
+  - checked: 2026-03-16
+  - result: GitHub evidence matched
+- `orch-siphon-reward-isolation` → repo-file: v2/orchestrators/guides/deployment-details/siphon-setup.mdx
+  - checked: 2026-03-16
+  - result: repo evidence matched
+- `orch-siphon-reward-isolation` → github-repo: https://github.com/Stronk-Tech/OrchestratorSiphon
+  - checked: 2026-03-16
+  - result: GitHub evidence matched
+
+## Validation
+
+- target_files: 6
+- claim_families: 9
+- contradictions: 7
+- evidence_sources: 21

--- a/tasks/reports/repo-ops/2026-03-16-page-content-research-pr-simulation-task2-improvements.json
+++ b/tasks/reports/repo-ops/2026-03-16-page-content-research-pr-simulation-task2-improvements.json
@@ -1,0 +1,1167 @@
+{
+  "generated_at": "2026-03-16T03:50:21.055Z",
+  "changed_files": [
+    "v2/orchestrators/guides/operator-considerations/business-case.mdx",
+    "v2/orchestrators/guides/deployment-details/requirements.mdx",
+    "v2/gateways/guides/payments-and-pricing/pricing-strategy.mdx",
+    "v2/gateways/guides/payments-and-pricing/clearinghouse-guide.mdx"
+  ],
+  "target_files": [
+    "v2/orchestrators/guides/operator-considerations/business-case.mdx",
+    "v2/orchestrators/guides/deployment-details/requirements.mdx",
+    "v2/gateways/guides/payments-and-pricing/pricing-strategy.mdx",
+    "v2/gateways/guides/payments-and-pricing/clearinghouse-guide.mdx"
+  ],
+  "matched_claim_families": [
+    {
+      "claim_id": "gw-price-cap-role",
+      "claim_family": "price-cap-role",
+      "status": "verified",
+      "canonical_owner": "v2/gateways/guides/payments-and-pricing/pricing-strategy.mdx",
+      "freshness_class": "review-on-change",
+      "confidence": "high"
+    },
+    {
+      "claim_id": "orch-batch-ai-vram-threshold",
+      "claim_family": "hardware-vram-minimums",
+      "status": "conflicted",
+      "canonical_owner": "v2/orchestrators/guides/deployment-details/requirements.mdx",
+      "freshness_class": "review-on-change",
+      "confidence": "low"
+    },
+    {
+      "claim_id": "gw-clearinghouse-public-readiness",
+      "claim_family": "clearinghouse-public-readiness",
+      "status": "conflicted",
+      "canonical_owner": "v2/gateways/guides/payments-and-pricing/clearinghouse-guide.mdx",
+      "freshness_class": "review-periodic",
+      "confidence": "low"
+    },
+    {
+      "claim_id": "orch-consumer-nvenc-session-cap",
+      "claim_family": "consumer-nvenc-session-cap",
+      "status": "conflicted",
+      "canonical_owner": "v2/orchestrators/guides/deployment-details/requirements.mdx",
+      "freshness_class": "volatile",
+      "confidence": "low"
+    },
+    {
+      "claim_id": "orch-pool-vs-solo-prerequisites",
+      "claim_family": "setup-prerequisites",
+      "status": "conflicted",
+      "canonical_owner": "v2/orchestrators/guides/deployment-details/setup-options.mdx",
+      "freshness_class": "review-on-change",
+      "confidence": "low"
+    },
+    {
+      "claim_id": "gw-discord-community-signal",
+      "claim_family": "community-signal",
+      "status": "conflicted",
+      "canonical_owner": "v2/gateways/guides/operator-considerations/production-gateways.mdx",
+      "freshness_class": "review-periodic",
+      "confidence": "low"
+    },
+    {
+      "claim_id": "orch-active-set-threshold",
+      "claim_family": "stake-threshold",
+      "status": "conflicted",
+      "canonical_owner": "v2/orchestrators/guides/operator-considerations/business-case.mdx",
+      "freshness_class": "volatile",
+      "confidence": "low"
+    },
+    {
+      "claim_id": "gw-spe-funded-provider-examples",
+      "claim_family": "ecosystem-provider-examples",
+      "status": "conflicted",
+      "canonical_owner": "v2/gateways/guides/operator-considerations/production-gateways.mdx",
+      "freshness_class": "review-periodic",
+      "confidence": "low"
+    },
+    {
+      "claim_id": "orch-ai-routing-capability-based",
+      "claim_family": "ai-routing-mechanics",
+      "status": "conflicted",
+      "canonical_owner": "v2/orchestrators/guides/ai-and-job-workloads/job-types.mdx",
+      "freshness_class": "review-on-change",
+      "confidence": "low"
+    },
+    {
+      "claim_id": "orch-siphon-github-current",
+      "claim_family": "community-tooling-status",
+      "status": "conflicted",
+      "canonical_owner": "v2/orchestrators/guides/deployment-details/setup-options.mdx",
+      "freshness_class": "review-periodic",
+      "confidence": "low"
+    },
+    {
+      "claim_id": "orch-siphon-reward-isolation",
+      "claim_family": "split-setup-reward-safety",
+      "status": "conflicted",
+      "canonical_owner": "v2/orchestrators/guides/deployment-details/siphon-setup.mdx",
+      "freshness_class": "review-periodic",
+      "confidence": "low"
+    },
+    {
+      "claim_id": "orch-bandwidth-per-stream-planning",
+      "claim_family": "transcoding-bandwidth-planning",
+      "status": "time-sensitive",
+      "canonical_owner": "v2/orchestrators/setup/configure.mdx",
+      "freshness_class": "review-periodic",
+      "confidence": "medium"
+    },
+    {
+      "claim_id": "orch-business-case-cost-viability",
+      "claim_family": "business-case-viability",
+      "status": "time-sensitive",
+      "canonical_owner": "v2/orchestrators/guides/operator-considerations/business-case.mdx",
+      "freshness_class": "volatile",
+      "confidence": "medium"
+    },
+    {
+      "claim_id": "orch-commercial-model-warmth",
+      "claim_family": "commercial-model-warmth",
+      "status": "time-sensitive",
+      "canonical_owner": "v2/orchestrators/guides/operator-considerations/business-case.mdx",
+      "freshness_class": "review-on-change",
+      "confidence": "medium"
+    },
+    {
+      "claim_id": "gw-community-signer-testing-surface",
+      "claim_family": "community-signer-testing-surface",
+      "status": "time-sensitive",
+      "canonical_owner": "v2/gateways/guides/payments-and-pricing/payment-guide.mdx",
+      "freshness_class": "review-periodic",
+      "confidence": "medium"
+    },
+    {
+      "claim_id": "orch-session-limit-default",
+      "claim_family": "transcoding-session-cap",
+      "status": "time-sensitive",
+      "canonical_owner": "v2/orchestrators/setup/configure.mdx",
+      "freshness_class": "review-on-change",
+      "confidence": "medium"
+    },
+    {
+      "claim_id": "orch-reward-profitability-threshold",
+      "claim_family": "reward-profitability",
+      "status": "time-sensitive",
+      "canonical_owner": "v2/orchestrators/guides/staking-and-rewards/rewards-and-fees.mdx",
+      "freshness_class": "volatile",
+      "confidence": "medium"
+    }
+  ],
+  "summary": {
+    "matched_claim_families": 17,
+    "verified_claims": 1,
+    "conflicted_claims": 10,
+    "time_sensitive_claims": 6,
+    "unresolved_claims": 16,
+    "contradiction_groups": 10,
+    "propagation_queue_items": 46,
+    "evidence_sources": 31
+  },
+  "contradictions": [
+    {
+      "claim_family": "hardware-vram-minimums",
+      "claim_id": "orch-batch-ai-vram-threshold",
+      "pages": [
+        {
+          "file": "v2/orchestrators/guides/deployment-details/requirements.mdx",
+          "values": [],
+          "snippet": "This page covers GPU support policy, session limits by card tier, VRAM requirements by AI pipeline, the minimum system stack, capacity testing, and the checklist to run before activating on the network."
+        },
+        {
+          "file": "v2/orchestrators/guides/operator-considerations/business-case.mdx",
+          "values": [],
+          "snippet": "This requires: Automated monitoring with immediate alerts on node failure Automated restart and recovery Stable, redundant connectivity (not shared home broadband) Consistent power supply (UPS or colocation) Hardware health monitoring (GPU temperatures, VRAM utilisation) Model warm up management For AI inference workloads, cold model starts (loading a model from disk into VRAM on first request) introduce latency that breaks user facing SLAs."
+        },
+        {
+          "file": "v2/orchestrators/setup/rcs-requirements.mdx",
+          "values": [
+            "16 GB",
+            "24 GB",
+            "8 GB"
+          ],
+          "snippet": "Hardware NVIDIA GPU with NVENC/NVDEC support installed and visible via NVIDIA driver version 525+ (Linux) or 527+ (Windows) CUDA 12.0+ installed (or plan to use the Docker image, which bundles CUDA) CPU: 4+ cores minimum, 8+ recommended RAM: 16 GB minimum, 32 GB recommended Storage: 100 GB SSD minimum (NVMe recommended for AI model weights) For AI inference, VRAM is the primary constraint: 8 GB for LLM only, 16 GB for basic batch AI, 24 GB+ for the full pipeline suite."
+        }
+      ],
+      "best_known_truth": "Docs disagree on the practical VRAM minimum for batch AI and real-time AI workloads. Hardware and setup pages should not present conflicting minimums as equally current.",
+      "confidence": "low",
+      "recommended_action": "verify-more"
+    },
+    {
+      "claim_family": "clearinghouse-public-readiness",
+      "claim_id": "gw-clearinghouse-public-readiness",
+      "pages": [
+        {
+          "file": "v2/gateways/guides/payments-and-pricing/clearinghouse-guide.mdx",
+          "values": [
+            "general availability",
+            "public clearinghouse"
+          ],
+          "snippet": "Public Use Status No public clearinghouse service has reached general availability as of early 2026."
+        },
+        {
+          "file": "v2/gateways/guides/payments-and-pricing/payment-guide.mdx",
+          "values": [
+            "general availability",
+            "public clearinghouse"
+          ],
+          "snippet": "Once a public clearinghouse reaches GA, this becomes a pure API key sign up."
+        }
+      ],
+      "best_known_truth": "Gateway payment docs should describe clearinghouse status with current precision: the protocol is implemented, but no public clearinghouse is generally available yet. Community-hosted signer access is a testing bridge, not evidence of GA.",
+      "confidence": "low",
+      "recommended_action": "verify-more"
+    },
+    {
+      "claim_family": "consumer-nvenc-session-cap",
+      "claim_id": "orch-consumer-nvenc-session-cap",
+      "pages": [
+        {
+          "file": "v2/orchestrators/guides/deployment-details/requirements.mdx",
+          "values": [
+            "3 concurrent NVENC encode sessions",
+            "3 concurrent sessions"
+          ],
+          "snippet": "Consumer cards are typically limited to 2 3 concurrent NVENC encode sessions before throttling or failing with errors."
+        },
+        {
+          "file": "v2/orchestrators/guides/ai-and-job-workloads/job-types.mdx",
+          "values": [],
+          "snippet": "Your best options: Transcoding — you can handle video transcoding sessions competitively with any modern NVIDIA GPU; NVENC session caps on consumer cards apply, but can be worked around."
+        },
+        {
+          "file": "v2/orchestrators/guides/ai-and-job-workloads/video-transcoding.mdx",
+          "values": [],
+          "snippet": "NVENC session caps on consumer GPUs Consumer NVIDIA GPUs (GTX/RTX series) have a hardware enforced cap on the number of concurrent NVENC encoding sessions."
+        }
+      ],
+      "best_known_truth": "Consumer NVIDIA NVENC session-cap guidance is factual but volatile. Hardware requirement and transcoding guides should stay aligned on whether GeForce-class cards are typically capped at 2-3 concurrent sessions and whether newer generations changed that default.",
+      "confidence": "low",
+      "recommended_action": "verify-more"
+    },
+    {
+      "claim_family": "setup-prerequisites",
+      "claim_id": "orch-pool-vs-solo-prerequisites",
+      "pages": [
+        {
+          "file": "v2/orchestrators/guides/deployment-details/setup-options.mdx",
+          "values": [
+            "Pool Worker",
+            "Pool worker",
+            "pool worker"
+          ],
+          "snippet": "At a Glance Alternative What it solves What it requires Guide Pool worker Earn from GPU compute without running an Orchestrator at all no LPT, no on chain management GPU; a pool to join; no stake O T split Separate protocol management from GPU workload processing; scale Transcoder machines independently Two machines; LPT stake; Siphon Keep the keystore on an isolated machine; GPU machine can restart without missing LPT rewards Two machines; LPT stake; Python on secure machine Pool Worker A pool worker does not run an Orchestrator."
+        },
+        {
+          "file": "v2/orchestrators/guides/deployment-details/setup-options.mdx",
+          "values": [
+            "Pool Worker",
+            "Pool worker",
+            "pool worker"
+          ],
+          "snippet": "At a Glance Alternative What it solves What it requires Guide Pool worker Earn from GPU compute without running an Orchestrator at all no LPT, no on chain management GPU; a pool to join; no stake O T split Separate protocol management from GPU workload processing; scale Transcoder machines independently Two machines; LPT stake; Siphon Keep the keystore on an isolated machine; GPU machine can restart without missing LPT rewards Two machines; LPT stake; Python on secure machine Pool Worker A pool worker does not run an Orchestrator."
+        },
+        {
+          "file": "v2/orchestrators/guides/operator-considerations/business-case.mdx",
+          "values": [],
+          "snippet": "Pool operators manage the Orchestrator registration, on chain staking, and reward calling for a fleet of GPU workers."
+        },
+        {
+          "file": "v2/orchestrators/setup/rcs-requirements.mdx",
+          "values": [],
+          "snippet": "LPT on Arbitrum One — for staking."
+        }
+      ],
+      "best_known_truth": "Pool workers and solo operators have different prerequisites. Pages should not imply that LPT, ETH, or public service exposure are universal requirements for every orchestrator entry path.",
+      "confidence": "low",
+      "recommended_action": "verify-more"
+    },
+    {
+      "claim_family": "community-signal",
+      "claim_id": "gw-discord-community-signal",
+      "pages": [
+        {
+          "file": "v2/gateways/guides/operator-considerations/production-gateways.mdx",
+          "values": [
+            "Community",
+            "community"
+          ],
+          "snippet": "This page documents real applications and community projects that are already running, gives you tooling references, and points to Foundation programmes for new builders."
+        },
+        {
+          "file": "v2/gateways/guides/roadmap-and-funding/operator-support.mdx",
+          "values": [
+            "community"
+          ],
+          "snippet": "The Livepeer ecosystem provides funding, programmes, and community resources for Gateway operators at every stage from first time builders to production platform operators."
+        }
+      ],
+      "best_known_truth": "When gateway docs rely on community support or current market/pricing conditions, the research runner should surface any repo-available Discord/community signals instead of treating chat as invisible.",
+      "confidence": "low",
+      "recommended_action": "verify-more"
+    },
+    {
+      "claim_family": "stake-threshold",
+      "claim_id": "orch-active-set-threshold",
+      "pages": [
+        {
+          "file": "v2/orchestrators/guides/operator-considerations/business-case.mdx",
+          "values": [
+            "active set"
+          ],
+          "snippet": "Practical discipline for commercial capability management: Declare only models that are loaded and warm at startup Remove capability declarations for models that are not being actively served Use to specify exactly which pipeline/model combinations to load on startup Monitor model load times and remove slow start models from the active set Building Gateway relationships Active commercial relationships with Gateways typically develop through: Consistent performance history visible on the Livepeer Explorer Participation in the channel on the Direct outreach to Gateway SPEs and ecosystem partners Demonstrated capability support for pipelines that specific Gateways need Gateways serving AI products actively look for Orchestrators with specific capability profiles."
+        },
+        {
+          "file": "v2/orchestrators/setup/rcs-requirements.mdx",
+          "values": [
+            "active set",
+            "top 100"
+          ],
+          "snippet": "The amount needed to enter the active set (top 100) varies — check for the current threshold."
+        }
+      ],
+      "best_known_truth": "Solo transcoding guidance repeatedly states that operators need enough bonded LPT to enter the active set, often phrased as top 100, but that wording is time-sensitive and should not be treated as durable fact without current evidence.",
+      "confidence": "low",
+      "recommended_action": "verify-more"
+    },
+    {
+      "claim_family": "ecosystem-provider-examples",
+      "claim_id": "gw-spe-funded-provider-examples",
+      "pages": [
+        {
+          "file": "v2/gateways/guides/operator-considerations/production-gateways.mdx",
+          "values": [
+            "LLM",
+            "Livepeer Cloud",
+            "Streamplace"
+          ],
+          "snippet": "Gateway Operators Operator Model Gateway type Daydream Livepeer Product Commercial AI video product; subscription and per use pricing AI gateway embedded in product Livepeer Studio Livepeer Product Video API for developers; per minute pricing Video gateway (on chain) Public Livepeer Cloud SPE SPE Funded Free public gateways funded by treasury SPE grant AI and video Public LLM SPE SPE Funded LLM inference routing on Livepeer network AI gateway (LLM focused) Public Streamplace SPE Funded Decentralised livestreaming platform (AT Protocol); embedded gateway Video gateway embedded in product Commercial Products Daydream Livepeer Inc."
+        },
+        {
+          "file": "v2/gateways/guides/roadmap-and-funding/operator-support.mdx",
+          "values": [
+            "LLM",
+            "Livepeer Cloud"
+          ],
+          "snippet": "Funding Paths Special Purpose Entity (SPE) grants fund Gateway operators through the Livepeer treasury governance process."
+        },
+        {
+          "file": "v2/gateways/guides/roadmap-and-funding/spe-grant-model.mdx",
+          "values": [],
+          "snippet": "Some Livepeer Gateway operators are funded by the Livepeer treasury through a Special Purpose Entity (SPE) grant."
+        }
+      ],
+      "best_known_truth": "Gateway comparison and support pages should only present provider examples that are still backed by current SPE/governance or public project evidence.",
+      "confidence": "low",
+      "recommended_action": "verify-more"
+    },
+    {
+      "claim_family": "ai-routing-mechanics",
+      "claim_id": "orch-ai-routing-capability-based",
+      "pages": [
+        {
+          "file": "v2/orchestrators/guides/ai-and-job-workloads/job-types.mdx",
+          "values": [
+            "Stake plays a much smaller role",
+            "capability match"
+          ],
+          "snippet": "Batch AI inference AI jobs route on capability match + price ceiling."
+        }
+      ],
+      "best_known_truth": "AI jobs are routed primarily by capability match and price ceilings rather than by stake weight. Docs should not collapse AI routing into the same rules as transcoding routing.",
+      "confidence": "low",
+      "recommended_action": "verify-more"
+    },
+    {
+      "claim_family": "community-tooling-status",
+      "claim_id": "orch-siphon-github-current",
+      "pages": [
+        {
+          "file": "v2/orchestrators/guides/deployment-details/setup-options.mdx",
+          "values": [
+            "OrchestratorSiphon",
+            "Siphon"
+          ],
+          "snippet": "At a Glance Alternative What it solves What it requires Guide Pool worker Earn from GPU compute without running an Orchestrator at all no LPT, no on chain management GPU; a pool to join; no stake O T split Separate protocol management from GPU workload processing; scale Transcoder machines independently Two machines; LPT stake; Siphon Keep the keystore on an isolated machine; GPU machine can restart without missing LPT rewards Two machines; LPT stake; Python on secure machine Pool Worker A pool worker does not run an Orchestrator."
+        },
+        {
+          "file": "v2/orchestrators/guides/deployment-details/setup-options.mdx",
+          "values": [
+            "OrchestratorSiphon",
+            "Siphon"
+          ],
+          "snippet": "At a Glance Alternative What it solves What it requires Guide Pool worker Earn from GPU compute without running an Orchestrator at all no LPT, no on chain management GPU; a pool to join; no stake O T split Separate protocol management from GPU workload processing; scale Transcoder machines independently Two machines; LPT stake; Siphon Keep the keystore on an isolated machine; GPU machine can restart without missing LPT rewards Two machines; LPT stake; Python on secure machine Pool Worker A pool worker does not run an Orchestrator."
+        }
+      ],
+      "best_known_truth": "Split-setup guidance depends on OrchestratorSiphon still being an active community-maintained project. That claim should be checked against the current GitHub repository, not just repeated in docs.",
+      "confidence": "low",
+      "recommended_action": "verify-more"
+    },
+    {
+      "claim_family": "split-setup-reward-safety",
+      "claim_id": "orch-siphon-reward-isolation",
+      "pages": [
+        {
+          "file": "v2/orchestrators/guides/deployment-details/siphon-setup.mdx",
+          "values": [
+            "GPU machine can restart",
+            "reward",
+            "reward calling"
+          ],
+          "snippet": "If the GPU machine reboots mid round, that round's LPT inflation reward is permanently lost and missed rewards compound over time."
+        },
+        {
+          "file": "v2/orchestrators/guides/deployment-details/setup-options.mdx",
+          "values": [
+            "GPU machine can restart",
+            "reward calling"
+          ],
+          "snippet": "At a Glance Alternative What it solves What it requires Guide Pool worker Earn from GPU compute without running an Orchestrator at all no LPT, no on chain management GPU; a pool to join; no stake O T split Separate protocol management from GPU workload processing; scale Transcoder machines independently Two machines; LPT stake; Siphon Keep the keystore on an isolated machine; GPU machine can restart without missing LPT rewards Two machines; LPT stake; Python on secure machine Pool Worker A pool worker does not run an Orchestrator."
+        }
+      ],
+      "best_known_truth": "A split setup with OrchestratorSiphon isolates the keystore from the GPU machine and keeps reward calling independent of GPU uptime. Docs should keep that claim aligned across setup-path pages.",
+      "confidence": "low",
+      "recommended_action": "verify-more"
+    }
+  ],
+  "unresolved_items": [
+    {
+      "claim_id": "orch-batch-ai-vram-threshold",
+      "claim_family": "hardware-vram-minimums",
+      "status": "conflicted",
+      "confidence": "low",
+      "canonical_owner": "v2/orchestrators/guides/deployment-details/requirements.mdx",
+      "summary": "Docs disagree on the practical VRAM minimum for batch AI and real-time AI workloads. Hardware and setup pages should not present conflicting minimums as equally current."
+    },
+    {
+      "claim_id": "gw-clearinghouse-public-readiness",
+      "claim_family": "clearinghouse-public-readiness",
+      "status": "conflicted",
+      "confidence": "low",
+      "canonical_owner": "v2/gateways/guides/payments-and-pricing/clearinghouse-guide.mdx",
+      "summary": "Gateway payment docs should describe clearinghouse status with current precision: the protocol is implemented, but no public clearinghouse is generally available yet. Community-hosted signer access is a testing bridge, not evidence of GA."
+    },
+    {
+      "claim_id": "orch-consumer-nvenc-session-cap",
+      "claim_family": "consumer-nvenc-session-cap",
+      "status": "conflicted",
+      "confidence": "low",
+      "canonical_owner": "v2/orchestrators/guides/deployment-details/requirements.mdx",
+      "summary": "Consumer NVIDIA NVENC session-cap guidance is factual but volatile. Hardware requirement and transcoding guides should stay aligned on whether GeForce-class cards are typically capped at 2-3 concurrent sessions and whether newer generations changed that default."
+    },
+    {
+      "claim_id": "orch-pool-vs-solo-prerequisites",
+      "claim_family": "setup-prerequisites",
+      "status": "conflicted",
+      "confidence": "low",
+      "canonical_owner": "v2/orchestrators/guides/deployment-details/setup-options.mdx",
+      "summary": "Pool workers and solo operators have different prerequisites. Pages should not imply that LPT, ETH, or public service exposure are universal requirements for every orchestrator entry path."
+    },
+    {
+      "claim_id": "gw-discord-community-signal",
+      "claim_family": "community-signal",
+      "status": "conflicted",
+      "confidence": "low",
+      "canonical_owner": "v2/gateways/guides/operator-considerations/production-gateways.mdx",
+      "summary": "When gateway docs rely on community support or current market/pricing conditions, the research runner should surface any repo-available Discord/community signals instead of treating chat as invisible."
+    },
+    {
+      "claim_id": "orch-active-set-threshold",
+      "claim_family": "stake-threshold",
+      "status": "conflicted",
+      "confidence": "low",
+      "canonical_owner": "v2/orchestrators/guides/operator-considerations/business-case.mdx",
+      "summary": "Solo transcoding guidance repeatedly states that operators need enough bonded LPT to enter the active set, often phrased as top 100, but that wording is time-sensitive and should not be treated as durable fact without current evidence."
+    },
+    {
+      "claim_id": "gw-spe-funded-provider-examples",
+      "claim_family": "ecosystem-provider-examples",
+      "status": "conflicted",
+      "confidence": "low",
+      "canonical_owner": "v2/gateways/guides/operator-considerations/production-gateways.mdx",
+      "summary": "Gateway comparison and support pages should only present provider examples that are still backed by current SPE/governance or public project evidence."
+    },
+    {
+      "claim_id": "orch-ai-routing-capability-based",
+      "claim_family": "ai-routing-mechanics",
+      "status": "conflicted",
+      "confidence": "low",
+      "canonical_owner": "v2/orchestrators/guides/ai-and-job-workloads/job-types.mdx",
+      "summary": "AI jobs are routed primarily by capability match and price ceilings rather than by stake weight. Docs should not collapse AI routing into the same rules as transcoding routing."
+    },
+    {
+      "claim_id": "orch-siphon-github-current",
+      "claim_family": "community-tooling-status",
+      "status": "conflicted",
+      "confidence": "low",
+      "canonical_owner": "v2/orchestrators/guides/deployment-details/setup-options.mdx",
+      "summary": "Split-setup guidance depends on OrchestratorSiphon still being an active community-maintained project. That claim should be checked against the current GitHub repository, not just repeated in docs."
+    },
+    {
+      "claim_id": "orch-siphon-reward-isolation",
+      "claim_family": "split-setup-reward-safety",
+      "status": "conflicted",
+      "confidence": "low",
+      "canonical_owner": "v2/orchestrators/guides/deployment-details/siphon-setup.mdx",
+      "summary": "A split setup with OrchestratorSiphon isolates the keystore from the GPU machine and keeps reward calling independent of GPU uptime. Docs should keep that claim aligned across setup-path pages."
+    },
+    {
+      "claim_id": "orch-bandwidth-per-stream-planning",
+      "claim_family": "transcoding-bandwidth-planning",
+      "status": "time-sensitive",
+      "confidence": "medium",
+      "canonical_owner": "v2/orchestrators/setup/configure.mdx",
+      "summary": "Bandwidth planning for transcoding is currently presented as an approximate planning rule rather than a single durable network constant. Pages should make the source-resolution assumption and rendition-set basis explicit when quoting per-stream bandwidth."
+    },
+    {
+      "claim_id": "orch-business-case-cost-viability",
+      "claim_family": "business-case-viability",
+      "status": "time-sensitive",
+      "confidence": "medium",
+      "canonical_owner": "v2/orchestrators/guides/operator-considerations/business-case.mdx",
+      "summary": "Business-case guidance should explicitly stay approximate and local-context dependent. Payback, electricity cost, and 'worth it' framing are useful, but they should not be presented as portable constants across operators, geographies, or market conditions."
+    },
+    {
+      "claim_id": "orch-commercial-model-warmth",
+      "claim_family": "commercial-model-warmth",
+      "status": "time-sensitive",
+      "confidence": "medium",
+      "canonical_owner": "v2/orchestrators/guides/operator-considerations/business-case.mdx",
+      "summary": "Commercial AI operator guidance should keep warm-model, pre-loaded startup, and cold-start SLA language aligned across setup and business-case pages. These claims describe real operational expectations, but they remain experimental and workload-sensitive."
+    },
+    {
+      "claim_id": "gw-community-signer-testing-surface",
+      "claim_family": "community-signer-testing-surface",
+      "status": "time-sensitive",
+      "confidence": "medium",
+      "canonical_owner": "v2/gateways/guides/payments-and-pricing/payment-guide.mdx",
+      "summary": "Docs that mention the Elite Encoder community signer should keep its role narrow and explicit: a repo/community-backed testing surface for early off-chain experimentation, not a generic production recommendation."
+    },
+    {
+      "claim_id": "orch-session-limit-default",
+      "claim_family": "transcoding-session-cap",
+      "status": "time-sensitive",
+      "confidence": "medium",
+      "canonical_owner": "v2/orchestrators/setup/configure.mdx",
+      "summary": "The default session limit and overload behavior are operational facts that multiple setup and hardware pages depend on. When docs state the default cap or the error condition, they should stay aligned with current go-livepeer behavior."
+    },
+    {
+      "claim_id": "orch-reward-profitability-threshold",
+      "claim_family": "reward-profitability",
+      "status": "time-sensitive",
+      "confidence": "medium",
+      "canonical_owner": "v2/orchestrators/guides/staking-and-rewards/rewards-and-fees.mdx",
+      "summary": "Reward-call profitability guidance should remain explicitly time-sensitive because gas cost, ETH price, and LPT price move. Docs must not present rough thresholds as durable constants."
+    }
+  ],
+  "propagation_queue": [
+    {
+      "file": "v2/gateways/guides/operator-considerations/production-gateways.mdx",
+      "page_class": "guide",
+      "role": "canonical-owner",
+      "action": "verify-only",
+      "claim_id": "gw-discord-community-signal"
+    },
+    {
+      "file": "v2/gateways/guides/operator-considerations/production-gateways.mdx",
+      "page_class": "guide",
+      "role": "canonical-owner",
+      "action": "verify-only",
+      "claim_id": "gw-spe-funded-provider-examples"
+    },
+    {
+      "file": "v2/gateways/guides/payments-and-pricing/clearinghouse-guide.mdx",
+      "page_class": "guide",
+      "role": "canonical-owner",
+      "action": "verify-only",
+      "claim_id": "gw-clearinghouse-public-readiness"
+    },
+    {
+      "file": "v2/gateways/guides/payments-and-pricing/clearinghouse-guide.mdx",
+      "page_class": "guide",
+      "role": "dependent-page",
+      "action": "verify-only",
+      "claim_id": "gw-community-signer-testing-surface"
+    },
+    {
+      "file": "v2/gateways/guides/payments-and-pricing/payment-guide.mdx",
+      "page_class": "guide",
+      "role": "dependent-page",
+      "action": "verify-only",
+      "claim_id": "gw-clearinghouse-public-readiness"
+    },
+    {
+      "file": "v2/gateways/guides/payments-and-pricing/payment-guide.mdx",
+      "page_class": "guide",
+      "role": "canonical-owner",
+      "action": "verify-only",
+      "claim_id": "gw-community-signer-testing-surface"
+    },
+    {
+      "file": "v2/gateways/guides/payments-and-pricing/payment-guide.mdx",
+      "page_class": "guide",
+      "role": "dependent-page",
+      "action": "update-now",
+      "claim_id": "gw-price-cap-role"
+    },
+    {
+      "file": "v2/gateways/guides/payments-and-pricing/pricing-strategy.mdx",
+      "page_class": "guide",
+      "role": "canonical-owner",
+      "action": "update-now",
+      "claim_id": "gw-price-cap-role"
+    },
+    {
+      "file": "v2/gateways/guides/payments-and-pricing/remote-signers.mdx",
+      "page_class": "guide",
+      "role": "dependent-page",
+      "action": "verify-only",
+      "claim_id": "gw-community-signer-testing-surface"
+    },
+    {
+      "file": "v2/gateways/guides/roadmap-and-funding/naap-multi-tenancy.mdx",
+      "page_class": "guide",
+      "role": "dependent-page",
+      "action": "update-now",
+      "claim_id": "gw-price-cap-role"
+    },
+    {
+      "file": "v2/gateways/guides/roadmap-and-funding/operator-support.mdx",
+      "page_class": "guide",
+      "role": "dependent-page",
+      "action": "verify-only",
+      "claim_id": "gw-clearinghouse-public-readiness"
+    },
+    {
+      "file": "v2/gateways/guides/roadmap-and-funding/operator-support.mdx",
+      "page_class": "guide",
+      "role": "dependent-page",
+      "action": "verify-only",
+      "claim_id": "gw-community-signer-testing-surface"
+    },
+    {
+      "file": "v2/gateways/guides/roadmap-and-funding/operator-support.mdx",
+      "page_class": "guide",
+      "role": "dependent-page",
+      "action": "verify-only",
+      "claim_id": "gw-discord-community-signal"
+    },
+    {
+      "file": "v2/gateways/guides/roadmap-and-funding/operator-support.mdx",
+      "page_class": "guide",
+      "role": "dependent-page",
+      "action": "verify-only",
+      "claim_id": "gw-spe-funded-provider-examples"
+    },
+    {
+      "file": "v2/gateways/guides/roadmap-and-funding/spe-grant-model.mdx",
+      "page_class": "guide",
+      "role": "dependent-page",
+      "action": "verify-only",
+      "claim_id": "gw-spe-funded-provider-examples"
+    },
+    {
+      "file": "v2/orchestrators/guides/ai-and-job-workloads/ai-workloads-guide.mdx",
+      "page_class": "guide",
+      "role": "dependent-page",
+      "action": "verify-only",
+      "claim_id": "orch-commercial-model-warmth"
+    },
+    {
+      "file": "v2/orchestrators/guides/ai-and-job-workloads/batch-ai-setup.mdx",
+      "page_class": "guide",
+      "role": "dependent-page",
+      "action": "verify-only",
+      "claim_id": "orch-commercial-model-warmth"
+    },
+    {
+      "file": "v2/orchestrators/guides/ai-and-job-workloads/job-types.mdx",
+      "page_class": "guide",
+      "role": "canonical-owner",
+      "action": "verify-only",
+      "claim_id": "orch-ai-routing-capability-based"
+    },
+    {
+      "file": "v2/orchestrators/guides/ai-and-job-workloads/job-types.mdx",
+      "page_class": "guide",
+      "role": "dependent-page",
+      "action": "verify-only",
+      "claim_id": "orch-consumer-nvenc-session-cap"
+    },
+    {
+      "file": "v2/orchestrators/guides/ai-and-job-workloads/video-transcoding.mdx",
+      "page_class": "guide",
+      "role": "dependent-page",
+      "action": "verify-only",
+      "claim_id": "orch-consumer-nvenc-session-cap"
+    },
+    {
+      "file": "v2/orchestrators/guides/deployment-details/dual-workload-setup.mdx",
+      "page_class": "guide",
+      "role": "dependent-page",
+      "action": "verify-only",
+      "claim_id": "orch-commercial-model-warmth"
+    },
+    {
+      "file": "v2/orchestrators/guides/deployment-details/requirements.mdx",
+      "page_class": "guide",
+      "role": "dependent-page",
+      "action": "verify-only",
+      "claim_id": "orch-bandwidth-per-stream-planning"
+    },
+    {
+      "file": "v2/orchestrators/guides/deployment-details/requirements.mdx",
+      "page_class": "guide",
+      "role": "canonical-owner",
+      "action": "verify-only",
+      "claim_id": "orch-batch-ai-vram-threshold"
+    },
+    {
+      "file": "v2/orchestrators/guides/deployment-details/requirements.mdx",
+      "page_class": "guide",
+      "role": "dependent-page",
+      "action": "verify-only",
+      "claim_id": "orch-business-case-cost-viability"
+    },
+    {
+      "file": "v2/orchestrators/guides/deployment-details/requirements.mdx",
+      "page_class": "guide",
+      "role": "canonical-owner",
+      "action": "verify-only",
+      "claim_id": "orch-consumer-nvenc-session-cap"
+    },
+    {
+      "file": "v2/orchestrators/guides/deployment-details/requirements.mdx",
+      "page_class": "guide",
+      "role": "dependent-page",
+      "action": "verify-only",
+      "claim_id": "orch-session-limit-default"
+    },
+    {
+      "file": "v2/orchestrators/guides/deployment-details/setup-options.mdx",
+      "page_class": "guide",
+      "role": "dependent-page",
+      "action": "verify-only",
+      "claim_id": "orch-active-set-threshold"
+    },
+    {
+      "file": "v2/orchestrators/guides/deployment-details/setup-options.mdx",
+      "page_class": "guide",
+      "role": "dependent-page",
+      "action": "verify-only",
+      "claim_id": "orch-ai-routing-capability-based"
+    },
+    {
+      "file": "v2/orchestrators/guides/deployment-details/setup-options.mdx",
+      "page_class": "guide",
+      "role": "dependent-page",
+      "action": "verify-only",
+      "claim_id": "orch-batch-ai-vram-threshold"
+    },
+    {
+      "file": "v2/orchestrators/guides/deployment-details/setup-options.mdx",
+      "page_class": "guide",
+      "role": "canonical-owner",
+      "action": "verify-only",
+      "claim_id": "orch-pool-vs-solo-prerequisites"
+    },
+    {
+      "file": "v2/orchestrators/guides/deployment-details/setup-options.mdx",
+      "page_class": "guide",
+      "role": "canonical-owner",
+      "action": "verify-only",
+      "claim_id": "orch-siphon-github-current"
+    },
+    {
+      "file": "v2/orchestrators/guides/deployment-details/setup-options.mdx",
+      "page_class": "guide",
+      "role": "dependent-page",
+      "action": "verify-only",
+      "claim_id": "orch-siphon-reward-isolation"
+    },
+    {
+      "file": "v2/orchestrators/guides/deployment-details/siphon-setup.mdx",
+      "page_class": "guide",
+      "role": "canonical-owner",
+      "action": "verify-only",
+      "claim_id": "orch-siphon-reward-isolation"
+    },
+    {
+      "file": "v2/orchestrators/guides/operator-considerations/business-case.mdx",
+      "page_class": "guide",
+      "role": "canonical-owner",
+      "action": "verify-only",
+      "claim_id": "orch-active-set-threshold"
+    },
+    {
+      "file": "v2/orchestrators/guides/operator-considerations/business-case.mdx",
+      "page_class": "guide",
+      "role": "dependent-page",
+      "action": "verify-only",
+      "claim_id": "orch-bandwidth-per-stream-planning"
+    },
+    {
+      "file": "v2/orchestrators/guides/operator-considerations/business-case.mdx",
+      "page_class": "guide",
+      "role": "dependent-page",
+      "action": "verify-only",
+      "claim_id": "orch-batch-ai-vram-threshold"
+    },
+    {
+      "file": "v2/orchestrators/guides/operator-considerations/business-case.mdx",
+      "page_class": "guide",
+      "role": "canonical-owner",
+      "action": "verify-only",
+      "claim_id": "orch-business-case-cost-viability"
+    },
+    {
+      "file": "v2/orchestrators/guides/operator-considerations/business-case.mdx",
+      "page_class": "guide",
+      "role": "canonical-owner",
+      "action": "verify-only",
+      "claim_id": "orch-commercial-model-warmth"
+    },
+    {
+      "file": "v2/orchestrators/guides/operator-considerations/business-case.mdx",
+      "page_class": "guide",
+      "role": "dependent-page",
+      "action": "verify-only",
+      "claim_id": "orch-pool-vs-solo-prerequisites"
+    },
+    {
+      "file": "v2/orchestrators/guides/operator-considerations/business-case.mdx",
+      "page_class": "guide",
+      "role": "dependent-page",
+      "action": "verify-only",
+      "claim_id": "orch-reward-profitability-threshold"
+    },
+    {
+      "file": "v2/orchestrators/guides/staking-and-rewards/rewards-and-fees.mdx",
+      "page_class": "guide",
+      "role": "canonical-owner",
+      "action": "verify-only",
+      "claim_id": "orch-reward-profitability-threshold"
+    },
+    {
+      "file": "v2/orchestrators/setup/configure.mdx",
+      "page_class": "setup",
+      "role": "canonical-owner",
+      "action": "verify-only",
+      "claim_id": "orch-bandwidth-per-stream-planning"
+    },
+    {
+      "file": "v2/orchestrators/setup/configure.mdx",
+      "page_class": "setup",
+      "role": "canonical-owner",
+      "action": "verify-only",
+      "claim_id": "orch-session-limit-default"
+    },
+    {
+      "file": "v2/orchestrators/setup/rcs-requirements.mdx",
+      "page_class": "setup",
+      "role": "dependent-page",
+      "action": "verify-only",
+      "claim_id": "orch-active-set-threshold"
+    },
+    {
+      "file": "v2/orchestrators/setup/rcs-requirements.mdx",
+      "page_class": "setup",
+      "role": "dependent-page",
+      "action": "verify-only",
+      "claim_id": "orch-batch-ai-vram-threshold"
+    },
+    {
+      "file": "v2/orchestrators/setup/rcs-requirements.mdx",
+      "page_class": "setup",
+      "role": "dependent-page",
+      "action": "verify-only",
+      "claim_id": "orch-pool-vs-solo-prerequisites"
+    }
+  ],
+  "evidence_sources": [
+    {
+      "claim_id": "orch-batch-ai-vram-threshold",
+      "type": "repo-file",
+      "ref": "v2/orchestrators/guides/deployment-details/requirements.mdx",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "repo evidence matched"
+    },
+    {
+      "claim_id": "orch-batch-ai-vram-threshold",
+      "type": "repo-file",
+      "ref": "v2/orchestrators/setup/rcs-requirements.mdx",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "repo evidence matched"
+    },
+    {
+      "claim_id": "gw-clearinghouse-public-readiness",
+      "type": "github-pr",
+      "ref": "https://github.com/livepeer/go-livepeer/pull/3791",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "GitHub evidence matched"
+    },
+    {
+      "claim_id": "gw-clearinghouse-public-readiness",
+      "type": "github-pr",
+      "ref": "https://github.com/livepeer/go-livepeer/pull/3822",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "GitHub evidence matched"
+    },
+    {
+      "claim_id": "gw-clearinghouse-public-readiness",
+      "type": "repo-file",
+      "ref": "v2/gateways/guides/payments-and-pricing/clearinghouse-guide.mdx",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "repo evidence matched"
+    },
+    {
+      "claim_id": "orch-bandwidth-per-stream-planning",
+      "type": "repo-file",
+      "ref": "v2/orchestrators/setup/configure.mdx",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "repo evidence matched"
+    },
+    {
+      "claim_id": "orch-bandwidth-per-stream-planning",
+      "type": "repo-file",
+      "ref": "v2/orchestrators/guides/deployment-details/requirements.mdx",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "repo evidence matched"
+    },
+    {
+      "claim_id": "orch-business-case-cost-viability",
+      "type": "repo-file",
+      "ref": "v2/orchestrators/guides/operator-considerations/business-case.mdx",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "repo evidence matched"
+    },
+    {
+      "claim_id": "orch-business-case-cost-viability",
+      "type": "repo-file",
+      "ref": "v2/orchestrators/guides/deployment-details/requirements.mdx",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "repo evidence matched"
+    },
+    {
+      "claim_id": "orch-commercial-model-warmth",
+      "type": "repo-file",
+      "ref": "v2/orchestrators/guides/operator-considerations/business-case.mdx",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "repo evidence matched"
+    },
+    {
+      "claim_id": "orch-commercial-model-warmth",
+      "type": "repo-file",
+      "ref": "v2/orchestrators/guides/deployment-details/dual-workload-setup.mdx",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "repo evidence matched"
+    },
+    {
+      "claim_id": "orch-commercial-model-warmth",
+      "type": "repo-file",
+      "ref": "v2/orchestrators/guides/ai-and-job-workloads/batch-ai-setup.mdx",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "repo evidence matched"
+    },
+    {
+      "claim_id": "gw-community-signer-testing-surface",
+      "type": "repo-discord-signal",
+      "ref": ".github/workflows/discord-issue-intake.yml",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "repo Discord/community signal matched"
+    },
+    {
+      "claim_id": "gw-community-signer-testing-surface",
+      "type": "repo-file",
+      "ref": "v2/gateways/guides/payments-and-pricing/payment-guide.mdx",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "repo evidence matched"
+    },
+    {
+      "claim_id": "gw-community-signer-testing-surface",
+      "type": "repo-file",
+      "ref": "v2/gateways/guides/roadmap-and-funding/operator-support.mdx",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "repo evidence matched"
+    },
+    {
+      "claim_id": "gw-price-cap-role",
+      "type": "repo-file",
+      "ref": "v2/gateways/guides/payments-and-pricing/pricing-strategy.mdx",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "repo evidence matched"
+    },
+    {
+      "claim_id": "gw-price-cap-role",
+      "type": "repo-file",
+      "ref": "v2/gateways/guides/roadmap-and-funding/naap-multi-tenancy.mdx",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "repo evidence matched"
+    },
+    {
+      "claim_id": "orch-consumer-nvenc-session-cap",
+      "type": "repo-file",
+      "ref": "v2/orchestrators/guides/deployment-details/requirements.mdx",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "repo evidence matched"
+    },
+    {
+      "claim_id": "orch-consumer-nvenc-session-cap",
+      "type": "repo-file",
+      "ref": "v2/orchestrators/guides/ai-and-job-workloads/video-transcoding.mdx",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "repo evidence matched"
+    },
+    {
+      "claim_id": "orch-pool-vs-solo-prerequisites",
+      "type": "repo-file",
+      "ref": "v2/orchestrators/guides/deployment-details/setup-options.mdx",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "repo evidence matched"
+    },
+    {
+      "claim_id": "orch-pool-vs-solo-prerequisites",
+      "type": "repo-file",
+      "ref": "v2/orchestrators/guides/deployment-details/join-a-pool.mdx",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "repo evidence matched"
+    },
+    {
+      "claim_id": "gw-discord-community-signal",
+      "type": "repo-file",
+      "ref": ".github/workflows/discord-issue-intake.yml",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "repo evidence matched"
+    },
+    {
+      "claim_id": "orch-active-set-threshold",
+      "type": "official-page",
+      "ref": "https://explorer.livepeer.org/orchestrators",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": false,
+      "summary": "official page fetched but signal missing"
+    },
+    {
+      "claim_id": "orch-session-limit-default",
+      "type": "repo-file",
+      "ref": "v2/orchestrators/setup/configure.mdx",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "repo evidence matched"
+    },
+    {
+      "claim_id": "orch-reward-profitability-threshold",
+      "type": "repo-file",
+      "ref": "v2/orchestrators/guides/staking-and-rewards/rewards-and-fees.mdx",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "repo evidence matched"
+    },
+    {
+      "claim_id": "gw-spe-funded-provider-examples",
+      "type": "forum-topic",
+      "ref": "https://forum.livepeer.org/t/spe-milestone-report/3035",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "forum topic matched"
+    },
+    {
+      "claim_id": "orch-ai-routing-capability-based",
+      "type": "repo-file",
+      "ref": "v2/orchestrators/guides/ai-and-job-workloads/job-types.mdx",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "repo evidence matched"
+    },
+    {
+      "claim_id": "orch-ai-routing-capability-based",
+      "type": "repo-file",
+      "ref": "v2/orchestrators/guides/deployment-details/dual-workload-setup.mdx",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "repo evidence matched"
+    },
+    {
+      "claim_id": "orch-siphon-github-current",
+      "type": "github-repo",
+      "ref": "https://github.com/Stronk-Tech/OrchestratorSiphon",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "GitHub evidence matched"
+    },
+    {
+      "claim_id": "orch-siphon-reward-isolation",
+      "type": "repo-file",
+      "ref": "v2/orchestrators/guides/deployment-details/siphon-setup.mdx",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "repo evidence matched"
+    },
+    {
+      "claim_id": "orch-siphon-reward-isolation",
+      "type": "github-repo",
+      "ref": "https://github.com/Stronk-Tech/OrchestratorSiphon",
+      "checked_on": "2026-03-16",
+      "ok": true,
+      "matched": true,
+      "summary": "GitHub evidence matched"
+    }
+  ],
+  "notes": [],
+  "markdown_artifact": "tasks/reports/repo-ops/2026-03-16-page-content-research-pr-simulation-task2-improvements.md",
+  "json_artifact": "tasks/reports/repo-ops/2026-03-16-page-content-research-pr-simulation-task2-improvements.json"
+}

--- a/tasks/reports/repo-ops/2026-03-16-page-content-research-pr-simulation-task2-improvements.md
+++ b/tasks/reports/repo-ops/2026-03-16-page-content-research-pr-simulation-task2-improvements.md
@@ -1,0 +1,91 @@
+# Advisory Research PR Report
+
+- Status: experimental, non-blocking
+- Generated: 2026-03-16T03:50:21.055Z
+
+## Scope
+
+- Changed files:
+  - `v2/orchestrators/guides/operator-considerations/business-case.mdx`
+  - `v2/orchestrators/guides/deployment-details/requirements.mdx`
+  - `v2/gateways/guides/payments-and-pricing/pricing-strategy.mdx`
+  - `v2/gateways/guides/payments-and-pricing/clearinghouse-guide.mdx`
+- Target docs pages:
+  - `v2/orchestrators/guides/operator-considerations/business-case.mdx`
+  - `v2/orchestrators/guides/deployment-details/requirements.mdx`
+  - `v2/gateways/guides/payments-and-pricing/pricing-strategy.mdx`
+  - `v2/gateways/guides/payments-and-pricing/clearinghouse-guide.mdx`
+
+## Summary
+
+- Matched claim families: 17
+- Verified claims: 1
+- Conflicted claims: 10
+- Time-sensitive claims: 6
+- Unresolved claims: 16
+- Contradiction groups: 10
+- Propagation queue items: 46
+- Evidence sources checked: 31
+
+## Claim Families
+
+- `gw-price-cap-role` (price-cap-role) — verified, high confidence, owner: `v2/gateways/guides/payments-and-pricing/pricing-strategy.mdx`
+- `orch-batch-ai-vram-threshold` (hardware-vram-minimums) — conflicted, low confidence, owner: `v2/orchestrators/guides/deployment-details/requirements.mdx`
+- `gw-clearinghouse-public-readiness` (clearinghouse-public-readiness) — conflicted, low confidence, owner: `v2/gateways/guides/payments-and-pricing/clearinghouse-guide.mdx`
+- `orch-consumer-nvenc-session-cap` (consumer-nvenc-session-cap) — conflicted, low confidence, owner: `v2/orchestrators/guides/deployment-details/requirements.mdx`
+- `orch-pool-vs-solo-prerequisites` (setup-prerequisites) — conflicted, low confidence, owner: `v2/orchestrators/guides/deployment-details/setup-options.mdx`
+- `gw-discord-community-signal` (community-signal) — conflicted, low confidence, owner: `v2/gateways/guides/operator-considerations/production-gateways.mdx`
+- `orch-active-set-threshold` (stake-threshold) — conflicted, low confidence, owner: `v2/orchestrators/guides/operator-considerations/business-case.mdx`
+- `gw-spe-funded-provider-examples` (ecosystem-provider-examples) — conflicted, low confidence, owner: `v2/gateways/guides/operator-considerations/production-gateways.mdx`
+- `orch-ai-routing-capability-based` (ai-routing-mechanics) — conflicted, low confidence, owner: `v2/orchestrators/guides/ai-and-job-workloads/job-types.mdx`
+- `orch-siphon-github-current` (community-tooling-status) — conflicted, low confidence, owner: `v2/orchestrators/guides/deployment-details/setup-options.mdx`
+- `orch-siphon-reward-isolation` (split-setup-reward-safety) — conflicted, low confidence, owner: `v2/orchestrators/guides/deployment-details/siphon-setup.mdx`
+- `orch-bandwidth-per-stream-planning` (transcoding-bandwidth-planning) — time-sensitive, medium confidence, owner: `v2/orchestrators/setup/configure.mdx`
+- `orch-business-case-cost-viability` (business-case-viability) — time-sensitive, medium confidence, owner: `v2/orchestrators/guides/operator-considerations/business-case.mdx`
+- `orch-commercial-model-warmth` (commercial-model-warmth) — time-sensitive, medium confidence, owner: `v2/orchestrators/guides/operator-considerations/business-case.mdx`
+- `gw-community-signer-testing-surface` (community-signer-testing-surface) — time-sensitive, medium confidence, owner: `v2/gateways/guides/payments-and-pricing/payment-guide.mdx`
+- `orch-session-limit-default` (transcoding-session-cap) — time-sensitive, medium confidence, owner: `v2/orchestrators/setup/configure.mdx`
+- `orch-reward-profitability-threshold` (reward-profitability) — time-sensitive, medium confidence, owner: `v2/orchestrators/guides/staking-and-rewards/rewards-and-fees.mdx`
+
+## Unresolved Items
+
+- `orch-batch-ai-vram-threshold` (conflicted) — Docs disagree on the practical VRAM minimum for batch AI and real-time AI workloads. Hardware and setup pages should not present conflicting minimums as equally current.
+- `gw-clearinghouse-public-readiness` (conflicted) — Gateway payment docs should describe clearinghouse status with current precision: the protocol is implemented, but no public clearinghouse is generally available yet. Community-hosted signer access is a testing bridge, not evidence of GA.
+- `orch-consumer-nvenc-session-cap` (conflicted) — Consumer NVIDIA NVENC session-cap guidance is factual but volatile. Hardware requirement and transcoding guides should stay aligned on whether GeForce-class cards are typically capped at 2-3 concurrent sessions and whether newer generations changed that default.
+- `orch-pool-vs-solo-prerequisites` (conflicted) — Pool workers and solo operators have different prerequisites. Pages should not imply that LPT, ETH, or public service exposure are universal requirements for every orchestrator entry path.
+- `gw-discord-community-signal` (conflicted) — When gateway docs rely on community support or current market/pricing conditions, the research runner should surface any repo-available Discord/community signals instead of treating chat as invisible.
+- `orch-active-set-threshold` (conflicted) — Solo transcoding guidance repeatedly states that operators need enough bonded LPT to enter the active set, often phrased as top 100, but that wording is time-sensitive and should not be treated as durable fact without current evidence.
+- `gw-spe-funded-provider-examples` (conflicted) — Gateway comparison and support pages should only present provider examples that are still backed by current SPE/governance or public project evidence.
+- `orch-ai-routing-capability-based` (conflicted) — AI jobs are routed primarily by capability match and price ceilings rather than by stake weight. Docs should not collapse AI routing into the same rules as transcoding routing.
+- `orch-siphon-github-current` (conflicted) — Split-setup guidance depends on OrchestratorSiphon still being an active community-maintained project. That claim should be checked against the current GitHub repository, not just repeated in docs.
+- `orch-siphon-reward-isolation` (conflicted) — A split setup with OrchestratorSiphon isolates the keystore from the GPU machine and keeps reward calling independent of GPU uptime. Docs should keep that claim aligned across setup-path pages.
+- `orch-bandwidth-per-stream-planning` (time-sensitive) — Bandwidth planning for transcoding is currently presented as an approximate planning rule rather than a single durable network constant. Pages should make the source-resolution assumption and rendition-set basis explicit when quoting per-stream bandwidth.
+- `orch-business-case-cost-viability` (time-sensitive) — Business-case guidance should explicitly stay approximate and local-context dependent. Payback, electricity cost, and 'worth it' framing are useful, but they should not be presented as portable constants across operators, geographies, or market conditions.
+- `orch-commercial-model-warmth` (time-sensitive) — Commercial AI operator guidance should keep warm-model, pre-loaded startup, and cold-start SLA language aligned across setup and business-case pages. These claims describe real operational expectations, but they remain experimental and workload-sensitive.
+- `gw-community-signer-testing-surface` (time-sensitive) — Docs that mention the Elite Encoder community signer should keep its role narrow and explicit: a repo/community-backed testing surface for early off-chain experimentation, not a generic production recommendation.
+- `orch-session-limit-default` (time-sensitive) — The default session limit and overload behavior are operational facts that multiple setup and hardware pages depend on. When docs state the default cap or the error condition, they should stay aligned with current go-livepeer behavior.
+- `orch-reward-profitability-threshold` (time-sensitive) — Reward-call profitability guidance should remain explicitly time-sensitive because gas cost, ETH price, and LPT price move. Docs must not present rough thresholds as durable constants.
+
+## Propagation Queue
+
+- `gw-discord-community-signal` → `v2/gateways/guides/operator-considerations/production-gateways.mdx` [verify-only]
+- `gw-spe-funded-provider-examples` → `v2/gateways/guides/operator-considerations/production-gateways.mdx` [verify-only]
+- `gw-clearinghouse-public-readiness` → `v2/gateways/guides/payments-and-pricing/clearinghouse-guide.mdx` [verify-only]
+- `gw-community-signer-testing-surface` → `v2/gateways/guides/payments-and-pricing/clearinghouse-guide.mdx` [verify-only]
+- `gw-clearinghouse-public-readiness` → `v2/gateways/guides/payments-and-pricing/payment-guide.mdx` [verify-only]
+- `gw-community-signer-testing-surface` → `v2/gateways/guides/payments-and-pricing/payment-guide.mdx` [verify-only]
+- `gw-price-cap-role` → `v2/gateways/guides/payments-and-pricing/payment-guide.mdx` [update-now]
+- `gw-price-cap-role` → `v2/gateways/guides/payments-and-pricing/pricing-strategy.mdx` [update-now]
+- `gw-community-signer-testing-surface` → `v2/gateways/guides/payments-and-pricing/remote-signers.mdx` [verify-only]
+- `gw-price-cap-role` → `v2/gateways/guides/roadmap-and-funding/naap-multi-tenancy.mdx` [update-now]
+- `gw-clearinghouse-public-readiness` → `v2/gateways/guides/roadmap-and-funding/operator-support.mdx` [verify-only]
+- `gw-community-signer-testing-surface` → `v2/gateways/guides/roadmap-and-funding/operator-support.mdx` [verify-only]
+- `gw-discord-community-signal` → `v2/gateways/guides/roadmap-and-funding/operator-support.mdx` [verify-only]
+- `gw-spe-funded-provider-examples` → `v2/gateways/guides/roadmap-and-funding/operator-support.mdx` [verify-only]
+- `gw-spe-funded-provider-examples` → `v2/gateways/guides/roadmap-and-funding/spe-grant-model.mdx` [verify-only]
+- `orch-commercial-model-warmth` → `v2/orchestrators/guides/ai-and-job-workloads/ai-workloads-guide.mdx` [verify-only]
+- `orch-commercial-model-warmth` → `v2/orchestrators/guides/ai-and-job-workloads/batch-ai-setup.mdx` [verify-only]
+- `orch-ai-routing-capability-based` → `v2/orchestrators/guides/ai-and-job-workloads/job-types.mdx` [verify-only]
+- `orch-consumer-nvenc-session-cap` → `v2/orchestrators/guides/ai-and-job-workloads/job-types.mdx` [verify-only]
+- `orch-consumer-nvenc-session-cap` → `v2/orchestrators/guides/ai-and-job-workloads/video-transcoding.mdx` [verify-only]
+- ... 26 more item(s)

--- a/tasks/research/claims/gateways.json
+++ b/tasks/research/claims/gateways.json
@@ -128,6 +128,180 @@
           ]
         }
       ]
+    },
+    {
+      "claim_id": "gw-price-cap-role",
+      "claim_family": "price-cap-role",
+      "entity": "gateway",
+      "claim_summary": "Gateway pricing docs should keep the role of caps aligned: on-chain caps act as marketplace filters, while off-chain caps act as safety ceilings for known orchestrators. The same claim family also covers how `-ignoreMaxPriceIfNeeded` changes job-failure behavior.",
+      "canonical_owner": "v2/gateways/guides/payments-and-pricing/pricing-strategy.mdx",
+      "source_type": "repo-doc-reference",
+      "source_ref": "v2/gateways/guides/payments-and-pricing/pricing-strategy.mdx",
+      "evidence_date": "2026-03-16",
+      "status": "verified",
+      "freshness_class": "review-on-change",
+      "dependent_pages": [
+        "v2/gateways/guides/payments-and-pricing/payment-guide.mdx",
+        "v2/gateways/guides/roadmap-and-funding/naap-multi-tenancy.mdx"
+      ],
+      "related_claims": [
+        "gw-clearinghouse-public-readiness"
+      ],
+      "last_reviewed_by": "codex",
+      "notes": "This is a routing-and-cost semantics family, not a navigation concern. It exists to catch factual drift in how gateway operators reason about price caps and fallback behavior.",
+      "match_terms": [
+        "marketplace filter",
+        "safety ceiling",
+        "ignoreMaxPriceIfNeeded",
+        "maxPricePerCapability",
+        "maxPricePerUnit",
+        "orchAddr"
+      ],
+      "comparison_patterns": [],
+      "evidence_refs": [
+        {
+          "type": "repo-file",
+          "ref": "v2/gateways/guides/payments-and-pricing/pricing-strategy.mdx",
+          "match_any": [
+            "marketplace filter",
+            "safety ceiling",
+            "ignoreMaxPriceIfNeeded"
+          ]
+        },
+        {
+          "type": "repo-file",
+          "ref": "v2/gateways/guides/roadmap-and-funding/naap-multi-tenancy.mdx",
+          "match_any": [
+            "orchAddr",
+            "maxPricePerCapability",
+            "route"
+          ]
+        }
+      ]
+    },
+    {
+      "claim_id": "gw-clearinghouse-public-readiness",
+      "claim_family": "clearinghouse-public-readiness",
+      "entity": "gateway",
+      "claim_summary": "Gateway payment docs should describe clearinghouse status with current precision: the protocol is implemented, but no public clearinghouse is generally available yet. Community-hosted signer access is a testing bridge, not evidence of GA.",
+      "canonical_owner": "v2/gateways/guides/payments-and-pricing/clearinghouse-guide.mdx",
+      "source_type": "github-pr",
+      "source_ref": "https://github.com/livepeer/go-livepeer/pull/3822",
+      "evidence_date": "2026-03-16",
+      "status": "time-sensitive",
+      "freshness_class": "review-periodic",
+      "dependent_pages": [
+        "v2/gateways/guides/payments-and-pricing/payment-guide.mdx",
+        "v2/gateways/guides/roadmap-and-funding/operator-support.mdx"
+      ],
+      "related_claims": [
+        "gw-discord-community-signal",
+        "gw-price-cap-role"
+      ],
+      "last_reviewed_by": "codex",
+      "notes": "This family should stay explicit about protocol readiness versus public-service readiness. The docs should not blur implementation status into GA claims.",
+      "match_terms": [
+        "general availability",
+        "public use status",
+        "public clearinghouse",
+        "community remote signer",
+        "testing surface",
+        "API key sign-up"
+      ],
+      "comparison_patterns": [
+        "\\bgeneral\\s+availability\\b",
+        "\\bpublic\\s+clearinghouse\\b",
+        "\\bsigner\\.eliteencoder\\.net\\b"
+      ],
+      "evidence_refs": [
+        {
+          "type": "github-pr",
+          "ref": "https://github.com/livepeer/go-livepeer/pull/3791",
+          "match_any": [
+            "clearinghouse",
+            "remote signer"
+          ]
+        },
+        {
+          "type": "github-pr",
+          "ref": "https://github.com/livepeer/go-livepeer/pull/3822",
+          "match_any": [
+            "clearinghouse",
+            "signer"
+          ]
+        },
+        {
+          "type": "repo-file",
+          "ref": "v2/gateways/guides/payments-and-pricing/clearinghouse-guide.mdx",
+          "match_any": [
+            "general availability",
+            "community remote signer",
+            "testing surface"
+          ]
+        }
+      ]
+    },
+    {
+      "claim_id": "gw-community-signer-testing-surface",
+      "claim_family": "community-signer-testing-surface",
+      "entity": "gateway",
+      "claim_summary": "Docs that mention the Elite Encoder community signer should keep its role narrow and explicit: a repo/community-backed testing surface for early off-chain experimentation, not a generic production recommendation.",
+      "canonical_owner": "v2/gateways/guides/payments-and-pricing/payment-guide.mdx",
+      "source_type": "repo-discord-signal",
+      "source_ref": ".github/workflows/discord-issue-intake.yml",
+      "evidence_date": "2026-03-16",
+      "status": "time-sensitive",
+      "freshness_class": "review-periodic",
+      "dependent_pages": [
+        "v2/gateways/guides/payments-and-pricing/clearinghouse-guide.mdx",
+        "v2/gateways/guides/roadmap-and-funding/operator-support.mdx",
+        "v2/gateways/guides/payments-and-pricing/remote-signers.mdx"
+      ],
+      "related_claims": [
+        "gw-clearinghouse-public-readiness",
+        "gw-discord-community-signal"
+      ],
+      "last_reviewed_by": "codex",
+      "notes": "Phase 1 evidence should use repo-available community signals plus current docs, not live Discord scraping. This family keeps that role visible in the outputs.",
+      "match_terms": [
+        "signer.eliteencoder.net",
+        "community signer",
+        "testing surface",
+        "no ETH required",
+        "community-hosted remote signer"
+      ],
+      "comparison_patterns": [
+        "\\bsigner\\.eliteencoder\\.net\\b"
+      ],
+      "evidence_refs": [
+        {
+          "type": "repo-discord-signal",
+          "ref": ".github/workflows/discord-issue-intake.yml",
+          "match_any": [
+            "discord",
+            "repository_dispatch",
+            "community"
+          ]
+        },
+        {
+          "type": "repo-file",
+          "ref": "v2/gateways/guides/payments-and-pricing/payment-guide.mdx",
+          "match_any": [
+            "signer.eliteencoder.net",
+            "testing",
+            "public clearinghouse reaches GA"
+          ]
+        },
+        {
+          "type": "repo-file",
+          "ref": "v2/gateways/guides/roadmap-and-funding/operator-support.mdx",
+          "match_any": [
+            "community-hosted remote signer",
+            "free ETH for testing",
+            "signer.eliteencoder.net"
+          ]
+        }
+      ]
     }
   ]
 }

--- a/tasks/research/claims/orchestrators.json
+++ b/tasks/research/claims/orchestrators.json
@@ -553,6 +553,120 @@
           ]
         }
       ]
+    },
+    {
+      "claim_id": "orch-commercial-model-warmth",
+      "claim_family": "commercial-model-warmth",
+      "entity": "orchestrator",
+      "claim_summary": "Commercial AI operator guidance should keep warm-model, pre-loaded startup, and cold-start SLA language aligned across setup and business-case pages. These claims describe real operational expectations, but they remain experimental and workload-sensitive.",
+      "canonical_owner": "v2/orchestrators/guides/operator-considerations/business-case.mdx",
+      "source_type": "repo-doc-reference",
+      "source_ref": "v2/orchestrators/guides/operator-considerations/business-case.mdx",
+      "evidence_date": "2026-03-16",
+      "status": "time-sensitive",
+      "freshness_class": "review-on-change",
+      "dependent_pages": [
+        "v2/orchestrators/guides/ai-and-job-workloads/ai-workloads-guide.mdx",
+        "v2/orchestrators/guides/ai-and-job-workloads/batch-ai-setup.mdx",
+        "v2/orchestrators/guides/deployment-details/dual-workload-setup.mdx"
+      ],
+      "related_claims": [
+        "orch-business-case-cost-viability",
+        "orch-batch-ai-vram-threshold"
+      ],
+      "last_reviewed_by": "codex",
+      "notes": "This family tracks whether docs consistently present warm models as a commercial latency/SLA requirement rather than a generic optimisation tip.",
+      "match_terms": [
+        "pre-loaded and warm",
+        "keep them warm",
+        "cold starts are SLA failures",
+        "warm at startup",
+        "cold start latency"
+      ],
+      "comparison_patterns": [],
+      "evidence_refs": [
+        {
+          "type": "repo-file",
+          "ref": "v2/orchestrators/guides/operator-considerations/business-case.mdx",
+          "match_any": [
+            "pre-loaded and warm",
+            "cold starts are SLA failures",
+            "commercial Orchestrators pre-load all advertised models"
+          ]
+        },
+        {
+          "type": "repo-file",
+          "ref": "v2/orchestrators/guides/deployment-details/dual-workload-setup.mdx",
+          "match_any": [
+            "\"warm\": true",
+            "model stays warm in VRAM",
+            "warm in VRAM"
+          ]
+        },
+        {
+          "type": "repo-file",
+          "ref": "v2/orchestrators/guides/ai-and-job-workloads/batch-ai-setup.mdx",
+          "match_any": [
+            "warm: true",
+            "Eliminates cold-start latency",
+            "one warm model per GPU"
+          ]
+        }
+      ]
+    },
+    {
+      "claim_id": "orch-consumer-nvenc-session-cap",
+      "claim_family": "consumer-nvenc-session-cap",
+      "entity": "orchestrator",
+      "claim_summary": "Consumer NVIDIA NVENC session-cap guidance is factual but volatile. Hardware requirement and transcoding guides should stay aligned on whether GeForce-class cards are typically capped at 2-3 concurrent sessions and whether newer generations changed that default.",
+      "canonical_owner": "v2/orchestrators/guides/deployment-details/requirements.mdx",
+      "source_type": "repo-doc-reference",
+      "source_ref": "v2/orchestrators/guides/deployment-details/requirements.mdx",
+      "evidence_date": "2026-03-16",
+      "status": "time-sensitive",
+      "freshness_class": "volatile",
+      "dependent_pages": [
+        "v2/orchestrators/guides/ai-and-job-workloads/job-types.mdx",
+        "v2/orchestrators/guides/ai-and-job-workloads/video-transcoding.mdx"
+      ],
+      "related_claims": [
+        "orch-session-limit-default",
+        "orch-bandwidth-per-stream-planning"
+      ],
+      "last_reviewed_by": "codex",
+      "notes": "The current docs already carry REVIEW notes for Ada Lovelace uncertainty. The runner should treat these figures as volatile operational claims, not settled constants.",
+      "match_terms": [
+        "NVENC session cap",
+        "2-3 concurrent sessions",
+        "consumer cards",
+        "Ada Lovelace",
+        "RTX 40xx"
+      ],
+      "comparison_patterns": [
+        "\\b2-3\\s*concurrent\\s*(?:NVENC\\s*)?(?:encode\\s*)?sessions\\b",
+        "\\b3\\s*concurrent\\s*(?:NVENC\\s*)?(?:encode\\s*)?sessions\\b",
+        "\\bAda\\s+Lovelace\\b"
+      ],
+      "evidence_refs": [
+        {
+          "type": "repo-file",
+          "ref": "v2/orchestrators/guides/deployment-details/requirements.mdx",
+          "match_any": [
+            "2-3 concurrent NVENC encode sessions",
+            "Ada Lovelace",
+            "NVIDIA matrix"
+          ]
+        },
+        {
+          "type": "repo-file",
+          "ref": "v2/orchestrators/guides/ai-and-job-workloads/video-transcoding.mdx",
+          "match_any": [
+            "NVENC session caps on consumer GPUs",
+            "If your GPU is capped at 3 concurrent NVENC sessions",
+            "Ada Lovelace"
+          ]
+        }
+      ]
     }
   ]
 }

--- a/tests/unit/docs-fact-registry.test.js
+++ b/tests/unit/docs-fact-registry.test.js
@@ -123,9 +123,25 @@ async function runTests() {
     assert.strictEqual(parsed.claim_families[0].domain, 'gateways');
   });
 
+  await runCase('Validate accepts repo-discord-signal evidence refs', async () => {
+    const root = mkTmpDir('docs-fact-registry-discord-');
+    const registry = sampleRegistry('gateways');
+    registry.claim_families[0].evidence_refs = [
+      {
+        type: 'repo-discord-signal',
+        ref: '.github/workflows/discord-issue-intake.yml',
+        match_any: ['discord']
+      }
+    ];
+    writeJson(path.join(root, 'gateways.json'), registry);
+
+    const result = runNode(['--validate', '--registry', root]);
+    assert.strictEqual(result.status, 0, result.stderr || result.stdout);
+  });
+
   return {
     passed: errors.length === 0,
-    total: 3,
+    total: 4,
     errors
   };
 }

--- a/tests/unit/docs-page-research.test.js
+++ b/tests/unit/docs-page-research.test.js
@@ -155,6 +155,49 @@ Batch AI requires 24 GB VRAM for competitive diffusion pipelines.
     });
   });
 
+  await runCase('Evidence adapter matches public GA and repo Discord signal variants', async () => {
+    const root = mkTmpDir('docs-page-research-discord-');
+    const repoDir = path.join(root, 'repo');
+    const workflowPath = path.join(repoDir, '.github/workflows/discord-issue-intake.yml');
+    writeFile(
+      workflowPath,
+      'name: discord-issue-intake\non:\n  repository_dispatch:\n    types: [discord]\n# discord.com/channels/livepeer\n'
+    );
+
+    const previousCwd = process.cwd();
+    process.chdir(repoDir);
+    try {
+      const signalEvidence = await research.fetchEvidenceRef({
+        type: 'repo-discord-signal',
+        ref: '.github/workflows/discord-issue-intake.yml',
+        match_any: ['discord.com/channels', 'repository_dispatch']
+      });
+      assert.strictEqual(signalEvidence.ok, true);
+      assert.strictEqual(signalEvidence.matched, true);
+    } finally {
+      process.chdir(previousCwd);
+    }
+
+    await withMockedFetch(async () => ({
+      ok: true,
+      status: 200,
+      async text() {
+        return JSON.stringify({
+          title: 'Clearinghouse status',
+          cooked: 'No public clearinghouse service is at general availability yet; the community remote signer is still the testing path.'
+        });
+      }
+    }), async () => {
+      const evidence = await research.fetchEvidenceRef({
+        type: 'forum-topic',
+        ref: 'https://forum.livepeer.org/t/clearinghouse-status/9997',
+        match_any: ['public use status', 'community signer']
+      });
+      assert.strictEqual(evidence.ok, true);
+      assert.strictEqual(evidence.matched, true);
+    });
+  });
+
   await runCase('Research runner reports contradictions on real value drift', async () => {
     const root = mkTmpDir('docs-page-research-runner-');
     const repoDir = path.join(root, 'repo');
@@ -226,9 +269,74 @@ Batch AI requires 24 GB VRAM for competitive diffusion pipelines.
     }
   });
 
+  await runCase('Markdown report escapes raw braces in extracted claims', async () => {
+    const root = mkTmpDir('docs-page-research-markdown-');
+    const repoDir = path.join(root, 'repo');
+    const registryDir = path.join(repoDir, 'tasks/research/claims');
+    const guideA = 'v2/gateways/a.mdx';
+    writeFile(path.join(repoDir, guideA), '{/* TODO: test */}\nThe public clearinghouse is not at general availability yet.');
+    writeFile(
+      path.join(registryDir, 'gateways.json'),
+      `${JSON.stringify(
+        {
+          version: 1,
+          domain: 'gateways',
+          claim_families: [
+            {
+              claim_id: 'gw-clearinghouse-public-readiness',
+              claim_family: 'clearinghouse-public-readiness',
+              entity: 'gateway',
+              claim_summary: 'Use current public clearinghouse status wording.',
+              canonical_owner: guideA,
+              source_type: 'repo-doc-reference',
+              source_ref: guideA,
+              evidence_date: '2026-03-16',
+              status: 'time-sensitive',
+              freshness_class: 'review-periodic',
+              dependent_pages: [],
+              related_claims: [],
+              last_reviewed_by: 'codex',
+              notes: 'test',
+              match_terms: ['general availability'],
+              comparison_patterns: [],
+              evidence_refs: [
+                {
+                  type: 'repo-file',
+                  ref: guideA,
+                  match_any: ['general availability']
+                }
+              ]
+            }
+          ]
+        },
+        null,
+        2
+      )}\n`
+    );
+
+    const previousCwd = process.cwd();
+    process.chdir(repoDir);
+    try {
+      const reportPath = path.join(root, 'report.md');
+      await research.run({
+        registry: 'tasks/research/claims',
+        page: guideA,
+        files: [],
+        reportMd: reportPath,
+        reportJson: '',
+        quiet: true
+      });
+      const markdown = fs.readFileSync(reportPath, 'utf8');
+      assert.ok(!markdown.includes('{'));
+      assert.ok(!markdown.includes('{/* TODO: test */}'));
+    } finally {
+      process.chdir(previousCwd);
+    }
+  });
+
   return {
     passed: errors.length === 0,
-    total: 7,
+    total: 9,
     errors
   };
 }

--- a/tools/scripts/docs-fact-registry.js
+++ b/tools/scripts/docs-fact-registry.js
@@ -33,6 +33,7 @@ const VALID_FRESHNESS = new Set([
 const VALID_EVIDENCE_TYPES = new Set([
   'official-page',
   'repo-file',
+  'repo-discord-signal',
   'github-repo',
   'github-issue',
   'github-pr',

--- a/tools/scripts/docs-page-research-pr-report.js
+++ b/tools/scripts/docs-page-research-pr-report.js
@@ -309,7 +309,7 @@ function buildMarkdown(summary) {
     }
   }
   lines.push('');
-  return `${lines.join('\n')}\n`;
+  return `${lines.join('\n').trimEnd()}\n`;
 }
 
 function writeJson(filePath, value) {

--- a/tools/scripts/docs-page-research.js
+++ b/tools/scripts/docs-page-research.js
@@ -280,6 +280,18 @@ function normalizeForMatch(value) {
     .replace(/\bfeasibilit(?:y|ies)\b/g, ' viable ')
     .replace(/\bworth it\b/g, ' viable ')
     .replace(/\bprofitab(?:le|ility)\b/g, ' viable ')
+    .replace(/\bcommercial(?:ly)?\s+viable\b/g, ' viable ')
+    .replace(/\bpre[\s-]?loaded\b/g, ' warm ')
+    .replace(/\bkeep\s+(?:them|models?)\s+warm\b/g, ' warm ')
+    .replace(/\bwarmed?\s+at\s+startup\b/g, ' warm startup ')
+    .replace(/\bcold[\s-]?starts?\b/g, ' cold start ')
+    .replace(/\bservice[\s-]?level\s+agreement[s]?\b/g, ' sla ')
+    .replace(/\bgeneral\s+availability\b/g, ' public ga ')
+    .replace(/\bpublic\s+use\s+status\b/g, ' public ga ')
+    .replace(/\bmarketplace\s+filter\b/g, ' price filter ')
+    .replace(/\bsafety\s+ceiling\b/g, ' price ceiling ')
+    .replace(/\bsession\s+cap\b/g, ' session limit ')
+    .replace(/\bconcurrent\s+encoding\s+sessions?\b/g, ' nvenc session ')
     .replace(/\bmax\s*price\s*per\s*capability\b/g, ' price ceiling ')
     .replace(/\bmaxpricepercapability\b/g, ' price ceiling ')
     .replace(/\bmax\s*price\s*per\s*unit\b/g, ' price ceiling ')
@@ -357,20 +369,25 @@ async function fetchText(url, headers = {}) {
 
 async function fetchEvidenceRef(ref) {
   const checked_on = localIsoDate();
-  if (ref.type === 'repo-file') {
+  if (ref.type === 'repo-file' || ref.type === 'repo-discord-signal') {
     const absPath = path.resolve(repoRoot(), ref.ref);
     if (!fs.existsSync(absPath)) {
       return { type: ref.type, ref: ref.ref, checked_on, ok: false, matched: false, summary: 'repo file missing' };
     }
     const text = readFile(absPath);
     const matched = matchAnySignal(text, ref.match_any);
+    const matchedSummary = ref.type === 'repo-discord-signal' ? 'repo Discord/community signal matched' : 'repo evidence matched';
+    const missingSummary =
+      ref.type === 'repo-discord-signal'
+        ? 'repo Discord/community signal fetched but signal missing'
+        : 'repo evidence fetched but signal missing';
     return {
       type: ref.type,
       ref: ref.ref,
       checked_on,
       ok: true,
       matched,
-      summary: matched ? 'repo evidence matched' : 'repo evidence fetched but signal missing'
+      summary: matched ? matchedSummary : missingSummary
     };
   }
 
@@ -612,6 +629,11 @@ function buildValidation(report) {
 }
 
 function buildMarkdown(report) {
+  const mdxSafe = (value) =>
+    String(value || '')
+      .replace(/[{}]/g, (match) => `\\${match}`)
+      .replace(/\s+/g, ' ')
+      .trim();
   const lines = [];
   lines.push('# Docs Page Research Report');
   lines.push('');
@@ -624,7 +646,7 @@ function buildMarkdown(report) {
   report.claims_reviewed.forEach((entry) => {
     lines.push(`- \`${entry.file}\``);
     lines.push(`  - claim families: ${entry.matched_claim_families.length ? `\`${entry.matched_claim_families.join('`, `')}\`` : 'none'}`);
-    entry.extracted_claims.slice(0, 4).forEach((claim) => lines.push(`  - extracted: ${claim}`));
+    entry.extracted_claims.slice(0, 4).forEach((claim) => lines.push(`  - extracted: ${mdxSafe(claim)}`));
   });
   lines.push('');
 
@@ -643,7 +665,7 @@ function buildMarkdown(report) {
       entries.forEach((entry) => {
         lines.push(`- \`${entry.claim_id}\` (${entry.status}, ${entry.confidence})`);
         lines.push(`  - owner: \`${entry.canonical_owner}\``);
-        lines.push(`  - summary: ${entry.summary}`);
+        lines.push(`  - summary: ${mdxSafe(entry.summary)}`);
       });
     }
     lines.push('');
@@ -657,7 +679,7 @@ function buildMarkdown(report) {
     report.cross_page_contradictions.forEach((entry) => {
       lines.push(`- \`${entry.claim_id}\` (${entry.claim_family})`);
       lines.push(`  - action: ${entry.recommended_action}`);
-      entry.pages.forEach((page) => lines.push(`  - \`${page.file}\`: ${page.values.join(', ') || page.snippet}`));
+      entry.pages.forEach((page) => lines.push(`  - \`${page.file}\`: ${mdxSafe(page.values.join(', ') || page.snippet)}`));
     });
   }
   lines.push('');
@@ -677,9 +699,9 @@ function buildMarkdown(report) {
     lines.push('- None');
   } else {
     report.evidence_sources.forEach((entry) => {
-      lines.push(`- \`${entry.claim_id}\` → ${entry.type}: ${entry.ref}`);
+      lines.push(`- \`${entry.claim_id}\` → ${entry.type}: ${mdxSafe(entry.ref)}`);
       lines.push(`  - checked: ${entry.checked_on}`);
-      lines.push(`  - result: ${entry.summary}`);
+      lines.push(`  - result: ${mdxSafe(entry.summary)}`);
     });
   }
   lines.push('');
@@ -691,7 +713,7 @@ function buildMarkdown(report) {
   });
   lines.push('');
 
-  return `${lines.join('\n')}\n`;
+  return `${lines.join('\n').trimEnd()}\n`;
 }
 
 async function run(args) {


### PR DESCRIPTION
## Summary
- broaden the fact-check research registries for current orchestrator and gateway claim families
- improve evidence matching and add repo-available Discord/community signal support in the research runner
- add real pilot artifacts and PR-advisory simulation outputs for the new coverage

## What Changed
- added gateway claim families for pricing-cap semantics, clearinghouse public readiness, and community-signer testing status
- added orchestrator claim families for commercial warm-model/SLA guidance and consumer NVENC session-cap volatility
- extended the fact registry validator with `repo-discord-signal`
- improved markdown report generation so saved research artifacts are MDX-safe and commit-safe
- added unit coverage for the new adapter and markdown emitter behavior

## Validation
- `node tests/unit/docs-fact-registry.test.js`
- `node tests/unit/docs-page-research.test.js`
- `node tests/unit/docs-page-research-pr-report.test.js`
- `node tools/scripts/docs-fact-registry.js --validate --registry tasks/research/claims`
- `node tests/run-all.js --staged --skip-browser`
- `node tests/run-pr-checks.js --base-ref docs-v2-dev`

## Real Runs
- orchestrator cluster: `business-case`, `requirements`, `dual-workload-setup`, `ai-workloads-guide`, `video-transcoding`, `batch-ai-setup`
- gateway cluster: `pricing-strategy`, `payment-guide`, `clearinghouse-guide`, `remote-signers`, `operator-support`, `naap-multi-tenancy`
- PR advisory simulation saved under `tasks/reports/repo-ops/2026-03-16-page-content-research-pr-simulation-task2-improvements.*`
