### PR TITLE
Update Discord links to the current invite URL

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -142,7 +142,7 @@
   "footer": {
     "socials": {
       "github": "https://github.com/livepeer",
-      "discord": "https://discord.gg/livepeer",
+      "discord": "https://discord.gg/55SZFEEH5y",
       "x": "https://x.com/livepeer"
     }
   }

--- a/network/explanation/how-the-network-works.mdx
+++ b/network/explanation/how-the-network-works.mdx
@@ -77,7 +77,7 @@ stake), and pays for the work in ETH. From an orchestrator's seat, gateways *are
 <Note>
   Want to be on that side of the marketplace — sending jobs instead of serving them? A developer
   platform and a Build section of these docs are on the way; until then, ask in the
-  [Livepeer Discord](https://discord.gg/livepeer).
+  [Livepeer Discord](https://discord.gg/55SZFEEH5y).
 </Note>
 
 ## The life of a job

--- a/network/index.mdx
+++ b/network/index.mdx
@@ -30,7 +30,7 @@ marketplace:
 <Note>
   **Looking to build on Livepeer instead?** These docs cover *running* the network. A developer
   platform — and a Build section of these docs — is on the way. In the meantime, ask in the
-  [Livepeer Discord](https://discord.gg/livepeer); the team and community can point you at what's
+  [Livepeer Discord](https://discord.gg/55SZFEEH5y); the team and community can point you at what's
   possible today.
 </Note>
 

--- a/network/reference/faq.mdx
+++ b/network/reference/faq.mdx
@@ -131,7 +131,7 @@ of them before concluding the network is at fault.
 ## Still stuck?
 
 <CardGroup cols={3}>
-  <Card title="Discord" icon="discord" href="https://discord.gg/livepeer">
+  <Card title="Discord" icon="discord" href="https://discord.gg/55SZFEEH5y">
     The most active real-time support. Search before posting.
   </Card>
   <Card title="Forum" icon="comments" href="https://forum.livepeer.org/c/transcoding">

--- a/network/who-this-is-for.mdx
+++ b/network/who-this-is-for.mdx
@@ -49,7 +49,7 @@ supply it. That's the **demand side**, and its docs aren't here yet: a developer
 Build section of this site, are on the way.
 
 Until then, the best place to ask what's possible today is the
-[Livepeer Discord](https://discord.gg/livepeer). If you're curious how demand reaches the network in
+[Livepeer Discord](https://discord.gg/55SZFEEH5y). If you're curious how demand reaches the network in
 the meantime, [How the network works](/network/explanation/how-the-network-works) shows the full
 path from application to GPU.
 


### PR DESCRIPTION
## What changed

The `discord.gg/livepeer` vanity URL no longer resolves to the Livepeer Discord server. All five Discord references on `docs-v3` now point at the current, non-expiring invite `https://discord.gg/55SZFEEH5y`:

- **`docs.json`** — the footer Discord social link
- **`network/index.mdx`**, **`network/who-this-is-for.mdx`**, **`network/explanation/how-the-network-works.mdx`** — the "ask in the Livepeer Discord" callouts
- **`network/reference/faq.mdx`** — the Discord support card

`git grep -E 'discord\.(gg/livepeer|com/invite/livepeer)'` returns nothing on this branch.

## Notes for reviewers

- Please sanity-check the invite code `55SZFEEH5y` against the real server before merging. It matches the one adopted in livepeer/website#94 and livepeer/go-livepeer#4030.
- `main` still uses the old URL in 99 files (`v1/`, `v2/`, the `cn`/`es`/`fr` trees, `docs.json`, `snippets/data/*/hrefs.jsx`, the issue template). If `docs-v3` is not yet what serves docs.livepeer.org, `main` needs the same update — say the word and I will open that PR too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
