### PR TITLE
Docs(contract-addresses): update BondingManager target address

### DIFF
--- a/v2/resources/references/contract-addresses.mdx
+++ b/v2/resources/references/contract-addresses.mdx
@@ -35,7 +35,7 @@ All contracts on Arbitrum One implement the Delta version of the protocol.
 - **LivepeerToken**: [`0x289ba1701C2F088cf0faf8B3705246331cB8A839`](https://arbiscan.io/address/0x289ba1701C2F088cf0faf8B3705246331cB8A839)
 - **Minter**: [`0xc20DE37170B45774e6CD3d2304017fc962f27252`](https://arbiscan.io/address/0xc20DE37170B45774e6CD3d2304017fc962f27252)
 - **BondingManager (Proxy)**: [`0x35Bcf3c30594191d53231E4FF333E8A770453e40`](https://arbiscan.io/address/0x35Bcf3c30594191d53231E4FF333E8A770453e40)
-- **BondingManager (Target)**: [`0x4bA7E7531Ab56bC8d78dB4FDc88D21F621f34BB4`](https://arbiscan.io/address/0x4bA7E7531Ab56bC8d78dB4FDc88D21F621f34BB4)
+- **BondingManager (Target)**: [`0xdA6fe3f332Ae11539b3cF777284Ae70fd3bF2D74`](https://arbiscan.io/address/0xdA6fe3f332Ae11539b3cF777284Ae70fd3bF2D74)
 - **TicketBroker (Proxy)**: [`0xa8bB618B1520E284046F3dFc448851A1Ff26e41B`](https://arbiscan.io/address/0xa8bB618B1520E284046F3dFc448851A1Ff26e41B)
 - **TicketBroker (Target)**: [`0xea1b0F6c8D158328a6e3D3F924B86A759F41465c`](https://arbiscan.io/address/0xea1b0F6c8D158328a6e3D3F924B86A759F41465c)
 - **RoundsManager (Proxy)**: [`0xdd6f56DcC28D3F5f27084381fE8Df634985cc39f`](https://arbiscan.io/address/0xdd6f56DcC28D3F5f27084381fE8Df634985cc39f)
@@ -112,7 +112,8 @@ Since the Confluence upgrade, the protocol has been deployed to Arbitrum One and
 - **V8**: [`0x557093B1Ab53412166beAd939f34244170b6525B`](https://arbiscan.io/address/0x557093B1Ab53412166beAd939f34244170b6525B)
 - **V9**: [`0x6b397f20DC227B4E23fEc20BBDBe166d0DFFC452`](https://arbiscan.io/address/0x6b397f20DC227B4E23fEc20BBDBe166d0DFFC452)
 - **V10**: [`0xd1C1F5d44D8F83ca2A05Baf40461e550cFDDecA2`](https://arbiscan.io/address/0xd1C1F5d44D8F83ca2A05Baf40461e550cFDDecA2)
-- **V11 (current)**: [`0x4bA7E7531Ab56bC8d78dB4FDc88D21F621f34BB4`](https://arbiscan.io/address/0x4bA7E7531Ab56bC8d78dB4FDc88D21F621f34BB4)
+- **V11**: [`0xF62C30242fccd3a46721f155d4d367De3fD5B3b3`](https://arbiscan.io/address/0xF62C30242fccd3a46721f155d4d367De3fD5B3b3)
+- **V12**: [`0x4bA7E7531Ab56bC8d78dB4FDc88D21F621f34BB4`](https://arbiscan.io/address/0x4bA7E7531Ab56bC8d78dB4FDc88D21F621f34BB4)
 
 #### BondingVotes (Target)
 


### PR DESCRIPTION
## Description
Updates the BondingManager contract address references to reflect the latest deployment on Arbitrum Mainnet. The previous target address is now documented as V12, and the current active target address has been updated in documentation version V2.

## Scope

<!-- Required for codex/* PRs: list in-scope files/prefixes and any explicit out-of-scope exclusions -->
<!-- Tip: node tools/scripts/create-codex-pr.js --create -->

## Validation

<!-- Required for codex/* PRs: list exact commands run and notable outcomes -->
<!-- Tip: node tools/scripts/create-codex-pr.js --create -->

## Follow-up Tasks

<!-- Required for codex/* PRs: link follow-up issues, or write "none" -->
<!-- Tip: node tools/scripts/create-codex-pr.js --create -->

## Type of Change

<!-- Check all that apply -->

- [ ] Bug fix (fixes an issue)
- [x] New content (adds new documentation)
- [x] Content update (improves existing content)
- [ ] Style/formatting fix
- [ ] Information architecture change
- [ ] Other (please describe)

## Related Issues

<!-- Link to related GitHub issues -->

Fixes #
Related to #

## Changes Made

<!-- Describe the specific changes in this PR -->

- Updates the BondingManager (Target) address to reflect the [latest protocol update on Arbitrum Mainnet](https://github.com/livepeer/protocol/blob/6e6b452634542ff92b93643196a97ff356bac230/deployments/arbitrumMainnet/BondingManagerTarget.json#L2).
- Fixes V11 BondingManager entry in the "Historical-deprecated" section  in `v2/resources/references/contract-addresses.mdx` by updating it  from `0x4bA7E7531Ab56bC8d78dB4FDc88D21F621f34BB4` to `0xF62C30242fccd3a46721f155d4d367De3fD5B3b3` pointing to the correct V11 address.
- Added V12 BondingManager entry in the "Historical-deprecated" section  in `v2/resources/references/contract-addresses.mdx`  documenting the previous target address `0x4bA7E7531Ab56bC8d78dB4FDc88D21F621f34BB4`

## Testing

<!-- Describe how you tested your changes -->

- [x] Tested locally with `npm run dev`
- [ ] Verified all links work
- [ ] Checked formatting and style
- [ ] Reviewed against style guides
- [ ] Screenshots (if UI changes)

## Screenshots (if applicable)

<!-- Add screenshots if this PR changes the UI or adds visual content -->
s1:
<img width="1822" height="996" alt="Screenshot from 2026-03-24 11-36-59" src="https://github.com/user-attachments/assets/579416b8-5b10-4e2d-a2b4-2d2f7e659e61" />

s2:
<img width="1822" height="996" alt="Screenshot from 2026-03-24 11-37-16" src="https://github.com/user-attachments/assets/7be175cd-a9d0-4b9c-b428-6213a26a579b" />

## Checklist

<!-- Check all that apply -->

- [ ] My changes follow the [style guides](../../docs/ABOUT/ABOUT-SECTION-STYLE-GUIDE.md)
- [ ] I've reviewed the [Component Library](../../v2/pages/07_resources/documentation-guide/component-library) for available components
- [ ] I've updated related pages if needed
- [ ] I've checked for broken links
- [x] My changes are clear and easy to understand
- [x] I've tested locally
- [ ] I've added/updated keywords and metadata if needed

## Additional Notes
<!-- Any additional information, context, or notes for reviewers -->
1. We opened this PR against the `doc-v2` branch, as this was discussed in a [previous PR](https://github.com/livepeer/docs/pull/759#issuecomment-3980397348).
2. We couldn’t update the V1 addresses because a commit hook prevents changes to the V1 documentation.
<img width="782" height="363" alt="Screenshot from 2026-03-24 11-39-14" src="https://github.com/user-attachments/assets/af33c78c-8509-450c-8bb5-5767478c30ec" />

3. We noticed that the ["Historical" section](https://docs.livepeer.org/v2/resources/references/contract-addresses#historical-deprecated-%E2%80%94-for-reference-only) in the v2 docs lists active BondingManager [marked as (current)](https://docs.livepeer.org/v2/resources/references/contract-addresses#historical-deprecated-%E2%80%94-for-reference-only). In our opinion, this is incorrect, so we only added the new address on top, while adding previously active v11 and v12 addresses to the Historical section.
4. We found that contract address references exist in multiple files, including:
   - `docs/resources/references/contract-addresses.mdx`
   - `v2/gateways/x-archived/references/contract-addresses.mdx`
   - `v2/gateways/resources/technical/dep-contract-addresses.mdx`
   - `v2/gateways/resources/technical/contract-addresses.mdx`
   - `v2/gateways/resources/technical/new-contract-addresses.mdx`
   - `v2/gateways/guides/monitoring-and-tooling/x-resources/v2-refs--contract-addresses.mdx`
   
   - Currently, we have not updated the addresses in any of these files, since the purpose of each file is unclear, let us know if we need to update anything else or take over this task.