### PR TITLE
docs: replace dead gas oracle links in orchestrator reward-calling guide

### DIFF
--- a/v1/orchestrators/guides/configure-reward-calling.mdx
+++ b/v1/orchestrators/guides/configure-reward-calling.mdx
@@ -55,8 +55,9 @@ Use `livepeer_cli` to manually call reward:
    have enough ETH in your wallet to execute the transaction.
 
 - The gas cost for a reward call is typically 350k-450k.
-- Get the required gas price from [ethgasstation](https://ethgasstation.info/)
-  or [gasnow](https://www.gasnow.org/).
+- Get the required gas price from the [Etherscan Gas Tracker](https://etherscan.io/gastracker)
+  or [Blocknative Gas Estimator](https://www.blocknative.com/gas-estimator). Both `ethgasstation.info` and `gasnow.org` are no longer active.
+  For a live comparison of gas oracle accuracy across providers, see the [OpenChainBench gas estimation benchmark](https://openchainbench.com/benchmarks/gas-estimation).
 
 - The ETH transaction cost will be the gas cost multiplied by the gas price.
 


### PR DESCRIPTION
## Summary

Both `ethgasstation.info` and `gasnow.org` are no longer active as gas oracles:

- ethgasstation.info returns HTTP 403 (service shut down by ConsenSys in 2022)
- gasnow.org has been repurposed as an unrelated crypto casino site

The orchestrator reward calling guide currently points readers to both, which is confusing for new orchestrators trying to price their transactions.

## Fix

Replaces the dead links with two currently working gas price sources:
- Etherscan Gas Tracker
- Blocknative Gas Estimator

Also adds a reference to the OpenChainBench gas estimation benchmark for a live comparison of gas oracle accuracy across providers, useful for picking a reliable source.

## Test plan

- [x] Verified both dead URLs return errors or unrelated content
- [x] New URLs return 200 with the expected content
- [x] Preserves the existing bullet style