### PR TITLE
Redirect legacy /references/contract-addresses to the contracts reference

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -108,6 +108,10 @@
       "destination": "/network"
     },
     {
+      "source": "/references/contract-addresses",
+      "destination": "/network/reference/contracts"
+    },
+    {
       "source": "/v2/about/resources/reference/livepeer-contract-addresses",
       "destination": "/network/reference/contracts"
     },


### PR DESCRIPTION
## Problem

The Explorer links to `https://docs.livepeer.org/references/contract-addresses`, which 404s — the legacy unversioned `/references/*` path was missed in the contract redirect pass (#978).

## Change

Adds a redirect in `docs.json`:

`/references/contract-addresses` → `/network/reference/contracts`

## Notes

The destination page has no `#contract-addresses` anchor (headings are `Deployed addresses (Arbitrum One)` / `(Ethereum Mainnet)`), so the redirect targets the page itself.

Refs livepeer/explorer#759