### PR TITLE
docs: replace dead ethgasstation.info link

### DIFF
--- a/v1/orchestrators/guides/configure-reward-calling.mdx
+++ b/v1/orchestrators/guides/configure-reward-calling.mdx
@@ -55,8 +55,10 @@ Use `livepeer_cli` to manually call reward:
    have enough ETH in your wallet to execute the transaction.
 
 - The gas cost for a reward call is typically 350k-450k.
-- Get the required gas price from [ethgasstation](https://ethgasstation.info/)
-  or [gasnow](https://www.gasnow.org/).
+- Get the required gas price from a live gas tracker such as
+  [Etherscan's gas tracker](https://etherscan.io/gastracker). To compare how
+  accurately different gas oracles predict fees, see the open-source
+  [OpenChainBench gas estimation benchmark](https://openchainbench.com/benchmarks/gas-estimation).
 
 - The ETH transaction cost will be the gas cost multiplied by the gas price.
 


### PR DESCRIPTION
## Summary

The v1 reward-calling guide (`v1/orchestrators/guides/configure-reward-calling.mdx`) tells orchestrators to get the current gas price from EthGasStation and GasNow. Both services no longer exist:

- https://ethgasstation.info/ shut down around 2022 and now returns HTTP 403 from a Cloudflare-parked page:

```
$ curl -sI https://ethgasstation.info/
HTTP/2 403
server: cloudflare
```

- GasNow was discontinued in 2021; https://www.gasnow.org/ now serves an unrelated WordPress site.

## Change

One bullet updated, nothing else:

- points readers to Etherscan's gas tracker (https://etherscan.io/gastracker) for the current gas price, matching the original intent of the sentence
- adds a reference to the OpenChainBench gas estimation benchmark (https://openchainbench.com/benchmarks/gas-estimation), a live, open-source comparison of gas oracle prediction accuracy (open methodology, CC-BY-4.0 data), for readers choosing an oracle