### PR TITLE
fix(v1): simplify Ubuntu build dependencies

### DIFF
--- a/v1/orchestrators/guides/install-go-livepeer.mdx
+++ b/v1/orchestrators/guides/install-go-livepeer.mdx
@@ -160,16 +160,10 @@ docker pull livepeer/go-livepeer:master
 
 Building `livepeer` requires some system dependencies.
 
-#### Linux (Ubuntu: 16.04 or 18.04)
+#### Linux (Ubuntu Server 20.04 or newer)
 
 ```bash
-apt-get update && apt-get -y install build-essential pkg-config autoconf git curl yasm
-```
-
-#### Linux (Ubuntu: 20.04 or newer)
-
-```bash
-apt-get -y install protobuf-compiler-grpc golang-goprotobuf-dev yasm pkg-config
+apt-get -y install build-essential pkg-config nasm libx264-dev
 ```
 
 #### Linux GPU support


### PR DESCRIPTION
## Summary

- Consolidates two Ubuntu version blocks (16.04/18.04 and 20.04+) into a single block for Ubuntu Server 20.04+
- Replaces outdated packages with the correct minimal set: `build-essential pkg-config nasm libx264-dev`
- Tested on clean Ubuntu Server installs (20.04, 22.04, 24.04)

Based on community contribution from @chrishobcroft in #721.

## Test plan

- [ ] Verify the install command works on Ubuntu 20.04+